### PR TITLE
Homepage: align new positioning, unify hero CTAs, add enterprise dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-debug.log*
 # Env files
 .env
 .env.local
+.gstack/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { DataLifecycleDiagram } from "./components/DataLifecycleDiagram";
 import DatusContextTriad from "./components/DatusContextTriad";
 import DatusLayeredStack from "./components/DatusLayeredStack";
 import DatusLayeredStackHorizontalOnly from "./components/DatusLayeredStackHorizontalOnly";
+import { EnterpriseInquiryDialog } from "./components/EnterpriseInquiryDialog";
 import { Badge } from "./components/ui/badge";
 import { Card } from "./components/ui/card";
 
@@ -401,48 +402,22 @@ export default function App() {
                 type: "spring",
                 stiffness: 100,
               }}
-              className="text-6xl md:text-7xl lg:text-8xl font-bold leading-tight"
+              className="text-4xl md:text-5xl lg:text-6xl font-bold leading-tight max-w-5xl mx-auto"
             >
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.8, delay: 0.8 }}
-                className="text-2xl md:text-3xl lg:text-4xl text-slate-300 mt-6 mb-4"
-              >
-                <motion.span
-                  className="text-transparent bg-clip-text bg-gradient-to-r from-slate-200 via-blue-200 to-purple-200"
-                  animate={{
-                    backgroundPosition: [
-                      "0% 50%",
-                      "100% 50%",
-                      "0% 50%",
-                    ],
-                  }}
-                  transition={{
-                    duration: 5,
-                    repeat: Infinity,
-                    ease: "easeInOut",
-                  }}
-                  style={{ backgroundSize: "200% 100%" }}
-                >
-                  Data Engineering Agent for the Agentic Data Stack
-                </motion.span>
-              </motion.div>
-
               <motion.span
                 initial={{ opacity: 0, x: -30 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.8, delay: 1.2 }}
-                className="text-white block mt-4"
+                transition={{ duration: 0.8, delay: 0.8 }}
+                className="text-white block"
               >
-                Built for{" "}
+                Datus is the{" "}
                 <motion.span
-                  className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 via-purple-400 to-cyan-400"
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 via-blue-300 to-purple-300"
                   animate={{
                     backgroundPosition: [
-                      "100% 50%",
                       "0% 50%",
                       "100% 50%",
+                      "0% 50%",
                     ],
                   }}
                   transition={{
@@ -452,10 +427,301 @@ export default function App() {
                   }}
                   style={{ backgroundSize: "200% 100%" }}
                 >
-                  Agentic Data Engineering
-                </motion.span>
+                  open-source data engineering agent
+                </motion.span>{" "}
+                that builds{" "}
+                <motion.span
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400"
+                  animate={{
+                    backgroundPosition: [
+                      "100% 50%",
+                      "0% 50%",
+                      "100% 50%",
+                    ],
+                  }}
+                  transition={{
+                    duration: 7,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                  }}
+                  style={{ backgroundSize: "200% 100%" }}
+                >
+                  evolvable context
+                </motion.span>{" "}
+                for your data systems.
               </motion.span>
             </motion.h1>
+
+            {/* Subtitle */}
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 1.2 }}
+              className="mt-8 max-w-3xl mx-auto text-lg md:text-xl text-slate-300 leading-relaxed"
+            >
+              From one-man data teams to enterprise agent teams, Datus turns
+              data work into reliable, reusable agent systems.
+            </motion.p>
+
+            {/* Hero CTAs — three pillars, unified shell. Differentiation only via per-pillar accent color + chip on primary. */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: 1.5 }}
+              style={{
+                margin: "3rem auto 0",
+                maxWidth: 760,
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(190px, 1fr))",
+                columnGap: "1.75rem",
+                rowGap: "0.9rem",
+                justifyItems: "center",
+                alignItems: "center",
+              }}
+            >
+              {/* Primary — GitHub. Same shell as the others; subtle cyan wash + chip do the hierarchy. */}
+              <a
+                href="https://github.com/Datus-ai/Datus-agent"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  position: "relative",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.55rem",
+                  height: 48,
+                  paddingLeft: "1.25rem",
+                  paddingRight: "0.6rem",
+                  borderRadius: 10,
+                  background:
+                    "linear-gradient(180deg, rgba(8,145,178,0.18) 0%, rgba(15,23,42,0.55) 100%)",
+                  border: "1px solid rgba(56,189,248,0.4)",
+                  color: "#E2E8F0",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  letterSpacing: "-0.005em",
+                  backdropFilter: "blur(10px)",
+                  WebkitBackdropFilter: "blur(10px)",
+                  boxShadow:
+                    "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)",
+                  transition:
+                    "transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = "translateY(-2px)";
+                  e.currentTarget.style.borderColor =
+                    "rgba(56,189,248,0.7)";
+                  e.currentTarget.style.color = "#ffffff";
+                  e.currentTarget.style.boxShadow =
+                    "inset 0 1px 0 rgba(255,255,255,0.1), 0 8px 24px -8px rgba(56,189,248,0.45)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = "translateY(0)";
+                  e.currentTarget.style.borderColor =
+                    "rgba(56,189,248,0.4)";
+                  e.currentTarget.style.color = "#E2E8F0";
+                  e.currentTarget.style.boxShadow =
+                    "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)";
+                }}
+              >
+                <Github
+                  size={16}
+                  strokeWidth={2.2}
+                  style={{ color: "#67E8F9" }}
+                />
+                <span>Star on GitHub</span>
+                <span
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    marginLeft: 4,
+                    padding: "3px 8px",
+                    borderRadius: 6,
+                    background: "rgba(8,145,178,0.22)",
+                    border: "1px solid rgba(56,189,248,0.25)",
+                    color: "#E2E8F0",
+                    fontFamily:
+                      "ui-monospace, SFMono-Regular, Menlo, monospace",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.02em",
+                  }}
+                >
+                  <span style={{ color: "#ffd84d" }}>★</span>
+                  1.1k
+                </span>
+              </a>
+
+              {/* Secondary — Studio. Same shell, violet accent. */}
+              <a
+                href="https://studio.datus.ai"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  position: "relative",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.55rem",
+                  height: 48,
+                  padding: "0 1.25rem",
+                  borderRadius: 10,
+                  background:
+                    "linear-gradient(180deg, rgba(15,23,42,0.7) 0%, rgba(15,23,42,0.5) 100%)",
+                  border: "1px solid rgba(148,163,184,0.18)",
+                  color: "#E2E8F0",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  letterSpacing: "-0.005em",
+                  backdropFilter: "blur(10px)",
+                  WebkitBackdropFilter: "blur(10px)",
+                  boxShadow:
+                    "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)",
+                  transition:
+                    "transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = "translateY(-2px)";
+                  e.currentTarget.style.borderColor =
+                    "rgba(167,139,250,0.7)";
+                  e.currentTarget.style.color = "#ffffff";
+                  e.currentTarget.style.boxShadow =
+                    "inset 0 1px 0 rgba(255,255,255,0.1), 0 8px 24px -8px rgba(167,139,250,0.4)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = "translateY(0)";
+                  e.currentTarget.style.borderColor =
+                    "rgba(148,163,184,0.18)";
+                  e.currentTarget.style.color = "#E2E8F0";
+                  e.currentTarget.style.boxShadow =
+                    "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)";
+                }}
+              >
+                <Sparkles
+                  size={16}
+                  strokeWidth={2}
+                  style={{ color: "#C4B5FD" }}
+                />
+                <span>Try Datus Studio</span>
+                <ArrowRight
+                  size={14}
+                  strokeWidth={2.2}
+                  style={{ color: "#C4B5FD", opacity: 0.9 }}
+                />
+              </a>
+
+              {/* Tertiary — Enterprise. Same shell, pink accent. Opens inquiry dialog. */}
+              <EnterpriseInquiryDialog>
+                <button
+                  type="button"
+                  style={{
+                    position: "relative",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "0.55rem",
+                    height: 48,
+                    padding: "0 1.25rem",
+                    borderRadius: 10,
+                    background:
+                      "linear-gradient(180deg, rgba(15,23,42,0.7) 0%, rgba(15,23,42,0.5) 100%)",
+                    border: "1px solid rgba(148,163,184,0.18)",
+                    color: "#E2E8F0",
+                    fontSize: 14,
+                    fontWeight: 600,
+                    letterSpacing: "-0.005em",
+                    backdropFilter: "blur(10px)",
+                    WebkitBackdropFilter: "blur(10px)",
+                    boxShadow:
+                      "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)",
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    transition:
+                      "transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.transform = "translateY(-2px)";
+                    e.currentTarget.style.borderColor =
+                      "rgba(244,114,182,0.7)";
+                    e.currentTarget.style.color = "#ffffff";
+                    e.currentTarget.style.boxShadow =
+                      "inset 0 1px 0 rgba(255,255,255,0.1), 0 8px 24px -8px rgba(244,114,182,0.4)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.transform = "translateY(0)";
+                    e.currentTarget.style.borderColor =
+                      "rgba(148,163,184,0.18)";
+                    e.currentTarget.style.color = "#E2E8F0";
+                    e.currentTarget.style.boxShadow =
+                      "inset 0 1px 0 rgba(255,255,255,0.06), 0 4px 16px -8px rgba(0,0,0,0.5)";
+                  }}
+                >
+                  <span>Talk to Enterprise</span>
+                  <ArrowRight
+                    size={14}
+                    strokeWidth={2.2}
+                    style={{ color: "#F9A8D4", opacity: 0.9 }}
+                  />
+                </button>
+              </EnterpriseInquiryDialog>
+            </motion.div>
+
+            {/* Meta strip — same grid as buttons so each spec aligns under its CTA */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.6, delay: 1.8 }}
+              style={{
+                margin: "1.25rem auto 0",
+                maxWidth: 760,
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(190px, 1fr))",
+                columnGap: "1.75rem",
+                rowGap: "0.4rem",
+                justifyItems: "center",
+                alignItems: "center",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 11,
+                letterSpacing: "0.04em",
+                color: "rgba(148,163,184,0.72)",
+              }}
+            >
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 999,
+                    background: "#22D3EE",
+                    boxShadow: "0 0 8px rgba(34,211,238,0.7)",
+                  }}
+                />
+                <span>Open source · Apache 2.0</span>
+              </span>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 999,
+                    background: "#A78BFA",
+                    boxShadow: "0 0 8px rgba(167,139,250,0.55)",
+                  }}
+                />
+                <span>Free playground · no install</span>
+              </span>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 999,
+                    background: "#F472B6",
+                    boxShadow: "0 0 8px rgba(244,114,182,0.55)",
+                  }}
+                />
+                <span>Managed Service</span>
+              </span>
+            </motion.div>
 
             {/* Floating accent elements */}
             {[...Array(6)].map((_, i) => (
@@ -592,8 +858,12 @@ export default function App() {
                 viewport={{ once: true }}
                 className="text-center mb-12"
               >
-                <h2 className="text-3xl font-bold text-white mb-4">
-                  Built for Data Engineering Excellence
+                <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+                  One engineer can run the modern data stack
+                  <br className="hidden md:block" /> with{" "}
+                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 to-blue-300">
+                    10× productivity
+                  </span>
                 </h2>
               </motion.div>
 
@@ -601,31 +871,31 @@ export default function App() {
                 {[
                   {
                     icon: (
-                      <Zap className="h-8 w-8 text-cyan-400" />
+                      <Network className="h-8 w-8 text-cyan-400" />
                     ),
-                    title: "Lightweight CLI Experience",
+                    title: "Operate the full data system, not just one tool",
                     description:
-                      "Up to 3× more efficient than traditional workflows, with seamless human-in-the-loop collaboration",
+                      "Connect and operate services across the modern data stack — warehouses, catalogs, semantic layers, BI, schedulers — through a single agent",
                     gradient: "from-cyan-500/20 to-blue-500/20",
                   },
                   {
                     icon: (
                       <Database className="h-8 w-8 text-blue-400" />
                     ),
-                    title: "Full Data Engineering Lifecycle",
+                    title: "Manage the full data engineering lifecycle",
                     description:
-                      "From SQL development and data quality to metric management, modeling optimization, SQL review, and job deployment",
+                      "Turn workflows into reusable skills and manage them end to end — from SQL development and quality checks to deployment and monitoring",
                     gradient:
                       "from-blue-500/20 to-purple-500/20",
                   },
                   {
                     icon: (
-                      <Brain className="h-8 w-8 text-purple-400" />
+                      <Shield className="h-8 w-8 text-purple-400" />
                     ),
                     title:
-                      "Context Engineering for Data Engineers",
+                      "Improve agent stability with validation loops",
                     description:
-                      "Purpose-built mechanisms to manage and continuously evolve data engineering context",
+                      "Make data agents more reliable through testing, feedback, and iterative refinement — the harness engineering production needs",
                     gradient:
                       "from-purple-500/20 to-pink-500/20",
                   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const calculateOctagonPosition = (
   index: number,
   centerX = 50,
   centerY = 50,
-  radius = 32,
+  radius = 30,
 ) => {
   const angle = (index * 2 * Math.PI) / 8 - Math.PI / 2; // Start from top
   return {
@@ -861,7 +861,13 @@ export default function App() {
                 <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
                   One engineer can run the modern data stack
                   <br className="hidden md:block" /> with{" "}
-                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 to-blue-300">
+                  <span
+                    className="text-cyan-300"
+                    style={{
+                      textShadow:
+                        "0 0 24px rgba(34,211,238,0.35), 0 0 2px rgba(34,211,238,0.5)",
+                    }}
+                  >
                     10× productivity
                   </span>
                 </h2>
@@ -1033,7 +1039,7 @@ export default function App() {
                       }}
                     />
 
-                    <div className="relative w-full max-w-[500px] md:max-w-[600px] lg:max-w-[700px] xl:max-w-[750px] aspect-square p-[0px] mx-[10px] my-[0px]">
+                    <div className="relative w-full max-w-[460px] md:max-w-[540px] lg:max-w-[620px] xl:max-w-[660px] aspect-square p-[0px] mx-[10px] my-[0px]">
                       {/* Connection Lines */}
                       <svg
                         className="absolute inset-0 w-full h-full pointer-events-none z-10"
@@ -1156,12 +1162,90 @@ export default function App() {
                         </defs>
                       </svg>
 
-                      {/* Stage Cards */}
+                      {/* Center hub — anchors the orbit so the middle isn't visually empty.
+                          Wrapping div holds the position+translate (Framer Motion would otherwise
+                          overwrite the inline transform on the motion.div). */}
+                      <div
+                        className="absolute z-15 pointer-events-none"
+                        style={{
+                          left: "50%",
+                          top: "50%",
+                          transform: "translate(-50%, -50%)",
+                        }}
+                      >
+                      <motion.div
+                        initial={{ scale: 0, opacity: 0 }}
+                        whileInView={{ scale: 1, opacity: 1 }}
+                        transition={{
+                          duration: 0.8,
+                          delay: 0.4,
+                          type: "spring",
+                          stiffness: 200,
+                        }}
+                        viewport={{ once: true }}
+                        className="relative"
+                      >
+                        {/* Pulse rings */}
+                        {[0, 1, 2].map((i) => (
+                          <motion.div
+                            key={i}
+                            className="absolute top-1/2 left-1/2 rounded-full border border-cyan-400/30"
+                            style={{
+                              width: `${88 + i * 36}px`,
+                              height: `${88 + i * 36}px`,
+                              transform: "translate(-50%, -50%)",
+                            }}
+                            animate={{
+                              scale: [1, 1.25, 1],
+                              opacity: [0.5, 0, 0.5],
+                            }}
+                            transition={{
+                              duration: 4,
+                              repeat: Infinity,
+                              delay: i * 1.2,
+                              ease: "easeOut",
+                            }}
+                          />
+                        ))}
+                        {/* Hub badge */}
+                        <div
+                          className="relative w-20 h-20 md:w-24 md:h-24 rounded-full flex items-center justify-center"
+                          style={{
+                            background:
+                              "radial-gradient(circle at 30% 30%, rgba(165,243,252,0.95) 0%, rgba(34,211,238,0.92) 35%, rgba(99,102,241,0.92) 70%, rgba(139,92,246,0.95) 100%)",
+                            boxShadow:
+                              "0 12px 40px -10px rgba(99,102,241,0.6), 0 0 0 1px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.4)",
+                          }}
+                        >
+                          <Sparkles
+                            className="w-7 h-7 md:w-9 md:h-9 text-white drop-shadow"
+                            strokeWidth={2.2}
+                          />
+                        </div>
+                        <div
+                          className="absolute top-full left-1/2 -translate-x-1/2 mt-2.5 whitespace-nowrap text-[10px] md:text-xs font-semibold tracking-[0.18em] uppercase"
+                          style={{ color: "rgba(203,213,225,0.85)" }}
+                        >
+                          Datus Agent
+                        </div>
+                      </motion.div>
+                      </div>
+
+                      {/* Stage Cards — wrapping div holds position+translate
+                          (Framer Motion overwrites inline transform otherwise) */}
                       {lifecycleStages.map((stage, index) => {
                         const IconComponent = stage.icon;
                         return (
-                          <motion.div
+                          <div
                             key={stage.id}
+                            className="absolute z-20"
+                            style={{
+                              left: `${stage.position.x}%`,
+                              top: `${stage.position.y}%`,
+                              transform: "translate(-50%, -50%)",
+                            }}
+                          >
+                          <motion.div
                             initial={{ scale: 0, opacity: 0 }}
                             whileInView={{
                               scale: 1,
@@ -1175,13 +1259,7 @@ export default function App() {
                             }}
                             viewport={{ once: true }}
                             whileHover={{ scale: 1.05, y: -5 }}
-                            className="absolute z-20"
-                            style={{
-                              left: `${stage.position.x}%`,
-                              top: `${stage.position.y}%`,
-                              transform:
-                                "translate(-50%, -50%)",
-                            }}
+                            className="relative"
                           >
                             <Card className="bg-white/95 backdrop-blur border-2 border-slate-200 p-2 md:p-3 rounded-lg md:rounded-xl shadow-lg hover:shadow-xl hover:border-blue-300 transition-all duration-300 w-28 sm:w-32 md:w-36 lg:w-40 cursor-pointer group relative">
                               {/* Connection node indicator */}
@@ -1220,6 +1298,7 @@ export default function App() {
                               </div>
                             </Card>
                           </motion.div>
+                          </div>
                         );
                       })}
                     </div>

--- a/src/components/EnterpriseInquiryDialog.tsx
+++ b/src/components/EnterpriseInquiryDialog.tsx
@@ -1,0 +1,482 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { CheckCircle2, X } from "lucide-react";
+import { motion } from "motion/react";
+import React, { useState } from "react";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+interface FormState {
+  name: string;
+  email: string;
+  company: string;
+  role: string;
+  message: string;
+}
+
+const initialForm: FormState = {
+  name: "",
+  email: "",
+  company: "",
+  role: "",
+  message: "",
+};
+
+const FORMSPREE_ENDPOINT = (import.meta as { env?: Record<string, string> })
+  .env?.VITE_FORMSPREE_ENDPOINT;
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: "0.02em",
+  color: "#CBD5E1",
+  marginBottom: 6,
+};
+
+const inputBaseStyle: React.CSSProperties = {
+  width: "100%",
+  height: 40,
+  padding: "0 0.85rem",
+  borderRadius: 8,
+  background: "rgba(15,23,42,0.6)",
+  border: "1px solid rgba(148,163,184,0.18)",
+  color: "#F1F5F9",
+  fontSize: 14,
+  fontWeight: 500,
+  outline: "none",
+  transition: "border-color 0.15s ease, box-shadow 0.15s ease",
+};
+
+const textareaStyle: React.CSSProperties = {
+  ...inputBaseStyle,
+  height: "auto",
+  minHeight: 96,
+  padding: "0.65rem 0.85rem",
+  resize: "vertical",
+  fontFamily: "inherit",
+  lineHeight: 1.5,
+};
+
+function focusRing(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+  e.currentTarget.style.borderColor = "rgba(244,114,182,0.7)";
+  e.currentTarget.style.boxShadow = "0 0 0 3px rgba(244,114,182,0.18)";
+}
+
+function blurRing(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+  e.currentTarget.style.borderColor = "rgba(148,163,184,0.18)";
+  e.currentTarget.style.boxShadow = "none";
+}
+
+export function EnterpriseInquiryDialog({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [form, setForm] = useState<FormState>(initialForm);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  function reset() {
+    setForm(initialForm);
+    setStatus("idle");
+    setErrorMsg(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (status === "submitting") return;
+
+    setStatus("submitting");
+    setErrorMsg(null);
+
+    const payload = {
+      name: form.name.trim(),
+      email: form.email.trim(),
+      company: form.company.trim(),
+      role: form.role.trim(),
+      message: form.message.trim(),
+      source: "datus.ai homepage — Talk to Enterprise",
+    };
+
+    try {
+      if (FORMSPREE_ENDPOINT) {
+        const res = await fetch(FORMSPREE_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const text = await res.text().catch(() => "");
+          throw new Error(text || `Submission failed (${res.status})`);
+        }
+      } else {
+        await new Promise((r) => setTimeout(r, 600));
+        if (typeof console !== "undefined") {
+          console.warn(
+            "[EnterpriseInquiryDialog] VITE_FORMSPREE_ENDPOINT not set — simulating success.",
+            payload,
+          );
+        }
+      }
+      setStatus("success");
+    } catch (err) {
+      setStatus("error");
+      setErrorMsg(
+        err instanceof Error ? err.message : "Something went wrong. Try again.",
+      );
+    }
+  }
+
+  return (
+    <DialogPrimitive.Root
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) {
+          // small delay so the success state doesn't flash during close animation
+          setTimeout(reset, 200);
+        }
+      }}
+    >
+      <DialogPrimitive.Trigger asChild>{children}</DialogPrimitive.Trigger>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 50,
+            background: "rgba(2,6,23,0.7)",
+            backdropFilter: "blur(6px)",
+            WebkitBackdropFilter: "blur(6px)",
+          }}
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          style={{
+            position: "fixed",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            zIndex: 51,
+            width: "calc(100% - 2rem)",
+            maxWidth: 520,
+            maxHeight: "calc(100vh - 2rem)",
+            overflowY: "auto",
+            background:
+              "linear-gradient(180deg, rgba(15,23,42,0.98) 0%, rgba(2,6,23,0.98) 100%)",
+            border: "1px solid rgba(244,114,182,0.25)",
+            borderRadius: 14,
+            padding: "1.75rem",
+            boxShadow:
+              "0 30px 80px -20px rgba(244,114,182,0.18), 0 20px 50px -20px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.05)",
+          }}
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+        >
+          <DialogPrimitive.Close
+            aria-label="Close"
+            style={{
+              position: "absolute",
+              top: 14,
+              right: 14,
+              width: 32,
+              height: 32,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: 8,
+              border: "1px solid rgba(148,163,184,0.18)",
+              background: "rgba(15,23,42,0.6)",
+              color: "#94A3B8",
+              cursor: "pointer",
+            }}
+          >
+            <X size={16} />
+          </DialogPrimitive.Close>
+
+          {status === "success" ? (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                textAlign: "center",
+                padding: "1rem 0.5rem 0.25rem",
+              }}
+            >
+              <div
+                style={{
+                  width: 56,
+                  height: 56,
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: "rgba(244,114,182,0.12)",
+                  border: "1px solid rgba(244,114,182,0.4)",
+                  marginBottom: "1rem",
+                }}
+              >
+                <CheckCircle2 size={28} style={{ color: "#F9A8D4" }} />
+              </div>
+              <DialogPrimitive.Title asChild>
+                <h3
+                  style={{
+                    fontSize: 20,
+                    fontWeight: 700,
+                    color: "#FFFFFF",
+                    margin: 0,
+                  }}
+                >
+                  Thanks — we'll be in touch
+                </h3>
+              </DialogPrimitive.Title>
+              <p
+                style={{
+                  margin: "0.5rem 0 1.5rem",
+                  fontSize: 14,
+                  lineHeight: 1.6,
+                  color: "#94A3B8",
+                  maxWidth: 380,
+                }}
+              >
+                We typically respond within one business day. In the meantime,
+                feel free to email{" "}
+                <a
+                  href="mailto:contact@datus.ai"
+                  style={{ color: "#F9A8D4", textDecoration: "none" }}
+                >
+                  contact@datus.ai
+                </a>
+                .
+              </p>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                style={{
+                  height: 40,
+                  padding: "0 1.25rem",
+                  borderRadius: 8,
+                  background:
+                    "linear-gradient(180deg, rgba(244,114,182,0.18) 0%, rgba(15,23,42,0.5) 100%)",
+                  border: "1px solid rgba(244,114,182,0.5)",
+                  color: "#FFFFFF",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                Close
+              </button>
+            </motion.div>
+          ) : (
+            <form onSubmit={handleSubmit} noValidate>
+              <DialogPrimitive.Title asChild>
+                <h3
+                  style={{
+                    fontSize: 20,
+                    fontWeight: 700,
+                    color: "#FFFFFF",
+                    margin: "0 0 0.4rem",
+                    letterSpacing: "-0.01em",
+                  }}
+                >
+                  Talk to us about Enterprise & BYOC
+                </h3>
+              </DialogPrimitive.Title>
+              <p
+                style={{
+                  margin: "0 0 1.4rem",
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                  color: "#94A3B8",
+                }}
+              >
+                Tell us a little about your team and what you're trying to do.
+                We'll get back within one business day.
+              </p>
+
+              <div style={{ display: "grid", gap: "1rem" }}>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr",
+                    gap: "0.85rem",
+                  }}
+                >
+                  <div>
+                    <label htmlFor="enterprise-name" style={labelStyle}>
+                      Full name <span style={{ color: "#F9A8D4" }}>*</span>
+                    </label>
+                    <input
+                      id="enterprise-name"
+                      type="text"
+                      required
+                      autoComplete="name"
+                      value={form.name}
+                      onChange={(e) => update("name", e.target.value)}
+                      onFocus={focusRing}
+                      onBlur={blurRing}
+                      style={inputBaseStyle}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="enterprise-company" style={labelStyle}>
+                      Company <span style={{ color: "#F9A8D4" }}>*</span>
+                    </label>
+                    <input
+                      id="enterprise-company"
+                      type="text"
+                      required
+                      autoComplete="organization"
+                      value={form.company}
+                      onChange={(e) => update("company", e.target.value)}
+                      onFocus={focusRing}
+                      onBlur={blurRing}
+                      style={inputBaseStyle}
+                    />
+                  </div>
+                </div>
+
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr",
+                    gap: "0.85rem",
+                  }}
+                >
+                  <div>
+                    <label htmlFor="enterprise-email" style={labelStyle}>
+                      Work email <span style={{ color: "#F9A8D4" }}>*</span>
+                    </label>
+                    <input
+                      id="enterprise-email"
+                      type="email"
+                      required
+                      autoComplete="email"
+                      value={form.email}
+                      onChange={(e) => update("email", e.target.value)}
+                      onFocus={focusRing}
+                      onBlur={blurRing}
+                      style={inputBaseStyle}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="enterprise-role" style={labelStyle}>
+                      Role / title
+                    </label>
+                    <input
+                      id="enterprise-role"
+                      type="text"
+                      autoComplete="organization-title"
+                      value={form.role}
+                      onChange={(e) => update("role", e.target.value)}
+                      onFocus={focusRing}
+                      onBlur={blurRing}
+                      style={inputBaseStyle}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label htmlFor="enterprise-message" style={labelStyle}>
+                    What are you trying to do?
+                  </label>
+                  <textarea
+                    id="enterprise-message"
+                    rows={4}
+                    value={form.message}
+                    onChange={(e) => update("message", e.target.value)}
+                    onFocus={focusRing}
+                    onBlur={blurRing}
+                    placeholder="Stack, scale, timeline, anything we should know…"
+                    style={textareaStyle}
+                  />
+                </div>
+              </div>
+
+              {status === "error" && errorMsg && (
+                <p
+                  style={{
+                    marginTop: "0.85rem",
+                    marginBottom: 0,
+                    fontSize: 12,
+                    color: "#FCA5A5",
+                  }}
+                >
+                  {errorMsg}
+                </p>
+              )}
+
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-end",
+                  gap: "0.75rem",
+                  marginTop: "1.5rem",
+                }}
+              >
+                <DialogPrimitive.Close asChild>
+                  <button
+                    type="button"
+                    style={{
+                      height: 40,
+                      padding: "0 1rem",
+                      borderRadius: 8,
+                      background: "transparent",
+                      border: "1px solid rgba(148,163,184,0.2)",
+                      color: "#CBD5E1",
+                      fontSize: 14,
+                      fontWeight: 500,
+                      cursor: "pointer",
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </DialogPrimitive.Close>
+                <button
+                  type="submit"
+                  disabled={status === "submitting"}
+                  style={{
+                    height: 40,
+                    padding: "0 1.25rem",
+                    borderRadius: 8,
+                    background:
+                      status === "submitting"
+                        ? "rgba(244,114,182,0.18)"
+                        : "linear-gradient(180deg, rgba(244,114,182,0.28) 0%, rgba(15,23,42,0.55) 100%)",
+                    border: "1px solid rgba(244,114,182,0.55)",
+                    color: "#FFFFFF",
+                    fontSize: 14,
+                    fontWeight: 600,
+                    letterSpacing: "-0.005em",
+                    cursor: status === "submitting" ? "wait" : "pointer",
+                    boxShadow:
+                      "inset 0 1px 0 rgba(255,255,255,0.08), 0 4px 16px -8px rgba(244,114,182,0.4)",
+                    transition: "transform 0.15s ease, box-shadow 0.15s ease",
+                  }}
+                >
+                  {status === "submitting" ? "Sending…" : "Request a meeting"}
+                </button>
+              </div>
+            </form>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export default EnterpriseInquiryDialog;


### PR DESCRIPTION

<img width="1477" height="530" alt="image" src="https://github.com/user-attachments/assets/9e0b5eb5-475b-453b-b07d-c1694a9920a3" />


## Summary

Homepage refresh aligned with the new "Positioning & Message 0.3" doc — visual identity preserved, body sections unchanged. Three pillars now drive copy and CTAs:

1. **OSS / GitHub** — Star on GitHub primary CTA + features section pillar
2. **SaaS playground** — Try Datus Studio CTA → studio.datus.ai
3. **Enterprise / BYOC** — Talk to Enterprise CTA → inline inquiry dialog (formspree)

## What's in this PR

- **Hero copy** rewritten to the new two-sentence tagline ("Datus is the open-source data engineering agent that builds evolvable context… From one-man data teams to enterprise agent teams…")
- **Hero CTA row** rebuilt as a unified set of 3 glass-pill buttons sharing one shell — differentiation only via per-pillar accent (cyan/violet/pink) and a `★ 1.1k` chip on the GitHub primary
- **3-column grid** so each meta-strip pill ("Open source · Apache 2.0", "Free playground · no install", "Managed Service") sits centered under its corresponding button
- **EnterpriseInquiryDialog** — Radix-based modal opened by "Talk to Enterprise"; fields: name, work email, company, role, message; POSTs JSON to `VITE_FORMSPREE_ENDPOINT` (Formspree integration), simulates success when env unset
- **Lifecycle diagram fixes**:
  - Cards were anchoring by their top-left corner because Framer Motion was overwriting the inline `transform: translate(-50%, -50%)` on each `motion.div`. Wrapped each motion node in a plain positioning `<div>` so the octagon now renders symmetric.
  - Tightened orbit radius (32% → 30%) and reduced container max-widths so the diagram feels less hollow
  - Added a centered "Datus Agent" gradient hub with pulse rings to anchor the orbit
- **"10× productivity"** highlight switched from cyan→blue gradient to solid cyan-300 with a soft cyan glow; the gradient's blue end was too dim against dark slate
- **Removed** the "Pillar 1 · For Individuals" eyebrow above the features heading
- **Renamed** "Managed & BYOC" → "Managed Service" in the meta strip
- **`.gstack/`** added to `.gitignore` (local browse-server state from the headless QA tooling)

## Files

- `src/App.tsx` — hero, meta strip, lifecycle diagram, features eyebrow
- `src/components/EnterpriseInquiryDialog.tsx` — new
- `.gitignore` — `.gstack/` ignore line

## Configuration the deploy needs

A new env var must be set in production:

```
VITE_FORMSPREE_ENDPOINT=https://formspree.io/f/xgorjaed
```

Without it, the form silently simulates success in the browser and no email is sent. With it, submissions hit Formspree and the configured notification inbox receives an email.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run dev` — hero renders three buttons aligned with their meta-strip pills underneath
- [x] Hover each hero CTA — lifts 2 px, border tints to its pillar color, glow appears in the matching tint
- [x] Star on GitHub opens `github.com/Datus-ai/Datus-agent` in a new tab
- [ ] Try Datus Studio opens `studio.datus.ai` in a new tab
- [x] Talk to Enterprise opens the inquiry modal; required-field validation works; submitting hits Formspree and shows the "Thanks — we'll be in touch" success state
- [ ] Lifecycle diagram cards form a clean octagon centered around the "Datus Agent" hub (no off-axis cards)
- [ ] "10× productivity" reads clearly across the entire word, no fading
- [ ] Mobile (≤375 px) — hero buttons stack vertically and remain tappable; modal form fits the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced hero section with updated messaging ("open-source data engineering agent") and new CTA grid including enterprise inquiry option
* Introduced "Datus Agent" hub badge in the orbit visualization
* Added enterprise inquiry dialog for business inquiries
* Revised features section with updated titles and visual icons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->