### PR TITLE
fix(ci): pass VITE_FORMSPREE_ENDPOINT secret to build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,8 @@ jobs:
       run: npm ci
 
     - name: Build main site
+      env:
+        VITE_FORMSPREE_ENDPOINT: ${{ secrets.VITE_FORMSPREE_ENDPOINT }}
       run: npm run build
 
     - name: Build blog


### PR DESCRIPTION
## Summary
The **Talk to Enterprise** dialog on the homepage was silently failing in production — users saw a success state but no email was ever delivered.

## Root cause
- `EnterpriseInquiryDialog.tsx` posts to `VITE_FORMSPREE_ENDPOINT`. If that var is empty, it falls back to a fake-success branch (`setTimeout(600)` + `console.warn`).
- Vite only inlines `import.meta.env.VITE_*` values that exist **at build time**.
- The GitHub Pages deploy workflow did not expose the `VITE_FORMSPREE_ENDPOINT` secret to the build step, so the production bundle shipped with `FORMSPREE_ENDPOINT === undefined`. Every form submit hit the fake-success path.
- Locally things worked because `.env.local` provides the value.

## Fix
Inject the secret as an env var on the `Build main site` step:

```yaml
- name: Build main site
  env:
    VITE_FORMSPREE_ENDPOINT: ${{ secrets.VITE_FORMSPREE_ENDPOINT }}
  run: npm run build
```

The repo secret `VITE_FORMSPREE_ENDPOINT` has already been configured in GitHub Settings → Secrets and variables → Actions.

## Follow-up worth considering (not in this PR)
The fake-success fallback in `EnterpriseInquiryDialog.tsx:120-128` is dangerous — a missing endpoint should throw or fall back to a `mailto:` link instead of pretending the submit worked. Worth a follow-up so we'd notice immediately if this regresses.

## Test plan
- [ ] Merge → re-run the GitHub Pages workflow
- [ ] On the live homepage, open **Talk to Enterprise**, submit a test inquiry
- [ ] Confirm the email lands in the Formspree inbox / forwarded address
- [ ] Network tab should show a `POST` to the Formspree endpoint returning 200 (not a 600ms artificial delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)