### PR TITLE
feat(blog): data-engineering-agent & semantic-layer article clusters

### DIFF
--- a/blog/.vitepress/config.mts
+++ b/blog/.vitepress/config.mts
@@ -56,8 +56,31 @@ export default defineConfig({
         items: [
           { text: 'The General Chat Agent', link: '/posts/meet-the-general-chat-agent' },
           { text: 'Meet Datus', link: '/posts/meet_datus' },
-          { text: 'What Is a Data Engineering Agent?', link: '/posts/what-is-data-engineering-agent' },
           { text: 'From Human-First to the Agentic Data Stack', link: '/posts/agentic-data-stack' }
+        ]
+      },
+      {
+        text: 'Data Engineering Agent',
+        items: [
+          { text: 'What Is a Data Engineering Agent? (2026 Comparison)', link: '/posts/what-is-data-engineering-agent-2026' },
+          { text: 'What Is a Data Engineering Agent? (Practical Guide)', link: '/posts/what-is-data-engineering-agent' },
+          { text: 'Contextual Data Engineering', link: '/posts/contextual-data-engineering' },
+          { text: 'Best Data Engineering Agents in 2026', link: '/posts/best-data-engineering-agents-2026' },
+          { text: 'Open Source Data Engineering Agents', link: '/posts/open-source-data-engineering-agents' },
+          { text: 'Build Your First Agent in 15 Minutes', link: '/posts/build-your-first-data-engineering-agent' },
+          { text: 'Data Engineering Agent vs. Claude Code', link: '/posts/data-engineering-agent-vs-claude-code' },
+          { text: 'Data Engineering Agent vs. SQL Copilot', link: '/posts/data-engineering-agent-vs-sql-copilot' },
+          { text: 'One-Person Data Team', link: '/posts/one-person-data-team' },
+          { text: 'How a Context Engine Improves Accuracy', link: '/posts/context-engine-data-engineering-agent-accuracy' },
+          { text: 'MCP and Data Engineering', link: '/posts/mcp-data-engineering' },
+          { text: 'Enterprise Data Engineering Agent', link: '/posts/enterprise-data-engineering-agent' },
+          { text: 'Subagents: Domain-Specific Data Agents', link: '/posts/subagents-domain-specific-data-agents' }
+        ]
+      },
+      {
+        text: 'Semantic Layer',
+        items: [
+          { text: 'What Is a Semantic Layer?', link: '/posts/what-is-semantic-layer' }
         ]
       },
       {

--- a/blog/.vitepress/theme/BlogHome.vue
+++ b/blog/.vitepress/theme/BlogHome.vue
@@ -3,6 +3,19 @@ import { withBase } from 'vitepress'
 
 // All posts with dates, sorted newest first — used to compute "latest"
 const allPosts = [
+  { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', description: 'Four products now ship as a data engineering agent — but they are not the same thing. Definition, side-by-side comparison, and where persistent context separates agents from chat windows.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Research', link: '/posts/what-is-data-engineering-agent-2026' },
+  { title: 'What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer', description: 'The business translation layer between raw tables and analysts: what it includes, how it differs from metric layers and catalogs, and why static models break under AI agents.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Glossary', link: '/posts/what-is-semantic-layer' },
+  { title: 'Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context', description: 'Contextual data engineering explained: schemas, semantics, and feedback loops for durable data agents.', date: '2026-06-01', display: 'Jun 1, 2026', tag: 'Research', link: '/posts/contextual-data-engineering' },
+  { title: 'Best Data Engineering Agents in 2026: An Honest Comparison', description: 'Best data engineering agents in 2026 compared by stack fit, context, openness, and enterprise readiness.', date: '2026-06-02', display: 'Jun 2, 2026', tag: 'Comparison', link: '/posts/best-data-engineering-agents-2026' },
+  { title: 'Open Source Data Engineering Agents: Why They Exist, When to Use One, and What Your Options Are', description: 'Open-source data engineering agents compared: Datus, Wren AI, Altimate, and when self-hosting is worth it.', date: '2026-06-02', display: 'Jun 2, 2026', tag: 'Comparison', link: '/posts/open-source-data-engineering-agents' },
+  { title: 'How to Build Your First Data Engineering Agent in 15 Minutes', description: 'Build a first data engineering agent with Datus: install, ask questions, generate context, and create a subagent.', date: '2026-06-03', display: 'Jun 3, 2026', tag: 'Product', link: '/posts/build-your-first-data-engineering-agent' },
+  { title: 'Data Engineering Agent vs. Claude Code: When to Use Which', description: 'Data engineering agent vs Claude Code: when persistent data context matters and when a coding agent is enough.', date: '2026-06-03', display: 'Jun 3, 2026', tag: 'Comparison', link: '/posts/data-engineering-agent-vs-claude-code' },
+  { title: 'Data Engineering Agent vs. SQL Copilot: What\'s the Real Difference?', description: 'Data engineering agent vs SQL copilot: persistence, feedback, team context, and when each tool fits.', date: '2026-06-04', display: 'Jun 4, 2026', tag: 'Comparison', link: '/posts/data-engineering-agent-vs-sql-copilot' },
+  { title: 'One-Person Data Team: How a Data Engineering Agent Multiplies Your Output', description: 'How a one-person data team uses a data engineering agent to reduce SQL translation work and ship self-service analytics.', date: '2026-06-04', display: 'Jun 4, 2026', tag: 'Product', link: '/posts/one-person-data-team' },
+  { title: 'How a Context Engine Makes Data Engineering Agents More Accurate', description: 'How a context engine improves data engineering agent accuracy with schemas, validated SQL, and feedback loops.', date: '2026-06-01', display: 'Jun 1, 2026', tag: 'Research', link: '/posts/context-engine-data-engineering-agent-accuracy' },
+  { title: 'MCP and Data Engineering: The Protocol That Connects Your Entire Stack', description: 'MCP for data engineering: how agents connect to databases, orchestrators, quality tools, and context services.', date: '2026-06-02', display: 'Jun 2, 2026', tag: 'Research', link: '/posts/mcp-data-engineering' },
+  { title: 'What an Enterprise Data Engineering Agent Actually Needs', description: 'Enterprise data engineering agent requirements: shared context, RBAC, auditability, reliability, and governance.', date: '2026-06-03', display: 'Jun 3, 2026', tag: 'Research', link: '/posts/enterprise-data-engineering-agent' },
+  { title: 'Subagents: How to Ship Domain-Specific Data Agents Without Training a Model', description: 'Subagents explained: domain-specific data agents built from scoped context, feedback, and governed access.', date: '2026-06-04', display: 'Jun 4, 2026', tag: 'Product', link: '/posts/subagents-domain-specific-data-agents' },
   { title: 'Make Data Agents Usable: Ask, Explore, and Control with Confidence', description: 'Ask User, session management, Explore, and action display make Datus agents easier to trust and control.', date: '2026-04-02', display: 'Apr 2, 2026', tag: 'Product', link: '/posts/make-data-agents-truly-usable-ask-explore-and-control-with-confidence' },
   { title: 'Beyond SQL: How Datus Integrates With Your Entire Data Toolchain', description: 'How MCP and Skills connect Datus to your data catalog, metric layer, scripts, and quality workflows.', date: '2026-04-02', display: 'Apr 2, 2026', tag: 'Tooling', link: '/posts/beyond-sql-how-datus-integrates-with-your-entire-data-toolchain' },
   { title: 'Meet the General Chat Agent: Your Data Co-Pilot That Actually Thinks', description: 'A conversational data co-pilot that supports exploration, investigation, documentation, and knowledge-building.', date: '2026-03-25', display: 'Mar 25, 2026', tag: 'Product', link: '/posts/meet-the-general-chat-agent' },
@@ -31,8 +44,33 @@ const sections = [
     posts: [
       { title: 'Meet the General Chat Agent: Your Data Co-Pilot That Actually Thinks', date: 'Mar 25, 2026', link: '/posts/meet-the-general-chat-agent' },
       { title: 'SQL Agents Are Broken Without Context. Meet Datus.', date: 'Oct 21, 2025', link: '/posts/meet_datus' },
-      { title: 'What Is a Data Engineering Agent?', date: 'Mar 2, 2026', link: '/posts/what-is-data-engineering-agent' },
       { title: 'From Human-First Data Systems to the Agentic Data Stack', date: 'Mar 11, 2026', link: '/posts/agentic-data-stack' },
+    ]
+  },
+  {
+    label: 'Data Engineering Agent',
+    description: 'The category, the comparisons, and how to build with one — our core cluster.',
+    posts: [
+      { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', date: 'May 31, 2026', link: '/posts/what-is-data-engineering-agent-2026' },
+      { title: 'What Is a Data Engineering Agent? A Practical Guide with Datus', date: 'Mar 2, 2026', link: '/posts/what-is-data-engineering-agent' },
+      { title: 'Contextual Data Engineering: Why Every Agent Needs Evolvable Context', date: 'Jun 1, 2026', link: '/posts/contextual-data-engineering' },
+      { title: 'Best Data Engineering Agents in 2026: An Honest Comparison', date: 'Jun 2, 2026', link: '/posts/best-data-engineering-agents-2026' },
+      { title: 'Open Source Data Engineering Agents', date: 'Jun 2, 2026', link: '/posts/open-source-data-engineering-agents' },
+      { title: 'How to Build Your First Data Engineering Agent in 15 Minutes', date: 'Jun 3, 2026', link: '/posts/build-your-first-data-engineering-agent' },
+      { title: 'Data Engineering Agent vs. Claude Code: When to Use Which', date: 'Jun 3, 2026', link: '/posts/data-engineering-agent-vs-claude-code' },
+      { title: 'Data Engineering Agent vs. SQL Copilot: What\'s the Real Difference?', date: 'Jun 4, 2026', link: '/posts/data-engineering-agent-vs-sql-copilot' },
+      { title: 'One-Person Data Team: How a Data Engineering Agent Multiplies Your Output', date: 'Jun 4, 2026', link: '/posts/one-person-data-team' },
+      { title: 'How a Context Engine Makes Data Engineering Agents More Accurate', date: 'Jun 1, 2026', link: '/posts/context-engine-data-engineering-agent-accuracy' },
+      { title: 'MCP and Data Engineering: The Protocol That Connects Your Entire Stack', date: 'Jun 2, 2026', link: '/posts/mcp-data-engineering' },
+      { title: 'What an Enterprise Data Engineering Agent Actually Needs', date: 'Jun 3, 2026', link: '/posts/enterprise-data-engineering-agent' },
+      { title: 'Subagents: How to Ship Domain-Specific Data Agents Without Training a Model', date: 'Jun 4, 2026', link: '/posts/subagents-domain-specific-data-agents' },
+    ]
+  },
+  {
+    label: 'Semantic Layer',
+    description: 'What a semantic layer is, and how it differs from a metric layer or catalog.',
+    posts: [
+      { title: 'What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer', date: 'May 31, 2026', link: '/posts/what-is-semantic-layer' },
     ]
   },
   {

--- a/blog/.vitepress/theme/PostMeta.vue
+++ b/blog/.vitepress/theme/PostMeta.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { useData } from 'vitepress'
+import { computed, ref, onMounted, watch, nextTick } from 'vue'
+
+const { frontmatter, page } = useData()
+
+// Only render a byline when the page declares an author (i.e. it's an article).
+const show = computed(() => !!frontmatter.value.author && !!frontmatter.value.date)
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'
+]
+
+const formattedDate = computed(() => {
+  const raw = frontmatter.value.date
+  if (!raw) return ''
+  const d = new Date(raw)
+  if (isNaN(d.getTime())) return String(raw)
+  // Use UTC parts so an ISO date like 2026-06-01 never shifts a day across timezones.
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`
+})
+
+const root = ref(null)
+const ready = ref(false)
+const readingTime = ref(0)
+
+function position() {
+  if (!show.value) return
+  const doc = document.querySelector('.vp-doc')
+  if (!doc) return
+
+  // Reading time from the rendered article body (~200 wpm).
+  const words = (doc.innerText || '').trim().split(/\s+/).filter(Boolean).length
+  readingTime.value = Math.max(1, Math.round(words / 200))
+
+  // Move the byline directly beneath the article's H1 title.
+  const h1 = doc.querySelector('h1')
+  if (h1 && root.value && root.value.previousElementSibling !== h1) {
+    h1.insertAdjacentElement('afterend', root.value)
+  }
+  ready.value = true
+}
+
+onMounted(position)
+// Re-run on client-side route changes between posts.
+watch(() => page.value.relativePath, () => {
+  ready.value = false
+  readingTime.value = 0
+  nextTick(position)
+})
+</script>
+
+<template>
+  <div v-if="show" ref="root" class="post-meta" :class="{ ready }">
+    <span class="post-meta-author">{{ frontmatter.author }}</span>
+    <span class="post-meta-sep">·</span>
+    <time class="post-meta-date">{{ formattedDate }}</time>
+    <template v-if="readingTime">
+      <span class="post-meta-sep">·</span>
+      <span class="post-meta-read">{{ readingTime }} min read</span>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.post-meta {
+  /* Hidden until positioned under the H1 to avoid a layout flash above the title. */
+  display: none;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0 28px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--vp-c-divider);
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--vp-c-text-2);
+}
+.post-meta.ready {
+  display: flex;
+}
+.post-meta-author {
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+.post-meta-sep {
+  opacity: 0.5;
+}
+</style>

--- a/blog/.vitepress/theme/index.ts
+++ b/blog/.vitepress/theme/index.ts
@@ -1,9 +1,16 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
 import BlogHome from './BlogHome.vue'
+import PostMeta from './PostMeta.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'doc-before': () => h(PostMeta)
+    })
+  },
   enhanceApp({ app }) {
     app.component('BlogHome', BlogHome)
   }

--- a/blog/posts/best-data-engineering-agents-2026.md
+++ b/blog/posts/best-data-engineering-agents-2026.md
@@ -1,0 +1,188 @@
+---
+title: "Best Data Engineering Agents in 2026: An Honest Comparison"
+description: "Best data engineering agents in 2026 compared by stack fit, context, openness, and enterprise readiness."
+author: "John Smith"
+date: 2026-06-02
+lastmod: 2026-06-02
+head:
+  - - meta
+    - name: keywords
+      content: "best data engineering agents, data engineering agent comparison, top data engineering agents 2026, data engineering agent tools, compare data engineering agents"
+  - - meta
+    - property: og:title
+      content: "Best Data Engineering Agents in 2026: An Honest Comparison"
+  - - meta
+    - property: og:description
+      content: "Best data engineering agents in 2026 compared by stack fit, context, openness, and enterprise readiness."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/best-data-engineering-agents-2026
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/best-data-engineering-agents-2026
+---
+# Best Data Engineering Agents in 2026: An Honest Comparison
+
+At this point, eight different products call themselves a **data engineering agent**, and they barely do the same thing.
+
+One lives inside a cloud console. One is a SaaS capability for martech teams. One is a community prompt you paste into a terminal. One is an open-source framework that treats context as infrastructure. Three more occupy the independent space between. They all claim to "turn natural language into data work," and technically, they all do. But the differences that matter—who is allowed to use it, what it actually has access to, and what it remembers tomorrow—are invisible on product pages.
+
+The best data engineering agent depends on your stack: single-warehouse teams are best served by platform-native agents; multi-warehouse teams need stack-agnostic, context-persistent alternatives. This guide compares the eight most notable options side by side and gives you a decision framework—no demo video required. If you are new to the category, start with [what a data engineering agent is](/posts/what-is-data-engineering-agent-2026).
+
+## TL;DR
+
+- Eight products compete for the **data engineering agent** label in 2026, split across four categories: platform-embedded, prompt-as-agent, vertical SaaS, and open-source framework.
+- **No single agent wins for every team.** The right choice depends on your stack (single-warehouse or multi-warehouse), your need for persistent context, and whether you prioritize speed of setup or long-term control.
+- If everything lives in **one warehouse**, use the platform's agent (BigQuery DEA for GCP, Cortex Code for Snowflake). If you have **two or more**, you need a stack-agnostic agent or a context layer that travels.
+- The deepest split in the market is **context persistence**: four agents remember across sessions, three do not.
+
+## 1. The four categories, briefly
+
+Before listing products, it helps to understand that the eight agents fall into four categories with fundamentally different design philosophies. For a detailed breakdown of these categories, see [the category definition article](/posts/what-is-data-engineering-agent-2026). Here is the short version:
+
+**Platform-embedded agents** (BigQuery DEA, Snowflake Cortex Code) live inside a single cloud platform. They are deeply integrated with their host's metadata, IAM, and billing. They are the path of least resistance when your entire data life happens inside that platform. They are not an option when it does not.
+
+**Prompt-as-agent recipes** (Claude Code data-engineer subagent) turn a general-purpose coding agent into a data engineer for an afternoon. They are the right answer for one-off, exploratory work where setting up real infrastructure would cost more than the task itself. They are not the right answer for sustained, team-scale data engineering.
+
+**Vertical SaaS agents** (Adobe DEA) bring agentic workflows to a specific business function—in Adobe's case, martech data engineering inside the Experience Platform. They are deeply capable within their domain and irrelevant outside it.
+
+**Open-source agent frameworks** (Datus, Wren AI, Altimate) treat the agent as infrastructure that lives between tools rather than inside one. They are the right answer when your stack is heterogeneous, your team is growing, and you want an agent that accumulates knowledge instead of forgetting it after every session.
+
+TextQL sits between categories—closed-source but stack-agnostic, enterprise-focused but with an open-source component (Ana Small).
+
+## 2. The eight agents, side by side
+
+| Dimension | BigQuery DEA | Snowflake Cortex Code | Adobe DEA | Claude Code subagent | Datus | Wren AI | Altimate | TextQL / Ana |
+|---|---|---|---|---|---|---|---|
+| **Category** | Platform-embedded | Platform-embedded | Vertical SaaS | Prompt-as-agent | Open-source framework | Open-source framework | Open-source framework |
+| **Scope** | BigQuery + Dataform | Snowflake + dbt + Airflow | Adobe Experience Platform | Whatever is local | Stack-agnostic warehouses | Any JDBC source | dbt ecosystem | Enterprise analytics workflows |
+| **Environment** | GCP console | CLI | AEP UI | Terminal (Claude Code) | CLI · Chat · API · Studio | Web + SDK | CLI · VS Code · npm | SaaS workspace |
+| **Open source** | No | No | No | Prompt only | Apache 2.0 | Apache 2.0 | MIT | No |
+| **Persistent context** | Knowledge Catalog | Cortex Search Service | AEP platform state | None (no data store) | Context Engine | MDL semantic model | dbt manifest | Enterprise data memory |
+| **Feedback loop** | No | No | No | No | Yes (upvote/correction) | No (static) | ADE-Bench (benchmark) |
+| **Subagents** | No | No | No | No | Yes (scoped chatbots) | No | No |
+| **Multi-model** | Gemini only | Multi (Claude, GPT) | Sensei GenAI | Claude only | Pluggable | Plug-in | Plug-in | Vendor-managed |
+| **Pricing** | Free (compute only) | Independent sub + usage | AEP subscription | Claude Pro/Team sub | Free OSS + Cloud + Enterprise | Free OSS + Cloud | Free OSS | Enterprise SaaS |
+| **Best for** | GCP-only teams | Snowflake-heavy teams | Adobe martech teams | Ad-hoc exploratory work | Multi-warehouse teams | Analyst self-service | dbt-heavy DE teams | Large analytics teams |
+
+### BigQuery Data Engineering Agent
+
+Google's agent is the clearest platform-embedded option in this category, but Google currently documents it under Pre-GA terms. It generates and edits Dataform pipeline code, suggests schema designs, and is grounded in BigQuery's Knowledge Catalog for schema metadata; Google also states that users must review and run or schedule pipelines because the agent cannot execute them by itself. Its core strength is seamlessness: lineage, IAM, and billing work without configuration because everything happens inside one cloud. Its weakness is equally clear—if your stack includes Snowflake, Databricks, or anything on-premise, this agent is not the answer. It is a feature of BigQuery, not a tool that travels with you.
+
+### Snowflake Cortex Code CLI
+
+Snowflake's entry is best read as a Snowflake-native coding agent for data engineering workflows, with official materials emphasizing Snowflake integration, dbt and Airflow-adjacent work, and model choice. The independent subscription is a notable strategic move—it partially breaks the "platform-bound" framing. But the agent's context is still tied to Snowflake's Cortex Search Service, and teams running multiple warehouses will find the agent strongest inside Snowflake and thinner outside it.
+
+### Adobe Data Engineering Agent
+
+Adobe's agent targets a specific persona: customer-data engineers building audiences, schemas, and pipelines for marketing activation inside Adobe Experience Platform. It plans transformations, builds AEP data flows, and orchestrates work inside Adobe's catalog. The framing is genuinely different from the others—this is a vertical SaaS agent, not a general-purpose data engineering tool. Outside AEP, the product does not apply, and that is by design. (Note: Adobe's public materials describe the agent in future-forward language—it is an announced product with an evolving GA timeline.)
+
+### Claude Code data-engineer subagent
+
+This is a community-maintained persona configuration for Claude Code—a prompt that instructs Claude to act as a data engineer. It is the most stack-agnostic of the eight: no warehouse lock-in, no platform dependency, just a terminal and an LLM. It handles ad-hoc SQL generation, pipeline drafting, and schema exploration capably. It is also the most ephemeral: there is no persistent data context store, and session state does not carry between invocations. For an evening of exploratory work, it is excellent. For sustained team-scale data engineering, it starts from zero every morning.
+
+### Datus
+
+Datus is the open-source agent built around a persistent [Context Engine](/posts/contextual-data-engineering)—a dual-dimension context store (physical catalog tree + logical subject tree) that treats every successful query as training data for the next one. It runs as a CLI, chat, API, or hosted Studio, and connects to ten database types (Snowflake, BigQuery, Postgres, DuckDB, StarRocks, and more). Its subagent system packages scoped context into domain-specific chatbots. In Datus's Lakehouse deployment narrative, context feedback is tied to materially higher self-service usage and faster repeated query work. Datus is strongest for teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge rather than rediscovering it on every query.
+
+### Wren AI
+
+Wren AI (~9.8K GitHub stars) is the most mature open-source semantic layer plus text-to-SQL agent. Its MDL-based semantic modeling tools are more polished than Datus's, and its documentation and community are further along. But its context model is static: you build the semantic model once, and the agent queries against it. There is no feedback loop that updates the model based on usage. For teams that already have a well-maintained semantic layer and want to add an AI query interface on top, Wren AI is a strong choice. For teams whose context evolves faster than their modeling sprints, the static model becomes a bottleneck.
+
+### Altimate
+
+Altimate is the most focused agent in the group: it is an agentic data engineering harness built specifically for the dbt ecosystem. Its strongest evidence should come from Altimate's own benchmark and product materials, so teams should verify current ADE-Bench and SQL anti-pattern numbers before treating them as buyer-grade proof. Its CLI, VS Code extension, and npm package make it accessible to dbt practitioners. If your team is dbt-native and wants an agent that deeply understands dbt manifests, Altimate is the strongest option in its category. If your stack extends beyond dbt—or you do not use dbt at all—its scope is limiting.
+
+### TextQL (Ana)
+
+TextQL sits outside the four-category framework—it is closed-source, stack-agnostic, and enterprise-focused, with $17M in funding and customers including Amazon, Dropbox, and Scale AI. Ana, its AI data scientist, covers query generation, analysis, and visualization, with integrations to Cube, Looker, and dbt semantic layers. Its strengths are enterprise readiness (SOC 2 Type II, HIPAA) and clear pricing (Free/Team/Enterprise at $250/mo). Its weakness relative to the open-source options is vendor lock-in and a higher starting price for teams that want more than the free tier. It is also more targeted at the analysis side—"AI data scientist"—than the engineering side, making it a better fit for analyst-heavy teams than engineer-heavy ones.
+
+## 3. Decision framework: which agent fits your team?
+
+The most honest answer is that no single agent wins for everyone. The right choice depends on three questions:
+
+### Question 1: Single warehouse or plural?
+
+- **Single warehouse (BigQuery-only, Snowflake-only):** Use the platform's agent. BigQuery DEA or Cortex Code will be the path of least resistance with the deepest integration. You can always add a stack-agnostic agent later if you add a second warehouse.
+- **Multi-warehouse (two or more, or plans to add one):** You need a stack-agnostic agent. Among the open-source options, Datus covers the broadest set of database adapters (10+); Wren AI connects to any JDBC source but with a thinner integration layer; Altimate is dbt-only.
+
+### Question 2: Ad-hoc or durable?
+
+- **Ad-hoc, exploratory, session-bounded:** A prompt-based agent (Claude Code subagent) is fine. The work is one-off, and the cost of setup outweighs the value of persistence.
+- **Durable, repeated, team-scale:** You need persistent context. The agent that remembers validated SQL, business rules, and feedback history across sessions will compound in accuracy. Among the agents with persistent context, Datus has the most explicit feedback loop; Wren AI's context is static; Altimate's context is dbt-manifest-driven; the platform agents' context is platform metadata.
+
+### Question 3: Engineering side or analysis side?
+
+- **Engineering side (pipeline development, schema design, context management, agent delivery):** Datus, Altimate, or Cortex Code. Datus for multi-warehouse context engineering, Altimate for dbt-native harness work, Cortex Code for Snowflake-native pipeline development.
+- **Analysis side (self-service queries, ad-hoc analysis, dashboard data):** Wren AI or TextQL. Wren AI for open-source semantic-layer-driven analyst self-service, TextQL for enterprise AI data scientist capabilities with compliance requirements.
+
+### Quick-reference decision table
+
+| Your situation | Best fit | Runner-up |
+|---|---|---|
+| All-in on GCP, one warehouse | BigQuery DEA | — |
+| All-in on Snowflake, one warehouse | Cortex Code | Datus (if you want OSS) |
+| Adobe martech ecosystem | Adobe DEA | — |
+| One-off exploratory work, no infra | Claude Code subagent | Datus Cloud (free tier) |
+| Multi-warehouse, need persistent context | Datus | TextQL (if enterprise budget) |
+| dbt-native team, want agentic harness | Altimate | Datus (for non-dbt sources) |
+| Analyst self-service, have semantic layer | Wren AI | TextQL |
+| Enterprise compliance, budget available | TextQL | Cortex Code |
+| Open source, self-hosted, full control | Datus or Wren AI | Altimate |
+
+## 4. What separates the agents that will last from the ones that won't
+
+The data engineering agent category is young, and not every product will remain independent. The pattern is already visible across AI data tooling: some products are acquired, some narrow their open-source scope, and some reposition around enterprise workflows. Buyers should treat sustainability as part of product evaluation, not an afterthought.
+
+The agents with the strongest survival profile share two characteristics:
+
+**They own their context layer.** Agents that depend entirely on a platform's metadata (BigQuery DEA, Cortex Code) are features of that platform—they are safe as long as the platform invests in them, but they cannot outgrow their host. Agents with no context layer (Claude Code subagent) are utilities—useful, but not durable infrastructure. The agents that own their context layer (Datus's Context Engine, Wren AI's MDL, Altimate's dbt harness) have an independent value proposition that is not tied to any single platform's roadmap.
+
+**They have a path to monetization that does not depend on being free forever.** Open-source agents that rely entirely on community goodwill without a clear enterprise revenue path can struggle to sustain documentation, support, and roadmap momentum. The surviving open-source agents are the ones with a model: Datus's Cloud Personal (free) + Enterprise (paid), Wren AI's Cloud tier, Altimate's forthcoming commercial offering.
+
+This is not a judgment on engineering quality—it is a judgment on whether the agent you choose today will still be maintained in 2028. For teams building agent infrastructure into their core data workflows, this matters.
+
+## Source notes
+
+For a comparison page, keep product status tied to primary sources: Google's BigQuery Data Engineering Agent documentation for Pre-GA and execution limits, Snowflake's Cortex Code materials for supported workflows, Adobe's Experience Platform announcement for evolving agent capabilities, and each open-source project's GitHub/docs for license, install path, and maintenance state. Re-check these sources before each refresh because agent products are changing quickly.
+
+## 5. Bottom line
+
+The best data engineering agent in 2026 is the one that matches your stack, your team structure, and your tolerance for vendor dependency. If everything lives in one warehouse, use the platform's agent and move on. If you have a heterogeneous stack and want an agent that accumulates knowledge instead of forgetting it, the open-source frameworks—Datus most prominently for its Context Engine and subagent model—are the strongest candidates.
+
+The most useful question to ask when evaluating any of these agents is not "how smart is it today?" It is "what will it know about my data six months from now?" The answer tells you whether you are renting a feature or building an asset.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see a Context Engine in action—connect a warehouse, ask a question, and watch the agent build context that compounds.
+
+## Frequently asked questions
+
+### Which data engineering agent is best for small teams?
+
+For small teams (1-5 data engineers), the open-source options are the most practical starting point. Datus and Wren AI are both free under Apache 2.0, installable via pip, and do not require enterprise procurement. Datus's Cloud Personal tier is also free and removes the need for local setup. If your small team is purely on one warehouse, the platform's agent (BigQuery DEA or Cortex Code) may be even simpler—but you accept platform lock-in as the tradeoff.
+
+### How do open-source data engineering agents compare to platform-embedded ones?
+
+**Open-source agents** (Datus, Wren AI, Altimate) are stack-agnostic—they work across multiple warehouses and are self-hostable, giving you full control over data and infrastructure. Their context models are generally deeper (Datus's Context Engine, Wren AI's MDL) but require more setup. **Platform-embedded agents** (BigQuery DEA, Cortex Code) work out of the box if you are on the right platform, with zero configuration for IAM, billing, and metadata. The tradeoff is freedom vs. convenience: open-source agents give you portability and control; platform agents give you speed of setup and deep integration.
+
+### What should I look for when evaluating a data engineering agent?
+
+Four criteria that matter more than demo-quality SQL generation: (1) **Context persistence**—does the agent remember validated queries, business rules, and feedback across sessions? (2) **Stack coverage**—does it work with your actual warehouses, or only with the one it was built for? (3) **Feedback loop**—can users correct the agent's output, and does that correction improve future results? (4) **Delivery model**—can you scope the agent to specific domains and share it with non-engineers, or is it a single-user CLI tool? The first criterion separates agents from copilots; the fourth separates team tools from personal utilities.
+
+### Is there a free data engineering agent?
+
+Yes, several. Datus is Apache 2.0 (free CLI + free Cloud Personal tier). Wren AI is Apache 2.0 (free self-hosted + free Cloud tier). Altimate is MIT (free CLI + VS Code extension). Claude Code's data-engineer subagent is free if you already have a Claude subscription. BigQuery DEA is free (you pay only for BigQuery compute). The "free" agents vary dramatically in capability and scope—free does not mean equivalent.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and four-agent comparison
+- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model beneath every durable agent
+- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — auditability, self-hosting, and the case for open source

--- a/blog/posts/build-your-first-data-engineering-agent.md
+++ b/blog/posts/build-your-first-data-engineering-agent.md
@@ -1,0 +1,307 @@
+---
+title: "How to Build Your First Data Engineering Agent in 15 Minutes"
+description: "Build a first data engineering agent with Datus: install, ask questions, generate context, and create a subagent."
+author: "John Smith"
+date: 2026-06-03
+lastmod: 2026-06-03
+head:
+  - - meta
+    - name: keywords
+      content: "how to build a data engineering agent, build your first data engineering agent, data engineering agent tutorial, data engineering agent quickstart, data engineering agent setup, data engineering agent CLI, data engineering workflow"
+  - - meta
+    - property: og:title
+      content: "How to Build Your First Data Engineering Agent in 15 Minutes"
+  - - meta
+    - property: og:description
+      content: "Build a first data engineering agent with Datus: install, ask questions, generate context, and create a subagent."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/build-your-first-data-engineering-agent
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/build-your-first-data-engineering-agent
+---
+# How to Build Your First Data Engineering Agent in 15 Minutes
+
+You do not need a procurement approval. You do not need a cloud budget. You do not need to know how LLMs work. You need a terminal, Python 3.12 or later, and roughly 15 minutes if your environment is ready. By the end of this guide, you will have a working <a href="https://datus.ai/glossary">data engineering agent</a> connected to a real database, a generated semantic model, and a scoped chatbot you can share with a teammate.
+
+We will use Datus for this tutorial because it is free (Apache 2.0), installs with a single pip command, and ships with a built-in tutorial dataset so you do not need to connect a production warehouse to try it. If you want to understand what a data engineering agent is before building one, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+
+## TL;DR
+
+You will do seven things in this tutorial:
+1. Install Datus (`pip install datus-agent`)
+2. Start a session and load the built-in California Schools dataset
+3. Ask your first natural-language question
+4. Browse the context the agent automatically builds
+5. Generate a semantic model from your database schema
+6. Create a subagent—a scoped chatbot for a specific domain
+7. Share the subagent link with a teammate
+
+## Step 1: Install Datus
+
+Open your terminal and run:
+
+```bash
+pip install datus-agent
+```
+
+Requirements: Python 3.12 or later, macOS or Linux. Windows may work but is not officially tested. The install takes under a minute on a typical connection.
+
+Verify the installation:
+
+```bash
+datus-agent --version
+```
+
+You should see a version number (v0.2.6 or later). If you see a command-not-found error, make sure your Python bin directory is on your PATH.
+
+## Step 2: Start a session and load the tutorial dataset
+
+Datus ships with a built-in California Schools dataset—a small PostgreSQL-compatible database with school performance metrics. This lets you try the agent without connecting to a real warehouse.
+
+Start a new Datus session:
+
+```bash
+datus-agent
+```
+
+You will enter the Datus CLI. Load the tutorial dataset:
+
+```
+.load california_schools
+```
+
+The agent will initialize the database, inspect its schema, and begin building context. You will see output indicating it has discovered tables, columns, and relationships. This takes about 30 seconds on first load.
+
+## Step 3: Ask your first question
+
+With the dataset loaded, ask a natural-language question:
+
+```
+Show me schools with above-average math scores, grouped by county
+```
+
+The agent will:
+
+1. **Retrieve context** — it looks up the California Schools schema in its context store, finds relevant tables (`schools`, `scores`), and identifies which columns represent math scores and counties.
+2. **Generate SQL** — it composes a query that calculates the average math score, filters schools above that average, and groups by county.
+3. **Execute the query** — it runs the SQL against the local database.
+4. **Return results** — you see a table of counties and their above-average schools.
+
+Try a follow-up:
+
+```
+Now add the percentage of economically disadvantaged students for each
+```
+
+The agent extends the previous query—adding a join to the demographic data table and including the new column—without you needing to specify table names or join keys. That is the Context Engine at work: it already knows the schema from the first question, so the second question is cheaper.
+
+## Step 4: Browse the context the agent is building
+
+Behind the scenes, every query you ask is building context. You can inspect it. Try these commands:
+
+**Browse the physical catalog:**
+
+```
+@catalog
+```
+
+This shows you the database structure the agent has learned: databases → schemas → tables → columns. It is a tree view of your data's physical layout, annotated with any semantic models the agent has generated.
+
+**Browse the logical subject tree:**
+
+```
+@subject
+```
+
+This shows you the business-domain view: topics the agent has inferred, metrics it has identified, and reference SQL it has captured from your queries. This is the [contextual data engineering](/posts/contextual-data-engineering) layer—the institutional memory that makes the next query more accurate than the first.
+
+**Explore a specific table:**
+
+```
+@table schools
+```
+
+This shows you the columns, types, and any annotations for the `schools` table—including generated semantic information about which columns are likely dimensions vs. measures.
+
+Each of these commands is not just a viewer—it is a navigation interface into the context the agent is accumulating. The more you use it, the richer the context becomes.
+
+## Step 5: Generate a semantic model
+
+The agent can automatically generate a semantic model from your schema—identifying which columns are measures (quantities you aggregate), which are dimensions (attributes you group by), and how tables relate to each other.
+
+Run:
+
+```
+/gen_semantic_model
+```
+
+The agent will scan the California Schools schema and produce a semantic model in MetricFlow-compatible YAML format. It identifies, for example, that `math_score` in the `scores` table is a measure, that `county_name` in the `schools` table is a dimension, and that the two tables join on `school_id`.
+
+You can edit this model—add business definitions, correct wrong inferences, mark deprecated columns—and the corrections will feed back into the context engine, making future queries more accurate.
+
+For a deeper understanding of semantic models and how they relate to agent accuracy, see [what is a semantic layer](/posts/what-is-semantic-layer).
+
+## Step 6: Create a subagent
+
+A subagent is a scoped chatbot that packages a subset of context for a specific domain. Instead of giving a teammate access to the entire California Schools database, you give them a subagent that only knows about the schools domain—roughly 10 tables, 20 metrics, and 30 validated SQL references.
+
+Create one:
+
+```
+.subagent add
+```
+
+You will be prompted for:
+- **Name:** Give it a descriptive name like "California Schools Analyst"
+- **Scope:** Select which tables and metrics to include. For this tutorial, include the `schools`, `scores`, and `demographics` tables.
+- **Description:** Write a short description so users know what the subagent can do: "Answers questions about California school performance, test scores, and student demographics."
+
+The agent packages the scoped context and generates a shareable link. Anyone with the link can open the subagent in Datus Chat and ask natural-language questions—limited to the scope you defined. They cannot access tables outside the scope, and their queries are grounded in the same context the agent has built.
+
+```bash
+.subagent list
+```
+
+This shows all your subagents and their status. You will see your newly created "California Schools Analyst" listed with its scope summary and share link.
+
+## Step 7: Share with a teammate
+
+Copy the subagent link and send it to a teammate. They open it, type a question—"Compare average SAT scores across counties with more than 5 schools"—and the subagent generates and executes the query, grounded in the context you curated.
+
+This is the delivery model that separates a <a href="https://datus.ai/glossary">data engineering agent</a> from a personal SQL copilot. You are not just writing queries faster. You are packaging your team's data knowledge into a reusable, shareable, evolvable system. Next week, when someone asks a slightly different question, the subagent already knows the schema, the metrics, and the business rules. It does not start from zero.
+
+## What you just built
+
+In 15 minutes, you:
+
+- Installed a data engineering agent
+- Connected it to a real database
+- Asked natural-language questions and got correct SQL results
+- Browsed the context the agent automatically built from your schema and queries
+- Generated a semantic model that maps physical tables to business concepts
+- Created a scoped, shareable subagent for a specific domain
+- Shared it with a teammate—turning your data knowledge into a reusable system
+
+This is not only a demo workflow. It is the daily loop of a data engineer using Datus: explore, generate context, scope a domain, deliver a subagent, collect feedback, and improve the context. The first cycle is intentionally small; later cycles get faster because the context has been compounding the whole time.
+
+## What your daily workflow looks like
+
+Once you are past the tutorial, here is what a typical morning with Datus looks like—using a production warehouse instead of the California Schools dataset.
+
+### 9:00 AM: Start the session
+
+```bash
+datus-agent
+```
+
+The agent loads, connects to your configured databases (Snowflake for production, Postgres for staging, DuckDB for local analysis), and surfaces the accumulated context: schemas it has inspected, semantic models it has generated, and subagents it has deployed.
+
+### 9:05 AM: Review overnight changes
+
+```
+@catalog
+```
+
+The catalog tree shows schemas the agent has been tracking. A new table appeared in staging overnight—the product team added an `experiment_assignments` table for A/B test tracking. The agent discovered it during its scheduled schema refresh and flagged it for review.
+
+### 9:10 AM: Inspect the new table
+
+```
+@table experiment_assignments
+```
+
+The agent displays column types, row counts, sample values, and inferred semantics—`experiment_id` looks like a foreign key to `experiments`, `user_id` is a dimension, `variant` is a categorical column with three distinct values.
+
+### 9:15 AM: Generate a semantic model
+
+```
+/gen_semantic_model experiment_assignments
+```
+
+The agent produces a MetricFlow-compatible YAML model, defining dimensions, measures, and suggested joins. The engineer reviews, corrects one column type, and accepts.
+
+### 9:20 AM: Extract metrics from historical SQL
+
+```
+/gen_metrics --domain experiments
+```
+
+The agent scans accumulated historical SQL and surfaces candidate metrics: `experiment_assignment_count`, `unique_users_per_experiment`, `variant_distribution`. The engineer selects the relevant ones and promotes them to the context store.
+
+### 9:30 AM: Create a subagent
+
+```
+.subagent add
+```
+
+A subagent called "Product Experiments" is created—scoped to `experiments`, `experiment_assignments`, and `users`. The engineer adds a standing rule: "Experiment results are preliminary until `status = 'concluded'`." The subagent link goes to the product team on Slack.
+
+### 9:35 AM: Morning routine complete
+
+In one compact workflow: a new table discovered, a semantic model generated, metrics extracted from historical patterns, a scoped subagent delivered. The context generated this morning is available tomorrow—and the day after.
+
+### Key commands at a glance
+
+| Command | What it does | When you use it |
+|---|---|---|
+| `@catalog` | Browse the physical schema tree | Exploring new data, verifying schema changes |
+| `@subject` | Browse the logical subject tree | Navigating by business domain |
+| `@table <name>` | Inspect a table with types, samples, and inferred semantics | Triaging a data request |
+| `@metrics` | View generated and curated metrics | Validating definitions before sharing |
+| `@sql_history` | Search accumulated validated SQL | Finding proven query patterns to adapt |
+| `/gen_semantic_model` | Generate a MetricFlow-compatible model from schema | Bootstrapping context for a new data source |
+| `/gen_metrics` | Extract candidate metrics from historical SQL | Surfacing metrics the team already uses |
+| `.subagent add` | Create a scoped, shareable chatbot | Delivering self-service to a business team |
+| `.subagent list` | List deployed subagents | Managing your subagent portfolio |
+
+### CLI vs. GUI: when each makes sense
+
+The CLI is where engineers build and maintain the system. The chat interface is where analysts and business users consume it. A principled division:
+
+**CLI** for schema exploration, metric generation, context curation, subagent configuration, scripts, and automation. **GUI** (chat, dashboard, web) for analyst self-service, business user exploration, and collaborative metric review.
+
+The same context engine powers both. The CLI is your cockpit; the subagent chat is what you hand to the business.
+
+## Next steps
+
+- **Connect your real warehouse:** Run `datus-agent configure` and add your Snowflake, BigQuery, or Postgres credentials. The agent will inspect your actual schemas and begin building context from your real data environment.
+- **Bootstrap from historical SQL:** Run `datus-agent bootstrap-kb /path/to/sql/files` to seed the Context Engine with your team's existing query patterns. The agent will learn which tables, joins, and metrics your team actually uses—not just what the schema says.
+- **Set up feedback collection:** Share your subagent link with analysts and encourage them to upvote correct answers and report issues. Every feedback signal makes the context stronger.
+- **Read the deep dives:** [Contextual data engineering](/posts/contextual-data-engineering) for the theory behind the Context Engine, [best data engineering agents 2026](/posts/best-data-engineering-agents-2026) for the full landscape, and [open source data engineering agents](/posts/open-source-data-engineering-agents) for the case for self-hosting.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> for a zero-install version of everything in this tutorial—connect a warehouse, ask questions, and watch context build in your browser.
+
+## Frequently asked questions
+
+### Do I need to know SQL to use a data engineering agent?
+
+No. You need to know what question you want to answer. The agent translates your natural-language question into SQL, executes it, and returns results. That said, being able to read SQL helps you verify the agent's output and understand edge cases. Most teams have at least one SQL-literate person reviewing agent-generated queries before they go into production.
+
+### Is the built-in dataset enough to evaluate whether an agent will work for my team?
+
+The California Schools dataset is representative—it has multiple tables, joins, numeric measures, and categorical dimensions, similar to a real business database. It is enough to evaluate the agent's core capabilities: schema understanding, query generation, context accumulation, and subagent creation. To evaluate whether the agent works with your specific warehouse and data scale, you will need to connect it to a non-production copy of your actual database.
+
+### How does the agent handle corrections when it generates wrong SQL?
+
+When you receive an incorrect result in Datus Chat, you can file an issue report describing what was wrong. The correction flows back into the Context Engine: the agent notes which join path, filter condition, or metric definition produced the error, and it adjusts future queries to avoid the same mistake. Over time, the agent's accuracy improves—not because the underlying LLM changed, but because the context it operates on accumulated corrections. This is the feedback loop central to [contextual data engineering](/posts/contextual-data-engineering).
+
+### Can I run this on my company's data without sending anything to a third party?
+
+Yes. Datus is self-hosted (Apache 2.0). When you run `datus-agent` locally, all data—your queries, your schemas, the agent's context—stays on your machine. When you use Datus Studio (the browser version), your queries are sent to Datus's cloud for processing. For teams with strict data residency requirements, self-hosting the open-source version is the recommended path. See [open source data engineering agents](/posts/open-source-data-engineering-agents) for more on the self-hosting tradeoff.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and how agents differ from copilots
+- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model behind the agent you just built
+- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — why self-hosting matters for data infrastructure

--- a/blog/posts/context-engine-data-engineering-agent-accuracy.md
+++ b/blog/posts/context-engine-data-engineering-agent-accuracy.md
@@ -1,0 +1,157 @@
+---
+title: "How a Context Engine Makes Data Engineering Agents More Accurate"
+description: "How a context engine improves data engineering agent accuracy with schemas, validated SQL, and feedback loops."
+author: "John Smith"
+date: 2026-06-01
+lastmod: 2026-06-01
+head:
+  - - meta
+    - name: keywords
+      content: "context engine data engineering, data engineering agent accuracy, data engineering agent context, context engineering for data, how data agents improve accuracy"
+  - - meta
+    - property: og:title
+      content: "How a Context Engine Makes Data Engineering Agents More Accurate"
+  - - meta
+    - property: og:description
+      content: "How a context engine improves data engineering agent accuracy with schemas, validated SQL, and feedback loops."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/context-engine-data-engineering-agent-accuracy
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/context-engine-data-engineering-agent-accuracy
+---
+# How a Context Engine Makes Data Engineering Agents More Accurate
+
+Every [data engineering agent](/posts/what-is-data-engineering-agent-2026) uses an LLM to generate SQL. The LLM is not the differentiator. Any modern model—GPT-4o, Claude, Gemini, DeepSeek—can produce syntactically correct SQL against a well-described schema. The accuracy gap between agents is not about which model they use. It is about what context they give the model before asking it to generate a query.
+
+A context engine is the component that prepares, retrieves, and continuously updates that context. This article explains how it works, why it is the single largest lever for agent accuracy, and what separates a well-designed context engine from a thin wrapper around a model API. For the theoretical foundation, see [contextual data engineering](/posts/contextual-data-engineering).
+
+## TL;DR
+
+- A context engine has three jobs: **inspect** (discover schemas and patterns from real data), **retrieve** (find the right context at query time), and **update** (incorporate feedback into the context store).
+- The retrieval quality—not the LLM quality—is the ceiling on agent accuracy. A brilliant model with poor context retrieval will generate confidently wrong SQL.
+- What makes a context engine effective: dual-dimension organization (physical catalog + logical subject tree), feedback-driven updates, and reference SQL that grounds queries in proven patterns rather than generating from scratch.
+- In one production deployment (Yunqi Lakehouse), self-service analytics rates rose from 15% to 60%—not because the model improved, but because the context it operated on accumulated.
+
+## 1. The accuracy bottleneck is not the LLM
+
+A useful mental model: think of a data engineering agent as having two brains. The fast brain is the LLM—it generates SQL, plans multi-step tasks, and composes natural-language responses. The slow brain is the context engine—it builds and maintains the knowledge about your data that the fast brain queries before generating anything.
+
+Most discussion of agent accuracy focuses on the fast brain: which model, which prompt, which few-shot examples. This is a category error. The fast brain can only be as accurate as the context it receives. Give GPT-5.2 a brilliant prompt but incorrect information about which columns are deprecated, which join paths produce duplicates, and which metric definition the finance team uses—and it will produce brilliant, confidently wrong SQL.
+
+The accuracy ceiling is set by the context engine, not the LLM. This is why the agents that will define the category are the ones that invest in context infrastructure, not the ones that invest in prompt engineering.
+
+## 2. The three jobs of a context engine
+
+### Job 1: Inspect — discover what exists
+
+Before the agent can answer questions about your data, it needs to know what data you have. The context engine connects to your warehouse—or reads from your catalog—and builds an inventory: databases, schemas, tables, columns, types, primary keys, foreign keys, and any existing documentation or semantic annotations.
+
+This is the foundation every agent shares. Where they diverge is how deeply they inspect. A shallow inspection captures column names and types. A deep inspection captures:
+
+- **Data patterns:** Which columns are likely measures vs. dimensions based on data type and distribution (numeric, high-cardinality categorical, date fields)
+- **Join paths:** Which foreign key relationships exist, which are actually used in queries, and which produce duplicate rows
+- **Usage signals:** Which tables and columns are most frequently queried, which have been deprecated, which naming conventions imply relationships
+
+A deep inspection produces better context. Better context produces more accurate queries.
+
+### Job 2: Retrieve — find what matters at query time
+
+When a user asks "show me weekly net revenue by region for Q2," the agent needs to retrieve a specific subset of context:
+
+- Which tables contain revenue data (`fact_orders`, not `fact_sessions`)
+- Which column represents net revenue (`amount_usd`, not `revenue_usd`)
+- How revenue relates to region (join via `region_id` in `dim_geo`, not `geo_key` in `dim_customer`)
+- What "Q2" means in this warehouse's date dimensions (calendar quarter, `order_completed_at` timestamp)
+- Whether a test-account filter applies (yes, `account_type != 'test'` in the source, `is_internal = false` in the warehouse)
+
+The retrieval quality determines accuracy. Retrieve too little context, and the agent lacks the information to generate correct SQL. Retrieve too much, and the context overwhelms the LLM's context window—or dilutes the signal with irrelevant information.
+
+Effective retrieval requires both dimensions of organization. The physical catalog tree gives the agent a structured map of databases, schemas, and tables with their semantic annotations. The logical subject tree organizes knowledge by business domain—topics, metrics, and reference SQL grouped by what they mean, not where they live. A query about "revenue" retrieves context from the finance subject node, which pulls in the relevant tables from the catalog tree, the validated metric definitions, and the reference SQL that has proven correct. This dual-dimension retrieval is what separates a context engine from a simple schema dump.
+
+### Job 3: Update — learn from feedback
+
+The most important job—and the one most agents skip entirely.
+
+Every time a user confirms a query (upvote in chat, no issue reported), the context engine strengthens the pattern that produced it. Every time a user corrects a query (issue report, "this should have excluded test accounts"), the context engine updates the relevant rules, and the next query avoids the same mistake.
+
+This feedback loop is the engine of accuracy improvement. Without it, the agent's accuracy is static—it starts at its baseline and stays there, limited by whatever context was loaded at setup. With it, accuracy compounds. The hundredth query is more accurate than the first, not because the LLM changed, but because the context it operates on accumulated six months of corrections, validations, and usage patterns.
+
+An <a href="https://datus.ai/glossary">evaluation framework</a> that tracks exact SQL match, result count, schema usage, and semantic correctness provides the measurement layer—showing whether accuracy is actually improving and which types of queries need more attention.
+
+## 3. What a context engine is not
+
+To be precise about what makes a context engine different from adjacent concepts:
+
+- **It is not a data catalog.** A <a href="https://datus.ai/glossary">data catalog</a> inventories assets for human discovery. A context engine organizes context for machine retrieval at query time. The catalog tells a person where to look. The context engine tells an agent what to use.
+
+- **It is not a semantic layer.** A [semantic layer](/posts/what-is-semantic-layer) defines governed metrics and dimensions. A context engine includes semantic definitions but extends them with validated SQL, deprecation notes, feedback history, and business rules that move faster than governance cycles. The semantic layer is the certified foundation; the context engine is the living layer on top.
+
+- **It is not a vector database.** Some context engines use vector search for retrieval—finding semantically similar queries and schemas. But a context engine is more than its retrieval mechanism. It includes the inspection logic that builds context, the organizational model that structures it, the feedback loop that updates it, and the delivery mechanisms that package it for consumption.
+
+## 4. How a context engine improves accuracy in practice
+
+Here is a concrete example of how context accumulation changes query accuracy over time.
+
+**Week 1.** User asks: "Show me revenue by region." The context engine retrieves the schema for `fact_orders` and `dim_geo`, generates a query joining on `region_id`, and returns results. The user upvotes—correct. The context engine stores this query as validated reference SQL and strengthens the `region_id` join path association.
+
+**Week 2.** User asks: "Show me revenue by customer segment." The context engine retrieves the previous revenue query pattern, finds the `dim_customer` table, identifies `segment` as a dimension, and generates a query that correctly joins `fact_orders → dim_customer` on `customer_id` while preserving the validated region join from Week 1. Faster generation, higher accuracy—because the engine had a proven pattern to adapt rather than starting from scratch.
+
+**Week 3.** A new user asks: "Monthly net revenue for the board deck." The context engine retrieves the validated revenue pattern, but a different user—the finance team—has previously filed an issue report noting that "net revenue uses `amount_usd` minus refunds, with FX rates locked at close date." The engine applies this correction. The query returns finance-grade revenue numbers. The new user does not need to know that the finance team filed that correction three weeks ago. The context engine already knows.
+
+This is the compounding effect: validated SQL provides proven patterns to adapt. Corrections prevent repeated mistakes. Usage signals strengthen the patterns that work. Over time, the engine builds a representation of the warehouse that reflects not just what the schema says, but what the team has learned about the schema.
+
+## 5. Why this matters for evaluating agents
+
+When evaluating a data engineering agent, the accuracy of a single demo query tells you almost nothing. Any modern agent with any modern LLM can nail a well-scoped query against a clean schema. The demos are designed to work.
+
+The questions that predict long-term accuracy are:
+
+- **How does the agent build its initial context?** Does it only read column names, or does it analyze data patterns, identify join paths, and infer metric types?
+- **How does the agent retrieve context at query time?** Does it stuff the entire schema into the prompt (works for 10 tables, breaks for 1,000), or does it selectively retrieve the subset of context relevant to the query?
+- **Does the agent have a feedback loop?** When a user corrects a wrong answer, does the correction survive the session? Does the next query avoid the same mistake?
+- **Does the agent store validated SQL as reference patterns?** Or does it generate every query from scratch, missing the opportunity to adapt proven patterns?
+
+The answers to these questions determine whether the agent's accuracy plateaus at its demo-quality baseline or improves toward production reliability over weeks of real use. A stronger LLM paired with shallow context will still plateau on ambiguous warehouse-specific questions. A modest LLM paired with a deep context engine can outperform it on repeated domain patterns because it has better local facts.
+
+For a practical comparison of how different agents handle these questions, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+
+## Conclusion
+
+A context engine is the slow brain of a data engineering agent: the component that inspects your data, retrieves relevant context at query time, and updates that context based on feedback. Its quality—not the LLM's quality—sets the ceiling on agent accuracy.
+
+The agents that will define this category are the ones that invest in context infrastructure: deep schema inspection, dual-dimension context organization, feedback-driven updates, and reference SQL pattern storage. Agents that treat the LLM as the whole product can produce brilliant demos and still plateau. Agents that treat context as the product have a clearer path to improving on repeated production workloads.
+
+This is the practical implication of [contextual data engineering](/posts/contextual-data-engineering): accuracy is not a feature of the model. It is a property of the context.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see a context engine in action—ask ten questions against a connected warehouse and watch how the answers improve.
+
+## Frequently asked questions
+
+### Does a better LLM eliminate the need for a context engine?
+
+No. A better LLM generates more syntactically elegant SQL. It does not know which of three join paths is the authoritative one for your warehouse, which metric definition finance uses, or which columns were deprecated last month. Those are facts about your data, not facts about SQL. A context engine provides those facts. Even the best LLM, without them, will produce confidently wrong answers when the data context is ambiguous. Think of the LLM as the engine and the context engine as the navigation system—a more powerful engine does not help if you are driving in the wrong direction.
+
+### How long does a context engine take to build useful context?
+
+The initial bootstrap—inspecting schemas, inferring metric types, indexing existing SQL—takes minutes to hours depending on warehouse size. The feedback-driven accuracy improvement compounds over weeks: early queries are 60-80% accurate for common patterns, rising to 85-95% after a month of active use with corrections. The key variable is not time—it is volume of feedback. A team that actively uses the agent and corrects wrong answers will see faster improvement than a team that runs occasional queries without providing feedback.
+
+### Can I use my existing dbt project or semantic layer as the context engine?
+
+Partially. A well-maintained dbt project or semantic layer provides excellent schema and metric context (Layer 2 in the three-layer model). What it typically lacks is Layer 3: validated ad-hoc SQL, deprecation notes, usage-based corrections, and a feedback loop that updates context between governance cycles. A context engine can ingest and reinforce existing semantic definitions while adding the institutional memory layer. The two are complementary: the semantic layer is the governed foundation; the context engine is the living layer that captures what the team learns between modeling sprints.
+
+## Related articles
+
+- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer model behind context engines
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [What is a semantic layer?](/posts/what-is-semantic-layer) — definitions, implementations, and the gap agents fill

--- a/blog/posts/contextual-data-engineering.md
+++ b/blog/posts/contextual-data-engineering.md
@@ -1,0 +1,214 @@
+---
+title: "Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context"
+description: "Contextual data engineering explained: schemas, semantics, and feedback loops for durable data agents."
+author: "John Smith"
+date: 2026-06-01
+lastmod: 2026-06-01
+head:
+  - - meta
+    - name: keywords
+      content: "contextual data engineering, context engineering data, evolvable context for data, data context system, data engineering agent context"
+  - - meta
+    - property: og:title
+      content: "Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context"
+  - - meta
+    - property: og:description
+      content: "Contextual data engineering explained: schemas, semantics, and feedback loops for durable data agents."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/contextual-data-engineering
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/contextual-data-engineering
+---
+# Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context
+
+The largest cost in data engineering is not writing SQL. It is re-learning the same tables, the same metrics, the same business rules, over and over, every time a new question arrives. A data engineer joins a team and spends weeks absorbing context that exists only in people's heads. An analyst files a ticket, waits three days, and receives a query that the engineer wrote last quarter for someone else and cannot find. A new hire asks "what does 'revenue' mean here?" and gets three different answers from three different people.
+
+This is not a tooling problem. It is a context problem. And it is the problem that **contextual data engineering** is designed to solve.
+
+If you have read [what a data engineering agent is](/posts/what-is-data-engineering-agent-2026), you already know the rough shape of what follows. That article argued that the deepest split between today's data engineering agents is how they handle context. This article gives the idea its own name and its own definition.
+
+## TL;DR
+
+- **Contextual data engineering** treats data context—schemas, metrics, validated SQL, business rules, and feedback—as a **first-class, evolvable asset**, not a one-time modeling exercise.
+- It sits beneath a <a href="https://datus.ai/glossary">data engineering agent</a> the way an operating system sits beneath an application: the agent runs on top of it, and every run makes the context stronger.
+- Traditional data engineering models context once and consumes it statically. Contextual data engineering runs a **feedback loop**: agent operates → users correct or confirm → context evolves → next run is more accurate.
+- Context operates in three layers: **schema metadata** (what exists), **business semantics** (what it means), and **institutional memory** (what we learned the hard way). Most tools stop at layer one.
+
+## 1. The problem: context is the bottleneck, not compute
+
+Consider a realistic scenario. A data engineer at a mid-stage company receives this Slack message:
+
+> "Hey, can you pull weekly net revenue by region for Q2? Exclude test accounts. And use the same definition the finance team uses for their board deck."
+
+This is a five-minute task if the engineer already knows:
+- Which table holds revenue transactions (`fact_orders` or `fact_revenue_v2`? One was deprecated in March.)
+- How "net revenue" is defined by finance (gross minus refunds minus chargebacks, in USD, at the FX rate locked on the close date—not the transaction date.)
+- Which column identifies test accounts (`account_type = 'test'` or `is_test_account = true`? Depends on the source system.)
+- Which join path is authoritative for region mapping (three possible foreign keys, one is correct, the other two produce silently wrong duplicates.)
+
+Without that context, the same task takes hours: reading table schemas, tracing join keys, digging through old SQL, pinging three people on Slack, and writing test queries to verify assumptions. The engineer spends four hours to produce one query. And next week, someone asks a slightly different question about the same table, and the cycle repeats.
+
+This is the central observation of contextual data engineering: **the bottleneck is not query execution speed, and it is not even LLM intelligence. It is the availability of reliable, reusable, evolvable context at the moment a question is asked.**
+
+## 2. A working definition
+
+**Contextual data engineering** is the practice of treating data context as a first-class engineering artifact—one that is continuously generated, validated, updated, and consumed by agents and humans—rather than as a one-time documentation exercise that goes stale the week after it is written.
+
+Four properties distinguish it from traditional approaches:
+
+1. **Context is alive.** It is not a static document or a YAML file committed once. It is generated from real usage (historical SQL, user feedback, schema inspection), updated continuously, and versioned so teams can trace how definitions evolved.
+2. **Context is multi-layered.** It covers schema metadata (physical tables and columns), business semantics (metrics, dimensions, join rules), and institutional memory (validated SQL, deprecation notes, feedback history). Most tools stop at layer one.
+3. **Context is consumed by agents, not only by humans.** A data catalog helps a person find a table. A context engine helps an agent generate a correct query—grounded in schema, metrics, reference SQL, and business rules—without a human translating every column name.
+4. **Context compounds.** Every successful agent run becomes training data for the next one. Every correction flows back into the system. Over weeks, the agent stops being a clever stranger and starts being a junior engineer who has actually worked on your codebase.
+
+In short: contextual data engineering is what turns a data engineering agent from a chat window into a system that accumulates institutional knowledge.
+
+## 3. Three layers of context, and why most tools stop at one
+
+The most useful way to think about context is as a stack of three layers. Each layer depends on the one below it, and most tools in the modern data stack address only the first.
+
+### Layer 1: Schema metadata — "what tables and columns exist"
+
+This is the foundation. A <a href="https://datus.ai/glossary">data catalog</a> crawls your warehouse and builds an inventory: databases, schemas, tables, columns, types, primary keys, foreign keys. Tools like DataHub, Atlan, and Select Star do this well. Platform-embedded agents like Google's BigQuery Data Engineering Agent lean heavily on this layer, using the platform's own Knowledge Catalog to ground queries.
+
+Schema metadata tells an agent that `fact_orders` has a column called `amount_usd` of type `DECIMAL(18,2)`. It does not tell the agent that `amount_usd` means net revenue after refunds, at locked FX rates, excluding test accounts—and that another column called `revenue_usd` in the same table means gross revenue before any adjustments.
+
+### Layer 2: Business semantics — "what the data means"
+
+This is the layer where a <a href="https://datus.ai/glossary">semantic layer</a> lives: metrics, dimensions, entities, join rules, and business logic. Tools like MetricFlow (dbt), Cube, and LookML operate here. A well-built semantic layer tells an agent that "net revenue" is `sum(amount_usd)` from `fact_orders` filtered by `order_status != 'cancelled'`, joinable to `dim_region` via `region_id`, sliceable by `region_name` and `fiscal_quarter`.
+
+Most organizations stop here and consider the job done. The semantic layer is modeled, reviewed in a PR, deployed, and consumed by BI tools. It is static, governed, and correct—at the moment it was written.
+
+### Layer 3: Institutional memory — "what we learned the hard way"
+
+This is the layer that contextual data engineering adds. It captures information that never makes it into a formal semantic model but is essential for correct answers:
+
+- **Validated SQL** that has been tested in production and proven correct—not every useful query becomes a formal metric, but every successful query is evidence of how to use the data correctly.
+- **Deprecation notes** ("don't use `status` before March 2026; use `status_v2`") that live in Slack threads and engineering brains, not in any system.
+- **Feedback history**—which past agent outputs were upvoted, which were corrected, and why. This is training data for accuracy.
+- **Business rules** that are "obvious" to the team but invisible to an agent: test accounts are filtered by `account_type != 'test'` in the source system but by `is_internal = false` in the warehouse; revenue for the board deck uses locked FX rates while operational reports use spot rates.
+
+Layer 3 is where contextual data engineering earns its name. Without it, even a perfect semantic layer produces wrong answers when the question touches institutional knowledge that was never formalized. With it, the agent learns what the team knows—including the things nobody remembered to write down.
+
+> A schema tells an agent what exists. A semantic layer tells an agent what it means. Institutional memory tells an agent what to trust—and what to avoid.
+
+## 4. The feedback loop: how context evolves
+
+Traditional data engineering follows a linear model: model the data → build pipelines → write documentation → consume. Context is a snapshot. It ages from the moment it is created.
+
+Contextual data engineering replaces the linear model with a feedback loop:
+
+```
+Agent operates (generates SQL, answers a question)
+  → User confirms (upvote) or corrects (issue report)
+    → Feedback flows back into the context store
+      → Context is updated (validated SQL added, rule refined, deprecation noted)
+        → Next run is more accurate
+          → Repeat
+```
+
+Each cycle makes the context marginally stronger. Over weeks of usage, the agent accumulates:
+
+- A growing library of validated SQL patterns it can adapt instead of generating from scratch.
+- A set of business rules it will never violate because past violations were corrected.
+- An understanding of which tables, columns, and join paths are trusted by the team, based on actual usage rather than documentation claims.
+
+This is not a theoretical model. In Datus's Lakehouse deployment narrative, the feedback loop is the mechanism credited with improving self-service usage and reducing repeated ad-hoc query work. Treat the reported business outcomes as case-specific evidence, not a universal promise: the agent did not get smarter because the LLM improved; it got smarter because the context it operated on improved.
+
+## 5. Why this matters specifically for data engineering agents
+
+General-purpose coding agents treat every task as a fresh problem. They are brilliant at writing one-off scripts. They are not designed to accumulate domain knowledge about a specific warehouse across months of usage.
+
+Data engineering is different from general-purpose coding in ways that make context accumulation essential:
+
+| General coding task | Data engineering task |
+|---|---|
+| Write a function to sort a list | Query weekly revenue by region |
+| Correctness is objective (does it pass tests?) | Correctness is contextual (which definition of revenue? which FX rate? which test account filter?) |
+| Context is the codebase (files, imports, types) | Context is invisible (business definitions, institutional rules, historical SQL patterns) |
+| One correct answer | Multiple "correct" answers depending on which team is asking |
+
+A general coding agent can write syntactically perfect SQL. It cannot know that `fact_orders.amount_usd` is the column the finance team trusts and `fact_revenue_v2.revenue_usd` is the one operations uses—unless someone has already captured that distinction in a context layer it can retrieve.
+
+This is the practical argument for contextual data engineering: **without it, every data engineering agent is a first-day hire.** The agent may be brilliant, but it has no institutional knowledge. And data engineering is a discipline where institutional knowledge is the difference between a correct answer and a confidently wrong one.
+
+## 6. Contextual data engineering vs. documentation, catalogs, and semantic layers
+
+It is worth being precise about what contextual data engineering is not, because the term sits close to several established ideas.
+
+**It is not documentation.** Documentation is human-authored, human-consumed, and static. It tells a person what a table means. It does not tell an agent, at query time, which of three possible join paths is the authoritative one for region mapping. And it goes stale the week after it is written. Contextual data engineering produces machine-readable, queryable, continuously updated context—documentation is a byproduct, not the product.
+
+**It is not a data catalog.** A catalog inventories assets. It answers "what tables exist?" Contextual data engineering answers "how do I use this table correctly, right now, given everything the team has learned about it?" Catalogs are the foundation (Layer 1). Contextual data engineering builds on top of them.
+
+**It is not a semantic layer—but it reinforces one.** A semantic layer defines governed metrics, dimensions, and joins. It is essential infrastructure. But it is static at runtime: defined in Git, deployed on a schedule, consumed by BI tools. Contextual data engineering adds a fast feedback buffer on top: validated ad-hoc SQL, deprecation notes, usage patterns, and corrections that have not yet been promoted to the formal semantic layer. The two are complementary: the semantic layer provides the governed foundation; the context layer captures the institutional knowledge that moves faster than governance cycles.
+
+For more on this relationship, see [what is a semantic layer](/posts/what-is-semantic-layer).
+
+## 7. What a contextual data engineering system looks like in practice
+
+A concrete system that implements contextual data engineering typically includes these components:
+
+**A context engine** that organizes information along two dimensions: a physical catalog tree (databases → schemas → tables, annotated with semantic models) and a logical subject tree (business domains → topics → metrics, carrying reference SQL and external knowledge). Commands like `/gen_semantic_model` and `/gen_metrics` bootstrap context from existing schemas and historical SQL; user feedback refines it over time.
+
+**A feedback mechanism** that captures signals from actual usage. Every upvote strengthens the pattern. Every correction updates the rules. Every issue report flags something to fix. This is not a separate reporting dashboard—it is built into the agent's normal operation so feedback is captured at the moment it occurs, not in a retrospective meeting.
+
+**Delivery units**—scoped chatbots called subagents—that package a subset of context (roughly 10 tables, 20 metrics, 30 validated SQL references) for a specific domain. A finance subagent knows finance's definition of revenue. An operations subagent knows operations' definition. Both draw from the same context engine but are constrained to the scope their users need.
+
+**Versioning and auditability** so teams can trace how context evolved, who changed what, and why. If a metric definition changes in week 12, a team can see what queries were generated against the old definition and whether they need to be re-run.
+
+This architecture is not hypothetical. It is the design behind the open-source <a href="https://github.com/Datus-ai/Datus-agent" rel="nofollow noopener">Datus agent</a>—an Apache 2.0 licensed data engineering agent built around a persistent Context Engine that treats every successful run as training data for the next one.
+
+## 8. The competitive dimension: why this is the differentiator
+
+The data engineering agent space in 2026 is splitting along exactly this line. Platform-embedded agents (Google BigQuery DEA, Adobe DEA) lean on their host platform's catalog for Layer 1 context and some Layer 2 semantics, but they are bound to a single environment. Prompt-based agents (Claude Code subagents, Cursor) have no persistent context at all—every session starts from zero.
+
+Between those poles, the agents that will define the category are the ones that own their context layer. They are the ones that can answer not just "what query should I write?" but "given everything this team has learned about this warehouse over the past six months, what is the right query to write?"
+
+This is also why the term "contextual data engineering" matters. It gives a name to the thing that separates a data engineering agent from a chat window. Without the name, the distinction is invisible to buyers who see "data engineering agent" on four different product pages and assume they are the same thing. With the name, the conversation changes: "Does your agent do contextual data engineering—or does it start from zero every time?"
+
+## Conclusion
+
+Contextual data engineering addresses the real bottleneck in data work: not compute speed, not LLM quality, but the availability of reliable, reusable, evolvable context at the moment a question is asked. It treats context as a first-class engineering artifact with three layers—schema metadata, business semantics, and institutional memory—and it runs a feedback loop that makes every agent interaction strengthen the context for the next one.
+
+For teams evaluating data engineering agents, the most useful question is not "which agent writes the best SQL?" It is "where does the agent's context live, how does it evolve, and does it outlast a single session?" The answer determines whether you are buying a feature or building an asset.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a>—connect a warehouse, ask a question, and watch the Context Engine build context that compounds.
+
+## Frequently asked questions
+
+### What is contextual data engineering, in one sentence?
+
+**Contextual data engineering** is the practice of treating data context—schemas, metrics, validated SQL, business rules, and feedback—as a first-class, evolvable asset rather than a one-time documentation exercise, so that data engineering agents and teams accumulate institutional knowledge instead of rediscovering it on every query.
+
+### How is contextual data engineering different from building a semantic layer?
+
+A **semantic layer** defines governed metrics, dimensions, and join rules—it is the foundation (Layer 2 in the three-layer model). **Contextual data engineering** adds Layer 3: institutional memory—validated ad-hoc SQL, deprecation notes, feedback history, and business rules that move faster than governance cycles. The two are complementary: the semantic layer provides the governed baseline; contextual data engineering captures the knowledge that accrues between governance cycles and feeds it back into the system.
+
+### Do I need contextual data engineering if I already have a data catalog?
+
+A **data catalog** tells you what tables and columns exist (Layer 1). It does not tell an agent which join path is authoritative, which column was deprecated last month, or which SQL patterns the team has validated in production. Contextual data engineering builds on top of the catalog—it consumes catalog metadata and adds the layers that turn discovery into correct execution.
+
+### What does a team need to start practicing contextual data engineering?
+
+Three things: a system that can inspect and store schema context (a context engine), a feedback mechanism that captures corrections and validations from actual usage, and a commitment to treating context as a living asset rather than a documentation deliverable. The first two are tooling; the third is cultural. The cultural piece is the harder one—it requires the team to believe that capturing context during normal work is worth the small upfront cost, because it compounds into dramatically faster work later.
+
+### Does this replace my existing data documentation?
+
+No—it makes your documentation more accurate over time. Traditional documentation is a snapshot that ages. Contextual data engineering captures what the team actually does (validated SQL, corrections, usage patterns) and surfaces it as living documentation. The docs become a reflection of reality rather than a record of what was true when someone last had time to update a wiki page.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition this article builds on
+- [What is a semantic layer?](/posts/what-is-semantic-layer) — the governed semantics that contextual systems extend
+- [How a Context Engine improves accuracy](/posts/context-engine-data-engineering-agent-accuracy) — the architecture behind context retrieval and feedback

--- a/blog/posts/data-engineering-agent-vs-claude-code.md
+++ b/blog/posts/data-engineering-agent-vs-claude-code.md
@@ -1,0 +1,149 @@
+---
+title: "Data Engineering Agent vs. Claude Code: When to Use Which"
+description: "Data engineering agent vs Claude Code: when persistent data context matters and when a coding agent is enough."
+author: "John Smith"
+date: 2026-06-03
+lastmod: 2026-06-03
+head:
+  - - meta
+    - name: keywords
+      content: "data engineering agent vs Claude Code, Claude Code for data engineering, Claude Code data engineer, data engineering agent vs coding agent, Claude Code vs Datus"
+  - - meta
+    - property: og:title
+      content: "Data Engineering Agent vs. Claude Code: When to Use Which"
+  - - meta
+    - property: og:description
+      content: "Data engineering agent vs Claude Code: when persistent data context matters and when a coding agent is enough."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/data-engineering-agent-vs-claude-code
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/data-engineering-agent-vs-claude-code
+---
+# Data Engineering Agent vs. Claude Code: When to Use Which
+
+Claude Code is one of the best general-purpose coding agents available. It can write Python, debug infrastructure code, refactor APIs, and—with the right prompt—act as a capable data engineer for an afternoon. It is also, by design, not a data engineering agent.
+
+This distinction is not a dig at Claude Code. It is an acknowledgment that data engineering has requirements that general-purpose coding agents were not built to handle: persistent schema knowledge across sessions, validated SQL patterns that compound in accuracy, business metric definitions that survive beyond a single conversation, and delivery mechanisms that turn context into something a non-engineer can use.
+
+This article explains the real differences, the scenarios where each tool wins, and the pattern that turns them from competitors into complements. For a broader comparison of available agents, see the [best data engineering agents in 2026](/posts/best-data-engineering-agents-2026).
+
+## TL;DR
+
+- **Claude Code** is a general-purpose coding agent that can do data engineering tasks brilliantly in a single session. It does not carry data context between sessions.
+- A **data engineering agent** (Datus, Wren AI, Altimate) is purpose-built for data work with a persistent context store that grows more accurate with use.
+- The right question is not "which is better?" but **"does this task need persistent data context?"** If yes, use a DE agent. If no, Claude Code is faster to start.
+- The complementary pattern: a DE agent builds and maintains data context, and exposes it to Claude Code through MCP—Claude Code becomes the general-purpose interface to the specialized data context.
+
+## 1. The fundamental difference: context persistence
+
+Claude Code is stateless across sessions. It will write you an excellent SQL query against your warehouse right now. It will do it again tomorrow. And the day after. Each time, it starts from the same state: your prompt, the files in your directory, and whatever you tell it about your database.
+
+This is not a flaw. It is the right design for a general-purpose coding agent. Most coding tasks are self-contained: write a function, fix a bug, refactor a module. The context is in the codebase—files, imports, types, tests. What you need is in the repository.
+
+Data engineering tasks are different. The most important context is not in the repository. It is in the warehouse—and specifically, in the institutional knowledge about the warehouse that lives in engineers' heads:
+
+- "Use `fact_orders.amount_usd` for finance reports, not `fact_revenue_v2.revenue_usd`"
+- "Join to `dim_region` through `region_id`, not `geo_key`—the second path produces duplicates"
+- "Filter out `account_type = 'test'` on all revenue queries"
+- "The `status` column was deprecated in March; use `status_v2`"
+
+A human engineer learns these rules over weeks and applies them unconsciously. A [data engineering agent](/posts/what-is-data-engineering-agent-2026) with a persistent context engine learns them the same way—not in a single prompt, but across sessions, as it sees which queries were upvoted, which were corrected, and which patterns repeat. Claude Code cannot do this because it does not have anywhere to put that knowledge between sessions.
+
+## 2. When Claude Code is the right tool
+
+Claude Code wins in scenarios where the data task is bounded, exploratory, or code-adjacent:
+
+**One-off exploratory queries.** You need to understand a new table, prototype a complex join, or test a hypothesis. The task will take 20 minutes and you will never ask the same question again. Setting up a persistent agent for this is overkill; Claude Code in a terminal with database access is perfect.
+
+**Data-adjacent coding.** You are writing a Python ETL script, a dbt model, or an Airflow DAG. The primary task is coding—the data context is secondary (you already know the schema). Claude Code's code-generation strengths apply directly.
+
+**You do not have permission to install new infrastructure.** Many data engineers work in environments where installing a new agent requires a security review. Claude Code is already approved. For a quick task, using what you have is faster than requesting what you do not.
+
+**The task is about code quality, not data correctness.** You need a SQL query refactored for readability, a pipeline optimized for performance, or a test suite written. The correctness of the data logic is not in question—the code structure is. Claude Code is built for this.
+
+In all of these cases, the data context is either already in your head or not required for the task. Claude Code is the faster, simpler tool.
+
+## 3. When a data engineering agent is the right tool
+
+A dedicated data engineering agent wins when the task requires context that outlives a single session:
+
+**Repeated queries against the same warehouse.** If you or your team will ask variations of similar questions for months—weekly revenue by region, customer churn by cohort, campaign performance by channel—the agent that remembers the correct join paths, metric definitions, and business rules from last week will produce more accurate results than the one starting fresh.
+
+**You are building a system, not answering a question.** The deliverable is not a query result. It is a reusable, shareable system—a subagent that a business analyst can query without knowing SQL, or an API that a dashboard can call. A data engineering agent packages context into delivery units. Claude Code can generate the code for an API; it cannot maintain the context that makes the API's answers correct over time.
+
+**The team is larger than one person.** When multiple people query the same data, persistent shared context becomes essential—not optional. Without it, two analysts querying "revenue" get two different numbers because they are using two different definitions, two different join paths, and two different filter conditions. A data engineering agent provides a single source of context truth that every query is grounded in.
+
+**Accuracy improvement over time matters.** If the first query is expected to be merely plausible and the hundredth query should be grounded in corrected team patterns, you need a feedback loop. Claude Code starts every session at the same baseline accuracy. A [contextual data engineering](/posts/contextual-data-engineering) agent improves baseline accuracy every time a user confirms or corrects a result.
+
+## 4. The complementary pattern: DE agent as the context layer for Claude Code
+
+The most productive pattern is not to choose one over the other. It is to use both—each for what it does best.
+
+A data engineering agent maintains the persistent data context: schemas, metrics, validated SQL, business rules, feedback history. It packages that context into queryable, evolvable assets. Claude Code is the general-purpose interface that can access that context when doing data-adjacent coding work.
+
+The mechanism is MCP (Model Context Protocol). A data engineering agent exposes its context tools—schema search, metric lookup, validated SQL retrieval—as MCP tools. Claude Code, as an MCP client, can call those tools when working on a data task. The result: Claude Code writes the Python ETL script, and the DE agent provides the context that makes the script correct—the right tables, the right join paths, the right metric definitions.
+
+This is not a theoretical architecture. Datus supports MCP Server export, allowing Claude Code (and other MCP-compatible agents) to query Datus's Context Engine directly. For more on how MCP connects data tools, see <a href="/posts/mcp-data-engineering">MCP and data engineering</a>.
+
+> Claude Code writes the code. The data engineering agent provides the context that makes the code correct.
+
+## 5. A practical decision framework
+
+| Your scenario | Best tool | Why |
+|---|---|---|
+| One-off SQL query against a known schema | Claude Code | Fastest setup; context is in your head |
+| Exploratory data analysis on a new dataset | Claude Code | Flexible; no persistent context needed yet |
+| Writing a dbt model or ETL script | Claude Code | Code generation is the primary task |
+| Repeated weekly reporting queries | DE agent | Context persistence prevents repeated errors |
+| Building a self-service analytics chatbot for analysts | DE agent | Subagents package context for non-engineers |
+| Multi-person team sharing data context | DE agent | Shared, versioned context prevents metric drift |
+| Accuracy must improve over time | DE agent | Feedback loop compounds accuracy |
+| Both coding and data work in the same workflow | DE agent + Claude Code via MCP | Best of both: code generation + persistent context |
+
+## 6. The honest answer
+
+Claude Code and data engineering agents are not competitors. They operate at different layers of the stack.
+
+Claude Code is one of the strongest general-purpose coding agents available, and it handles data tasks well within the bounds of a single session. If your data work is session-bounded, exploratory, or code-heavy, Claude Code is the right tool—faster to start, familiar, and deeply capable.
+
+A data engineering agent is infrastructure. It is for teams that query the same warehouse repeatedly, that need their metrics to mean one thing across people and tools, and that want their agent to get more accurate over time rather than resetting to baseline every morning. If your data work is durable, repeated, and team-scale, a data engineering agent is the right investment.
+
+The two tools work best together—the DE agent as the persistent context layer, Claude Code as the general-purpose agent that consumes that context. This is not a battle between tools. It is an architecture.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see what a persistent context engine looks like, or <a href="https://github.com/Datus-ai/Datus-agent" rel="nofollow noopener">install Datus CLI</a> to connect your warehouse and start building context that survives beyond a single session.
+
+## Frequently asked questions
+
+### Can Claude Code replace a data engineering agent?
+
+For session-bounded, one-off data tasks—yes. Claude Code can write excellent SQL, connect to databases via MCP, and handle exploratory analysis. For repeated, team-scale data work that requires persistent context and improves with feedback—no. Claude Code does not maintain data context between sessions, and it has no mechanism for accumulating institutional knowledge about a specific warehouse.
+
+### Does using a data engineering agent mean I cannot use Claude Code?
+
+No. The two complement each other. Use the DE agent for persistent context—defining metrics, validating SQL, building subagents. Use Claude Code for code-heavy data tasks—writing dbt models, ETL scripts, Airflow DAGs. And connect them via MCP so Claude Code can query the DE agent's context when it needs to understand your data.
+
+### What is the MCP connection pattern between a DE agent and Claude Code?
+
+The DE agent (as an MCP Server) exposes tools like schema search, metric lookup, and validated SQL retrieval. Claude Code (as an MCP Client) calls those tools when it needs data context during a coding task. For example: Claude Code is writing a dbt model and needs to know the correct join path between `orders` and `customers`. It calls the DE agent's context search tool, retrieves the validated join definition, and uses it in the generated code. The context is maintained in one place (the DE agent) and consumed everywhere (Claude Code, dashboards, APIs).
+
+### Which should I start with if I am evaluating both?
+
+Start with the tool that matches your primary workflow. If you spend most of your time writing code (ETL, dbt, Airflow) and occasionally need to query data, start with Claude Code. If you spend most of your time building data context (schemas, metrics, reference SQL) and delivering it to others (analysts, dashboards, agents), start with a data engineering agent. Both are free to try—Datus is Apache 2.0 and installs with pip; Claude Code is available with a Claude subscription.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — why context persistence is the core differentiator
+- [Best data engineering agents in 2026](/posts/best-data-engineering-agents-2026) — full landscape comparison
+                                                                   

--- a/blog/posts/data-engineering-agent-vs-sql-copilot.md
+++ b/blog/posts/data-engineering-agent-vs-sql-copilot.md
@@ -1,0 +1,143 @@
+---
+title: "Data Engineering Agent vs. SQL Copilot: What's the Real Difference?"
+description: "Data engineering agent vs SQL copilot: persistence, feedback, team context, and when each tool fits."
+author: "John Smith"
+date: 2026-06-04
+lastmod: 2026-06-04
+head:
+  - - meta
+    - name: keywords
+      content: "data engineering agent vs SQL copilot, data engineering agent vs text-to-SQL, SQL copilot vs data agent, agent vs copilot data engineering, NL2SQL agent vs copilot"
+  - - meta
+    - property: og:title
+      content: "Data Engineering Agent vs. SQL Copilot: What's the Real Difference?"
+  - - meta
+    - property: og:description
+      content: "Data engineering agent vs SQL copilot: persistence, feedback, team context, and when each tool fits."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/data-engineering-agent-vs-sql-copilot
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/data-engineering-agent-vs-sql-copilot
+---
+# Data Engineering Agent vs. SQL Copilot: What's the Real Difference?
+
+Every SQL copilot and every data engineering agent will generate a query from a natural-language question. On a demo video, they look identical: type a question, get a result. The difference is invisible until the second question—and the tenth, and the hundredth.
+
+A SQL copilot is a clever stranger. It can write a brilliant query on first meeting. But it forgets you the moment the session ends. A <a href="https://datus.ai/glossary">data engineering agent</a> is a coworker. It gets better at your data the longer it works with you.
+
+This article explains what that difference actually means in practice—and why it matters for any team running more than a few queries a week. If you are new to the category, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+
+## TL;DR
+
+- **SQL copilots** (GitHub Copilot for SQL, text-to-SQL tools, IDE assistants) generate queries in response to prompts and stop there. No memory, no feedback loop, no accumulation.
+- **Data engineering agents** generate queries, execute them, capture feedback, and accumulate reusable context—schemas, metrics, validated SQL, business rules—across sessions.
+- The distinction is not about intelligence. It is about **architecture**: one has a context store that grows; the other does not.
+- For individual ad-hoc queries, a copilot is fine. For team-scale, repeated data work, an agent that accumulates context is the difference between a tool and an asset.
+
+## 1. What a SQL copilot does well
+
+SQL copilots are excellent at what they are designed for: generating a query from a prompt in a single session. Given a schema and a question, they produce syntactically correct SQL quickly. They reduce the friction of writing boilerplate joins and remembering exact column names. For a data engineer who already knows their warehouse and just wants to type faster, they are genuinely useful.
+
+The best of them—GitHub Copilot's SQL completions, the text-to-SQL features in Hex and Deepnote, dedicated tools like AskYourDatabase—have made SQL generation a commodity. In 2026, getting a machine to turn "show me monthly revenue by region" into `SELECT region, SUM(revenue) FROM fact_orders GROUP BY region` is a solved problem for any reasonable schema.
+
+The problem is that "generate syntactically correct SQL" is not the hard part of data engineering.
+
+## 2. What a SQL copilot cannot do
+
+The hard part of data engineering is not writing SQL. It is knowing which SQL to write. Consider a realistic prompt:
+
+> "Show me weekly net revenue by region for Q2, excluding test accounts, using finance's definition."
+
+A SQL copilot can write a `SELECT` statement with `GROUP BY` and `WHERE` clauses. It cannot know:
+
+- That "net revenue" means `amount_usd` from `fact_orders` minus refunds—not `revenue_usd` from `fact_revenue_v2`, which is gross revenue before adjustments.
+- That "region" joins through `region_id` from the `dim_geo` table—not `geo_key` from `dim_customer`, which produces duplicates for multi-location accounts.
+- That "test accounts" are identified by `account_type = 'test'` in the source system but by `is_internal = true` in the warehouse—and the two do not always agree.
+- That "finance's definition" uses FX rates locked at the close date, not the transaction date—a distinction that no schema or prompt can convey.
+
+A human data engineer learns these rules over weeks and applies them unconsciously. A SQL copilot has no mechanism to learn them at all. It treats every query as a fresh problem, because it has nowhere to store what it learned from the last one.
+
+This is the architectural gap: **a copilot generates. An agent generates, captures feedback, and accumulates context.** The first query from both might be similar. The hundredth query from an agent with a [persistent context engine](/posts/contextual-data-engineering) will be materially more accurate than the hundredth query from a copilot—not because the underlying model improved, but because the context it operates on accumulated.
+
+## 3. The three things a data engineering agent has that a SQL copilot lacks
+
+### A context store that survives sessions
+
+A data engineering agent maintains a persistent context store: schemas it has inspected, metrics it has defined, SQL it has validated, business rules it has learned from corrections, and feedback history it has accumulated. When a new question arrives, the agent retrieves relevant context before generating SQL—so the first attempt is already grounded in what the team knows about the data.
+
+A copilot has no such store. Every question is a first attempt.
+
+### A feedback loop that improves accuracy over time
+
+When an analyst using a data engineering agent's chat interface upvotes a correct answer, the agent strengthens the pattern that produced it. When they report an issue—"this query is missing test account filters"—the correction flows back into the context store, and the agent will not make the same mistake on the next query. Over weeks, the baseline accuracy rises. This is contextual data engineering in practice: context is not static documentation; it is a growing, evolving asset that every interaction strengthens.
+
+A copilot has no feedback loop. Upvotes, corrections, and usage patterns are lost at the end of the session.
+
+### Delivery units that turn context into something shareable
+
+A data engineering agent can package a scoped subset of context—roughly 10 tables, 20 metrics, 30 validated SQL patterns—into a subagent: a domain-specific chatbot that an analyst or business user can query without knowing SQL. The subagent inherits the context's accuracy and is scoped so it cannot access tables outside its domain. A finance subagent knows finance's definition of revenue. An operations subagent knows operations' definition. Both draw from the same context engine.
+
+A copilot generates SQL for one person. An agent packages context for a team. For a comparison of how different agents handle this, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+
+## 4. How to tell which you are using
+
+A simple diagnostic: after your tenth query against the same warehouse, ask the tool a question that references a business rule it should have learned from your first nine queries. For example, after asking nine revenue questions that all required test account filters, ask:
+
+> "Show me monthly revenue."
+
+If the tool generates a query without the test account filter—and you have to remind it, again—you are using a copilot. If the tool applies the filter automatically because it learned from your previous corrections, you are using an agent with a context store.
+
+The gap between these two behaviors is the gap between a clever stranger and a coworker.
+
+## 5. When a SQL copilot is enough
+
+SQL copilots are the right tool when:
+
+- **You are the sole data person**, you know your warehouse intimately, and you just want to type faster. The context is in your head; you need the tool to generate boilerplate, not to learn.
+- **You are doing ad-hoc exploration** on a dataset you may never query again. The session is bounded, the questions are one-off, and context persistence adds no value.
+- **You are evaluating a warehouse for the first time** and need to run exploratory queries to understand its structure. You are building your own mental context; the tool does not need to build any.
+
+In all of these cases, the copilot's statelessness is a feature, not a bug. You want speed, not accumulation.
+
+When the work becomes repeated, team-scale, and accuracy-sensitive—when the same warehouse will be queried thousands of times by multiple people over months—the copilot's statelessness becomes the bottleneck. That is the threshold where a data engineering agent earns its keep.
+
+## 6. Bottom line
+
+A SQL copilot helps you write queries. A data engineering agent helps you build a system that writes correct queries—and gets more correct over time. 
+
+The difference is not about which one is "smarter." The most advanced LLM in the world, used as a copilot with no persistent context, will make the same mistakes on the hundredth query that it made on the first. A modest LLM, backed by a context engine that has accumulated six months of validated SQL, business rules, and feedback history from real usage, will outperform it on the data that matters.
+
+This is the core insight of [contextual data engineering](/posts/contextual-data-engineering): in data work, context compounds. For repeated, team-scale data work, the tool that remembers has a structural advantage over the tool that forgets.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see the difference between generating queries and building context—ask ten questions against a connected warehouse and watch what the agent learns.
+
+## Frequently asked questions
+
+### Is text-to-SQL the same as a data engineering agent?
+
+No. **Text-to-SQL** is a capability—the ability to translate natural language into SQL. A **data engineering agent** includes text-to-SQL as one of several capabilities, alongside context persistence, feedback loops, subagent delivery, and multi-step workflow execution. Most text-to-SQL tools are copilots with no persistent context. A data engineering agent uses text-to-SQL as its query generation mechanism while maintaining the context that makes those queries accurate over time.
+
+### Can I add persistence to a SQL copilot to turn it into an agent?
+
+Not easily. Persistence is not a feature you bolt on—it is a fundamental architectural decision that affects how the tool stores context, retrieves it at query time, incorporates feedback, and packages context for delivery. Building a proper context engine requires designing the data model (what gets stored), the retrieval mechanism (how context is matched to queries), and the feedback loop (how corrections flow back). These are not afterthoughts—they are the core architecture of a data engineering agent.
+
+### If my team already uses a SQL copilot, should we switch?
+
+Not necessarily. If the copilot is meeting your needs—you use it for ad-hoc queries and the context stays in your head—there is no reason to switch. If you are experiencing the pain points that copilots cannot address—repeated corrections of the same mistakes, metric drift across team members, onboarding new analysts who cannot access institutional knowledge—that is the signal that you have outgrown the copilot model and should evaluate an agent with persistent context.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer model behind persistent context
+- [Data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code) — another comparison that turns competitors into complements

--- a/blog/posts/enterprise-data-engineering-agent.md
+++ b/blog/posts/enterprise-data-engineering-agent.md
@@ -1,0 +1,153 @@
+---
+title: "What an Enterprise Data Engineering Agent Actually Needs"
+description: "Enterprise data engineering agent requirements: shared context, RBAC, auditability, reliability, and governance."
+author: "John Smith"
+date: 2026-06-03
+lastmod: 2026-06-03
+head:
+  - - meta
+    - name: keywords
+      content: "enterprise data engineering agent, data engineering agent enterprise, enterprise data agent, data agent governance, enterprise NL2SQL"
+  - - meta
+    - property: og:title
+      content: "What an Enterprise Data Engineering Agent Actually Needs"
+  - - meta
+    - property: og:description
+      content: "Enterprise data engineering agent requirements: shared context, RBAC, auditability, reliability, and governance."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/enterprise-data-engineering-agent
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/enterprise-data-engineering-agent
+---
+# What an Enterprise Data Engineering Agent Actually Needs
+
+A [data engineering agent](/posts/what-is-data-engineering-agent-2026) that works for a single engineer on a single laptop is a productivity tool. A data engineering agent that works for fifty engineers, three hundred analysts, and a security team that audits every database query is infrastructure. The gap between the two is not a matter of scale. It is a matter of architecture.
+
+This article outlines the six requirements that separate an agent suitable for enterprise deployment from one suitable for personal use—and what each requirement means in practice. For the broader agent landscape, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+
+## TL;DR
+
+Enterprise data engineering agents need six things that personal agents can skip: **shared and versioned context**, **access control at the subagent level**, **auditability**, **long-running reliability**, **integration with existing governance**, and **a clear path from free to paid**.
+- Most agents on the market today address one or two of these. Few address all six.
+- The gap is not about features. It is about whether the agent was designed from the start to be infrastructure that a security team can sign off on.
+
+## 1. Shared and versioned context
+
+For a personal agent, context lives on one machine. If the engineer's laptop dies, the context dies with it. That is acceptable for personal productivity—annoying, but not catastrophic.
+
+For an enterprise, context is an organizational asset. If the agent has accumulated six months of validated SQL, business rules, and metric definitions across three teams, losing that context is a business continuity problem. The context must be shared across the organization (so the finance team's subagent and the marketing team's subagent draw from the same validated source of truth), backed up, and versioned (so teams can trace how a metric definition changed in week 12 and whether queries generated before the change need to be re-run).
+
+This is the architectural difference between local storage and a shared context store. Local storage is simpler. A shared, versioned context store requires database infrastructure, conflict resolution, and access patterns that support concurrent reads and writes from multiple subagents. For the theory behind this, see [contextual data engineering](/posts/contextual-data-engineering).
+
+## 2. Access control at the subagent level
+
+A personal agent has one user. An enterprise agent has hundreds—each with different permissions over different data.
+
+The right granularity for access control in a data engineering agent is the subagent. A finance subagent should have read access to finance tables and no access to HR tables. An operations subagent should see operations data and nothing else. Role-based access control (RBAC) at the subagent level means the agent's permissions align with the organization's existing data access policies.
+
+This is more nuanced than it sounds. A subagent's access is not just about which tables it can query. It is about which metrics it can reference, which business rules it applies, and which validated SQL patterns it can retrieve from the shared context store. A subagent for the marketing team should not retrieve finance's proprietary revenue definitions. The context engine must support scoped retrieval, not just scoped database access.
+
+## 3. Auditability
+
+Enterprise security teams need to answer one question about any tool that accesses production data: "What exactly did it do?"
+
+For a data engineering agent, auditability means: every query the agent generated, every schema it inspected, every metric it defined, every context change it made, who approved it, and what the result was. Not summary statistics—a complete, queryable audit log.
+
+This is table stakes for regulated industries (finance, healthcare, publicly traded companies) and increasingly expected in all enterprise procurement. SOC 2 Type II, HIPAA compliance, and GDPR data residency requirements are not optional features; they are prerequisites for any tool that touches production data.
+
+The architectural implication: the agent's core operations—query generation, context updates, feedback processing—must be instrumented from the start. Retrofitting auditability into an agent that was not designed for it is a rewrite, not a feature addition.
+
+## 4. Long-running agent reliability
+
+Personal agents answer questions interactively: you ask, they respond, the session ends. Enterprise agents run continuously: monitoring pipelines, checking data quality, triggering alerts, refreshing context on a schedule.
+
+This requires a different reliability model. A personal agent that crashes mid-query is an annoyance. An enterprise agent that silently stops monitoring a pipeline is a production incident. Long-running agents need:
+
+- **Scheduled execution** with retry logic for transient failures
+- **State persistence** so a restarted agent picks up where it left off
+- **Alerting** when an agent task fails or produces anomalous results
+- **Resource isolation** so one team's long-running agent does not degrade another team's interactive queries
+
+This is the operational layer that separates a CLI tool from an infrastructure service. It is also where integration with existing orchestration tools (Airflow, Dagster, Prefect) through [MCP](/posts/mcp-data-engineering) becomes valuable—not every agent needs to build its own scheduler.
+
+## 5. Integration with existing governance
+
+Enterprises already have governance: data catalogs (DataHub, Atlan), access control (IAM, RBAC), data quality frameworks (Monte Carlo, Soda, Elementary), and compliance tooling. A data engineering agent should integrate with this existing layer, not replace it.
+
+Practically, this means:
+- The agent consumes catalog metadata rather than re-crawling the warehouse from scratch
+- The agent respects existing IAM policies—a subagent's database access inherits from the user's Snowflake or BigQuery permissions
+- The agent feeds quality signals (query accuracy, schema anomalies) into existing data quality dashboards
+- The agent's audit log exports to the organization's SIEM or compliance tooling
+
+An agent that requires the enterprise to rebuild its governance around the agent's model will fail procurement. An agent that slots into existing governance will pass it.
+
+## 6. A clear path from free to paid
+
+Enterprise procurement teams do not reject tools because they cost money. They reject tools because the pricing model is unpredictable, the vendor's sustainability is unclear, or there is no path from the free tier to the enterprise tier without re-platforming.
+
+A data engineering agent's commercial model should answer three questions:
+
+- **What is open source, what is free, and what is paid?** Open-source core (Apache 2.0 CLI + Context Engine) provides adoption and community. Any cloud or enterprise tier should clearly explain evaluation limits, paid features, and long-term support.
+- **What does Enterprise add, and is it worth the money?** SSO, audit logging, shared context store, RBAC, SLA, long-running agent support. These are features enterprises need and will pay for.
+- **Is the vendor sustainable?** AI data tooling changes quickly. Enterprise buyers evaluating agents in 2026 should look for active maintenance, a clear revenue model, and a roadmap that does not depend on community goodwill alone.
+
+For the open-source perspective on this, see [open source data engineering agents](/posts/open-source-data-engineering-agents).
+
+## 7. The enterprise readiness checklist
+
+| Requirement | What it means in practice | Typical personal-tier agents¹ |
+|---|---|---|
+| Shared, versioned context | Centralized context store with change history; multiple subagents read from the same source of truth | ❌ Local-only context |
+| Subagent RBAC | Finance subagent cannot access HR tables; scoped context retrieval | ⚠️ Partial (some agents have scoping; few have retrieval scoping) |
+| Auditability | Complete, queryable log of every generated query, context change, and user action | ❌ Missing or partial |
+| Long-running reliability | Scheduled execution, state persistence, retry logic, alerting | ❌ Interactive-only |
+| Governance integration | Consumes catalog metadata; respects IAM; exports to SIEM | ❌ Siloed |
+| Clear commercial path | Predictable pricing; open-source core + paid enterprise; vendor sustainability signals | ⚠️ Mixed (varies by vendor) |
+
+¹ Based on publicly documented capabilities as of mid-2026. Several agents have enterprise tiers with additional features not reflected in their free/open-source tiers. Check vendor documentation for current enterprise offerings.
+
+## 8. What enterprise readiness looks like in practice
+
+In Datus's Lakehouse deployment narrative, these requirements show up as concrete operating patterns: shared context reduces metric drift between domains, scoped subagents give security teams a narrower approval surface, and feedback-backed answers increase analyst confidence in self-service workflows. Keep any numeric outcome tied to the case-study source rather than presenting it as a generic enterprise benchmark.
+
+The key insight from this deployment: enterprise readiness is not a feature checklist to be ticked off after the product is built. It is an architectural decision that affects context storage, access patterns, and instrumentation from day one. Agents that treat enterprise features as an add-on layer will struggle. Agents designed from the start for shared, governed, auditable context will have an easier path.
+
+## Conclusion
+
+An enterprise data engineering agent is not a personal agent with more users. It is a different architecture: shared context instead of local, governed access instead of open, auditable operations instead of opaque, reliable instead of interactive-only.
+
+The agents that succeed in the enterprise will be the ones that treat these requirements as design principles, not as a backlog. For teams evaluating agents, the question is not "which agent generates the best SQL in a demo?" It is "which agent can pass our security review, integrate with our existing governance, and provide a clear commercial model that gives us confidence it will still be maintained in three years?"
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see how an agent designed for both personal productivity and enterprise governance handles the transition.
+
+## Frequently asked questions
+
+### Can we start with a personal agent and upgrade to enterprise later?
+
+It depends on whether the agent was designed for the upgrade path. Agents that store context locally and have no shared context architecture will require a migration—exporting context from individual machines, reconciling conflicts, and importing into a shared store. Agents designed with a shared context architecture from the start allow a smoother transition: the context engine is already centralized; the upgrade adds enterprise features (SSO, audit, RBAC) on top of the existing architecture. Before starting with a personal agent, understand whether the upgrade path is a configuration change or a migration.
+
+### How does enterprise pricing typically work for data engineering agents?
+
+The most common models: per-user (for analyst-facing subagents), per-subagent (for domain-specific deployments), or per-warehouse (for the infrastructure layer). Most enterprise pricing is not publicly listed—it is negotiated based on team size, data volume, and feature requirements. The key question is not the exact number but the pricing model: does it scale predictably as your usage grows, or does it spike at unpredictable thresholds?
+
+### What security certifications should an enterprise data engineering agent have?
+
+Common enterprise expectations include SOC 2 Type II for vendor controls, GDPR readiness for European personal data, HIPAA-aligned controls for healthcare, and FedRAMP considerations for US government workloads. For self-hosted open-source agents, the agent itself does not hold certifications—the hosting infrastructure does. The agent should support the configurations (encryption at rest, access logging, RBAC) that your security team requires for certification.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — the context architecture that enterprises need
+- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — the self-hosting option for enterprises with strict data residency requirements

--- a/blog/posts/index.md
+++ b/blog/posts/index.md
@@ -16,8 +16,31 @@ The problem, the product, and the thesis behind it.
 - [Make Data Agents Usable: Ask, Explore, and Control with Confidence](/posts/make-data-agents-truly-usable-ask-explore-and-control-with-confidence) — Apr 2, 2026
 - [Meet the General Chat Agent: Your Data Co-Pilot That Actually Thinks](/posts/meet-the-general-chat-agent) — Mar 25, 2026
 - [SQL Agents Are Broken Without Context. Meet Datus.](/posts/meet_datus) — Oct 21, 2025
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) — Mar 2, 2026
 - [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack) — Mar 11, 2026
+
+## Data Engineering Agent
+
+The category, the comparisons, and how to build with one — our core cluster.
+
+- [What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison](/posts/what-is-data-engineering-agent-2026) — May 31, 2026
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) — Mar 2, 2026
+- [Contextual Data Engineering: Why Every Agent Needs Evolvable Context](/posts/contextual-data-engineering) — Jun 1, 2026
+- [Best Data Engineering Agents in 2026: An Honest Comparison](/posts/best-data-engineering-agents-2026) — Jun 2, 2026
+- [Open Source Data Engineering Agents](/posts/open-source-data-engineering-agents) — Jun 2, 2026
+- [How to Build Your First Data Engineering Agent in 15 Minutes](/posts/build-your-first-data-engineering-agent) — Jun 3, 2026
+- [Data Engineering Agent vs. Claude Code: When to Use Which](/posts/data-engineering-agent-vs-claude-code) — Jun 3, 2026
+- [Data Engineering Agent vs. SQL Copilot: What's the Real Difference?](/posts/data-engineering-agent-vs-sql-copilot) — Jun 4, 2026
+- [One-Person Data Team: How a Data Engineering Agent Multiplies Your Output](/posts/one-person-data-team) — Jun 4, 2026
+- [How a Context Engine Makes Data Engineering Agents More Accurate](/posts/context-engine-data-engineering-agent-accuracy) — Jun 1, 2026
+- [MCP and Data Engineering: The Protocol That Connects Your Entire Stack](/posts/mcp-data-engineering) — Jun 2, 2026
+- [What an Enterprise Data Engineering Agent Actually Needs](/posts/enterprise-data-engineering-agent) — Jun 3, 2026
+- [Subagents: How to Ship Domain-Specific Data Agents Without Training a Model](/posts/subagents-domain-specific-data-agents) — Jun 4, 2026
+
+## Semantic Layer
+
+What a semantic layer is, and how it differs from a metric layer or catalog.
+
+- [What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer](/posts/what-is-semantic-layer) — May 31, 2026
 
 ## Why agents, not copilots
 

--- a/blog/posts/mcp-data-engineering.md
+++ b/blog/posts/mcp-data-engineering.md
@@ -1,0 +1,159 @@
+---
+title: "MCP and Data Engineering: The Protocol That Connects Your Entire Stack"
+description: "MCP for data engineering: how agents connect to databases, orchestrators, quality tools, and context services."
+author: "John Smith"
+date: 2026-06-02
+lastmod: 2026-06-02
+head:
+  - - meta
+    - name: keywords
+      content: "MCP data engineering, MCP protocol data engineering, model context protocol explained, MCP server data engineering, MCP database agent"
+  - - meta
+    - property: og:title
+      content: "MCP and Data Engineering: The Protocol That Connects Your Entire Stack"
+  - - meta
+    - property: og:description
+      content: "MCP for data engineering: how agents connect to databases, orchestrators, quality tools, and context services."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/mcp-data-engineering
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/mcp-data-engineering
+---
+# MCP and Data Engineering: The Protocol That Connects Your Entire Stack
+
+The Model Context Protocol (MCP), introduced by Anthropic and maintained as an open protocol, is the closest thing the AI agent ecosystem has to a shared connector standard. It standardizes how agents discover and use external tools—databases, APIs, file systems, orchestrators—through a client-server model that works across vendors. For data engineering, it matters because it turns a fragmented stack of tools that do not talk to each other into a set of composable capabilities that an agent can orchestrate.
+
+This article explains what MCP means for data engineering specifically, how agents use it as both clients and servers, and where the protocol's current limitations leave room for native tooling. If you are new to the agent side, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+
+## TL;DR
+
+- **MCP** standardizes how AI agents connect to external tools—databases, orchestrators, quality tools, APIs—through a client-server model.
+- For data engineering, MCP enables two patterns: agents **consuming** data tools (querying databases via MCP, triggering Airflow DAGs) and agents **exposing** themselves as tools (a DE agent's context engine made available to Claude Code).
+- MCP is not a replacement for native tooling. The protocol adds latency and abstraction. Core data operations (schema inspection, query generation, context management) are better served by native, deeply integrated tools.
+- The practical strategy: use MCP for the long tail of integrations, not for the core path.
+
+## 1. What MCP is, in one paragraph
+
+MCP is an open protocol, originally developed by Anthropic, that standardizes communication between AI agents and external tools. It uses a client-server architecture: an MCP client (the agent) discovers available tools from an MCP server (the tool), calls them with structured inputs, and receives structured outputs. The protocol handles authentication, tool discovery, and message formatting—so an agent does not need custom integration code for every database, API, and file system it wants to access.
+
+In practice, this means a single agent can connect to a Postgres database, an Airflow instance, a Soda data quality check, and a Slack channel—all through MCP, all with the same tool-calling interface.
+
+## 2. Two patterns: MCP client and MCP server
+
+In the data engineering context, MCP creates two distinct integration patterns:
+
+### Pattern 1: The agent as MCP client (consuming tools)
+
+A <a href="https://datus.ai/glossary">data engineering agent</a> acts as an MCP client, connecting to external MCP servers to extend its capabilities. Examples:
+
+- **Database access:** An agent connects to a DuckDB MCP server to query a local analytics database—without needing a native database adapter.
+- **Orchestration:** An agent connects to an Airflow MCP server to trigger DAG runs, check pipeline status, and retrieve logs.
+- **Data quality:** An agent connects to a Soda MCP server to run data quality checks and retrieve results.
+- **Communication:** An agent connects to a Slack MCP server to send query results or alert on pipeline failures.
+
+This pattern is about extending the agent's reach. It turns the agent from a SQL generator into an orchestrator that can interact with the surrounding data stack.
+
+### Pattern 2: The agent as MCP server (being a tool for other agents)
+
+A data engineering agent exposes its own capabilities as an MCP server, making its context engine available to other agents. Examples:
+
+- **Claude Code queries Datus context:** Claude Code, working on a data pipeline refactor, calls Datus's MCP server to retrieve validated join paths and metric definitions—so the code it generates is grounded in the team's actual data context.
+- **A dashboard tool queries agent context:** A BI tool calls the agent's MCP server to retrieve metric definitions, ensuring that dashboard KPIs match the definitions the agent uses.
+
+This pattern is about making the agent's accumulated knowledge available to the rest of the ecosystem. The context engine becomes a shared service, not a silo. For more on how this complements general-purpose agents, see [data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code).
+
+## 3. The MCP data engineering ecosystem in 2026
+
+The MCP ecosystem for data engineering is young but growing rapidly. Here is what exists today:
+
+| Tool | MCP Role | What it enables |
+|---|---|---|
+| **Datus** | Client + Server | Consume MCP tools (Airflow, Soda, DuckDB); expose Context Engine to other agents |
+| **Snowflake Cortex Code** | Client (partial) | Connect to Snowflake-native tools through Cortex Search Service |
+| **Airflow MCP Server** (community) | Server | Agents trigger DAGs, check status, retrieve logs |
+| **Soda Core MCP** | Server | Agents run data quality checks programmatically |
+| **DuckDB MCP** | Server | Agents query embedded databases without native adapters |
+| **Claude Code / Claude Desktop** | Client | General-purpose agents consume MCP tools from any server |
+| **dbt MCP Server** (community) | Server | Agents trigger dbt runs, inspect model lineage |
+
+The pattern is clear: more tools are adding MCP servers, and more agents are adding MCP client support. MCP is moving toward table-stakes status for agent ecosystems, but the exact coverage still varies by tool and server maturity.
+
+## 4. Where MCP shines, and where it does not
+
+MCP's strength is **breadth**. It lets an agent connect to dozens of tools through a single protocol, without custom integration code for each one. For the long tail of data tools—the niche orchestrator, the custom quality checker, the internal API—MCP is the practical way to integrate.
+
+MCP's weakness is **depth**. The protocol adds latency (network calls, serialization) and abstraction (generic tool interfaces vs. domain-specific optimizations). For the core data path—schema inspection, query generation, context retrieval—native tooling that is deeply integrated with the agent's architecture will always outperform MCP-mediated access.
+
+This is not a criticism of MCP. It is a design tradeoff inherent in any abstraction layer. MCP is excellent for the capabilities you use occasionally and across many tools. It is not the right foundation for capabilities you use on every query.
+
+**A practical principle: MCP for the long tail, native for the core.**
+
+- **Core path (native):** Schema inspection, context retrieval, SQL generation, query execution, feedback capture. These happen on every interaction; they should be as fast and deeply integrated as possible.
+- **Long tail (MCP):** Orchestrator triggers, quality checks, Slack notifications, custom API calls. These happen occasionally and vary by deployment; MCP makes them accessible without bloating the agent's core.
+
+## 5. The MCP meta-pattern: agents that expose context
+
+The most strategically interesting MCP pattern for data engineering is not "agent calls database through MCP." It is "agent exposes its accumulated context through MCP."
+
+A [context engine](/posts/contextual-data-engineering) that has accumulated six months of validated SQL, business rules, and feedback history is a valuable asset. MCP turns that asset into a service. Instead of the context being locked inside one agent, it becomes available to every tool that speaks MCP:
+
+- Claude Code generates a dbt model and retrieves the correct join path from the context engine.
+- A dashboard tool retrieves metric definitions to ensure consistency.
+- A new analyst onboarding queries the context engine to understand which tables and columns are trusted.
+
+The context engine becomes the source of truth for machine-readable data knowledge—not just for the agent that built it, but for the entire ecosystem. This is the endgame for MCP in data engineering: not just connecting tools, but making the context that agents build available as infrastructure.
+
+## 6. What this means for choosing a data engineering agent
+
+When evaluating agents, MCP support is worth checking—but it should not be the primary criterion. Many serious agents are moving toward MCP support; buyers should still verify which MCP roles are actually implemented. The differentiation is not "does it support MCP?" but "what does it do natively, and does it expose the right things through MCP?"
+
+Questions worth asking:
+
+- **MCP Client:** Which external tools can the agent connect to? Is the MCP client general-purpose (any MCP server) or limited to a curated list?
+- **MCP Server:** Does the agent expose its context engine through MCP? Can other agents query the accumulated context—validated SQL, metrics, business rules?
+- **Core vs. MCP boundary:** Which capabilities are native (fast, deep, integrated) and which are MCP-mediated (broad, flexible, slower)? A clear boundary is a sign of architectural maturity; treating everything as MCP-mediated is a sign the agent has no native depth.
+
+For a comparison of how current agents handle this boundary, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+
+## Source notes
+
+MCP coverage changes quickly. Keep the protocol definition tied to Anthropic's Model Context Protocol announcement and the official MCP specification, then verify individual servers against their own repositories before naming them as production-ready.
+
+## Conclusion
+
+MCP is the protocol that connects data engineering agents to the rest of the stack—databases, orchestrators, quality tools, and other agents. It enables two valuable patterns: agents consuming tools through a unified interface, and agents exposing their accumulated context as a service for other tools to use.
+
+The strategic insight is not that MCP is important—that is becoming obvious. It is that the most valuable thing an agent can expose through MCP is not a database connection. It is the context the agent has built: the validated SQL, the business rules, the feedback history, the institutional knowledge. That is the asset. MCP is the pipe that delivers it.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see an agent that uses MCP to both consume tools and expose context—and watch how the context engine grows with every query.
+
+## Frequently asked questions
+
+### Is MCP required for a data engineering agent to work?
+
+No. MCP is a connector protocol, not a core capability. A data engineering agent can connect to databases, generate SQL, and maintain context without MCP. What MCP adds is the ability to connect to a broader ecosystem of tools (orchestrators, quality checkers, other agents) through a standard interface. It is valuable for breadth but not essential for core function.
+
+### Does MCP replace native database adapters?
+
+No. Native database adapters are optimized for a specific database's API, performance characteristics, and feature set. MCP provides generic database access that works across many databases but with higher latency and less optimization. For production workloads against a known database, native adapters are the right choice. MCP is useful for ad-hoc access to less common databases or for environments where installing native adapters is impractical.
+
+### How does MCP affect security when agents connect to data tools?
+
+MCP servers run with the permissions of the process that hosts them. When an agent calls an MCP tool, it inherits those permissions. This means security depends on how the MCP server is configured—not on the protocol itself. Best practice: run MCP servers with the minimum necessary permissions (read-only for databases, scoped to specific schemas for query tools), and treat the agent's MCP client the way you would treat any service account with access to your data infrastructure.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — the context model that MCP makes available to other agents
+- [Data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code) — the MCP-mediated complementary architecture

--- a/blog/posts/one-person-data-team.md
+++ b/blog/posts/one-person-data-team.md
@@ -1,0 +1,152 @@
+---
+title: "One-Person Data Team: How a Data Engineering Agent Multiplies Your Output"
+description: "How a one-person data team uses a data engineering agent to reduce SQL translation work and ship self-service analytics."
+author: "Harrison Zhao"
+date: 2026-06-04
+lastmod: 2026-06-04
+head:
+  - - meta
+    - name: keywords
+      content: "one person data team, one person data team agent, full stack data engineer agent, data engineering agent productivity, solo data engineer"
+  - - meta
+    - property: og:title
+      content: "One-Person Data Team: How a Data Engineering Agent Multiplies Your Output"
+  - - meta
+    - property: og:description
+      content: "How a one-person data team uses a data engineering agent to reduce SQL translation work and ship self-service analytics."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/one-person-data-team
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/one-person-data-team
+---
+# One-Person Data Team: How a Data Engineering Agent Multiplies Your Output
+
+The modern data stack was designed for teams. dbt, Airflow, Snowflake, Looker, Monte Carlo—each tool expects someone to own it, maintain it, and field the questions that flow through it. A mid-size company's data team might have three to five engineers, plus analysts, plus a manager. A startup or small company might have one person handling all of it—pipelines, queries, metrics, dashboards, ad-hoc requests, data quality, documentation.
+
+That one person is not underperforming. They are outnumbered. The bottleneck is not their speed; it is the volume of context-switching, the repetitive nature of data requests, and the impossibility of being the sole carrier of institutional knowledge about the warehouse.
+
+A [data engineering agent](/posts/what-is-data-engineering-agent-2026) changes the math. Not by replacing the engineer, but by handling the repetitive work, accumulating context so the engineer does not have to re-explain the same tables every week, and delivering self-service access to people who would otherwise file tickets. This article explains how—and what it actually looks like in daily practice.
+
+## TL;DR
+
+- The bottleneck for a solo data engineer is not query-writing speed. It is **context-switching, repetitive requests, and being the sole carrier of institutional knowledge**.
+- A data engineering agent addresses all three: it automates repetitive SQL generation, accumulates context so requests get more accurate over time, and packages that context into self-service subagents that analysts can use without filing tickets.
+- The result: a one-person data team spends less time on translation work and more time on the engineering that only they can do.
+
+## 1. The real bottleneck: it is not your typing speed
+
+Solo data engineers do not struggle with writing SQL. They struggle with three things that no amount of personal speed can fix:
+
+**Context-switching.** The day fractures into 15-minute slices: a Slack question about why revenue looks low, an urgent dashboard fix, a pipeline that broke overnight, a meeting about next quarter's data needs, and somewhere in between, the actual engineering work that moves things forward. Each switch costs cognitive overhead. By the end of the day, the engineer has worked for nine hours and advanced exactly zero long-term projects.
+
+**Repetitive translation work.** Most data requests are variations on the same few questions, asked by different people, in slightly different words: "What was revenue last week? Now by region. Now excluding test accounts. Now with a YoY comparison." The engineer translates each request into SQL, runs it, verifies it, and sends the result. The task is not hard—it takes five minutes. But it recurs daily, and the five-minute tasks consume half the week.
+
+**Being the sole carrier of institutional knowledge.** Every table's quirks, every metric's definition, every join path's trap—it all lives in one person's head. When that person is unavailable, the company stops being able to answer data questions. When that person leaves, the knowledge walks out the door. There is no system to capture it, because building that system is one more thing the one-person team does not have time to do.
+
+A data engineering agent does not solve all of these problems. But it takes aim at the largest chunk: the repetitive translation work that consumes the most hours and produces the least long-term value.
+
+## 2. How an agent changes the daily workflow
+
+Here is what a typical week looks like for a solo data engineer, before and after adopting an agent with a [persistent context engine](/posts/contextual-data-engineering).
+
+### Before: the ticket treadmill
+
+**Monday, 9:15 AM.** Slack message: "Can you pull weekly revenue by region? Need it for the Q2 review." Engineer opens their SQL client, writes the query, verifies against known totals, sends the CSV. 15 minutes.
+
+**Monday, 11:00 AM.** Another Slack message: "Same thing but with a YoY comparison?" Engineer reopens the query, adds the comparison logic, verifies, sends. Another 10 minutes.
+
+**Tuesday, 2:30 PM.** Email from marketing: "Can we get revenue broken out by acquisition channel? And exclude test accounts?" Engineer writes a new query—the join to the channel table is non-trivial, and the test-account filter varies by source system. 25 minutes.
+
+**Thursday, 10:00 AM.** Finance asks for "net revenue, same definition we used last quarter." Engineer searches through old Slack threads and query history to find the exact definition. 20 minutes.
+
+**Friday, 4:00 PM.** Three more ad-hoc requests. Engineer does not start the pipeline refactor that was supposed to be this week's main project.
+
+By Friday, the engineer has spent roughly 8-10 hours on translation work—taking questions from business users and turning them into SQL. The pipeline refactor, the data quality dashboard, the documentation that would make next week's requests faster—none of it happened.
+
+### After: the agent handles the translation
+
+**Week 1: Setup.** Engineer installs a data engineering agent, connects it to the warehouse, and bootstraps the context engine with historical SQL and documented metric definitions. Takes about half a day.
+
+**Week 2: The agent starts working.** Engineer creates a subagent for the finance domain—scoped to the relevant tables, pre-loaded with finance's revenue definitions, and configured with the test-account filter as a standing rule. Shares the subagent link with the finance team: "Ask this instead of Slacking me."
+
+**Week 3: The shift begins.** Finance asks the subagent for weekly revenue by region. The subagent generates the query—correctly, because it already knows finance's definition of revenue and the right join path for region mapping. Finance exports the CSV. The engineer never sees the request.
+
+Marketing asks for revenue by channel. The engineer creates a marketing subagent—scoped to the channel and campaign tables, with marketing's attribution rules baked in. 15 minutes to set up. Marketing's next ten requests go through the subagent, not through Slack.
+
+**Week 4: The engineer gets their time back.** The subagents handle the repetitive translation work. When a subagent gets a query wrong, the user reports the issue—and the correction flows back into the context engine, making the next query more accurate. The engineer reviews the corrections periodically, promoting validated rules into the formal context store.
+
+By the end of the month, the engineer has reclaimed roughly 60-70% of the time they were spending on ad-hoc requests. That time goes into the pipeline refactor, the data quality dashboard, and the documentation. The work that only the engineer can do.
+
+## 3. What makes this possible: context that compounds
+
+The key enabler is not the agent's ability to generate SQL. It is the agent's ability to accumulate context—and the subagent's ability to package that context into something a non-engineer can use.
+
+A <a href="https://datus.ai/glossary">data engineering agent</a> with a context engine works differently from a SQL copilot. With a copilot, every request starts fresh—the copilot generates a query, and if it is wrong, you correct it, but the correction does not survive the session. Next week, the same wrong query gets generated again.
+
+With an agent, the context engine stores every validated query, every corrected definition, and every business rule. When a new request arrives, the agent retrieves relevant context before generating SQL—so the first attempt is already grounded in what the team has learned. The finance subagent does not need to be told, every time, that "net revenue excludes refunds and uses locked FX rates." It knows, because that rule is in its context.
+
+This is [contextual data engineering](/posts/contextual-data-engineering) in practice: the agent does not just answer questions. It accumulates the institutional knowledge that makes answers consistently correct. For a one-person team, this is the difference between being the bottleneck and being the enabler.
+
+## 4. What the agent does not replace
+
+It is important to be clear-eyed about what an agent handles and what it does not. A data engineering agent is excellent at:
+
+- Translating natural-language questions into correct, context-grounded SQL
+- Answering repeated variations of the same questions without human intervention
+- Accumulating business rules, metric definitions, and validated SQL patterns
+- Packaging context into self-service interfaces for non-engineers
+
+It does not replace:
+
+- **Pipeline architecture and design.** The agent can generate pipeline code, but it does not understand business requirements or make architectural tradeoffs.
+- **Data modeling decisions.** The agent can suggest schema designs and generate semantic models, but the decision about which modeling approach to use—star schema vs. OBT vs. Data Vault—requires human judgment about the organization's needs.
+- **Stakeholder relationships.** Understanding what a business user actually needs (vs. what they asked for) is a human skill the agent does not replicate.
+- **Strategic thinking about data infrastructure.** Which tools to adopt, when to migrate, how to structure the team—these are human decisions.
+
+The agent handles the work that consumes time without creating lasting value. It frees the engineer to do the work that only an engineer can do.
+
+## 5. Getting started as a one-person data team
+
+The path from ticket treadmill to agent-assisted team:
+
+1. **Start with one domain.** Pick the area that generates the most repetitive requests—finance, marketing, or operations. One domain, one subagent.
+2. **Bootstrap context from what you already have.** Run the agent's knowledge-base bootstrap command against your historical SQL files and documented metric definitions. The agent will learn your schemas and metrics without manual configuration.
+3. **Create a subagent for that domain.** Scope it to the relevant tables and metrics. Give it a clear description so users understand what it can answer.
+4. **Redirect requests.** The next time someone from that domain asks a question you have answered before, send them the subagent link. "Ask this—it knows our definitions."
+5. **Review corrections weekly.** Spend 15 minutes reviewing issue reports and upvotes. Promote validated rules into the context store.
+6. **Expand to the next domain.** Once the first subagent is handling 80% of requests without your intervention, create the next one.
+
+The goal is not to automate yourself out of a job. It is to automate the part of the job that is not engineering—the translation, the repetition, the re-explaining—so you can spend your time on the engineering that moves the company forward.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see how an agent handles domain-specific context, or follow the [15-minute tutorial](/posts/build-your-first-data-engineering-agent) to set one up yourself.
+
+## Frequently asked questions
+
+### Is a data engineering agent only useful for solo data engineers?
+
+No. The same principles apply to larger teams—the agent handles repetitive translation work and accumulates shared context that prevents metric drift across team members. But the impact is most dramatic for solo engineers, because they have no one else to offload the translation work to. In a larger team, the agent improves efficiency; for a one-person team, it changes what is possible.
+
+### How long does it take before the agent's context is reliable enough to share with non-engineers?
+
+After the initial bootstrap (historical SQL + documented metrics), the safest rollout pattern is supervised use: the agent handles routine translation work, while the engineer reviews answers before sharing them broadly. As users upvote correct answers and file corrections, the context store gets better at the team's common query patterns. The first subagent can be shared with a verification caveat; routine use should follow only after the team has reviewed enough domain-specific answers to trust the pattern.
+
+### What happens when the agent gets a query wrong and an analyst sees an incorrect result?
+
+The analyst files an issue report describing what was wrong. The correction flows into the context engine, and the agent adjusts future queries. The engineer reviews the correction—either immediately for critical errors or in a weekly review—and promotes validated fixes into the formal context store. In Datus's Lakehouse deployment narrative, this feedback loop is tied to higher self-service usage because analysts gained confidence that corrections would improve the system rather than disappear in a Slack thread.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — the feedback loop that makes one-person teams work
+- [Build your first data engineering agent](/posts/build-your-first-data-engineering-agent) — a 15-minute tutorial

--- a/blog/posts/open-source-data-engineering-agents.md
+++ b/blog/posts/open-source-data-engineering-agents.md
@@ -1,0 +1,191 @@
+---
+title: "Open Source Data Engineering Agents: Why They Exist, When to Use One, and What Your Options Are"
+description: "Open-source data engineering agents compared: Datus, Wren AI, Altimate, and when self-hosting is worth it."
+author: "John Smith"
+date: 2026-06-02
+lastmod: 2026-06-02
+head:
+  - - meta
+    - name: keywords
+      content: "open source data engineering agent, open source data agent, self-hosted data engineering agent, Apache 2.0 data agent, free data engineering agent"
+  - - meta
+    - property: og:title
+      content: "Open Source Data Engineering Agents: Why They Exist, When to Use One, and What Your Options Are"
+  - - meta
+    - property: og:description
+      content: "Open-source data engineering agents compared: Datus, Wren AI, Altimate, and when self-hosting is worth it."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/open-source-data-engineering-agents
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/open-source-data-engineering-agents
+---
+# Open Source Data Engineering Agents: Why They Exist, When to Use One, and What Your Options Are
+
+Not every category needs an open-source option. Most people do not need an open-source CRM or an open-source email client—the SaaS version works fine, and the data is not sensitive enough to justify the overhead of self-hosting.
+
+Data engineering is different. The agent you choose will have credentials to your warehouse. It will read your schemas, generate your SQL, and—in some configurations—execute queries against production data. It will become part of your data infrastructure the way dbt or Airflow is part of your infrastructure. When a tool sits that deep in your stack, the questions that matter are not just about features. They are about control, auditability, and what happens if the vendor changes direction.
+
+This article explains why open-source data engineering agents exist as a category, when the tradeoff of self-hosting is worth it, and how to choose among the three leading open-source options. For the full landscape including closed-source and platform-embedded agents, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+
+## TL;DR
+
+- **Three open-source data engineering agents** lead the category in 2026: Datus (Apache 2.0, Context Engine + subagents), Wren AI (Apache 2.0, semantic layer + text-to-SQL), and Altimate (MIT, agentic dbt harness).
+- Open source matters in this category for three reasons: **auditability** (you can read what queries the agent generates and why), **self-hosting** (your warehouse credentials stay on your infrastructure), and **no platform lock-in** (the agent works across warehouses, not inside one).
+- The tradeoff is **setup cost**: open-source agents require more initial configuration than platform-embedded ones. The payoff is **long-term control**: the agent's context belongs to you, not to a vendor.
+- Open source is not a guarantee of sustainability. Choose projects with visible maintenance, clear licensing, active docs, and a credible commercial or community path.
+
+## 1. Why open source matters specifically for data engineering agents
+
+A data engineering agent is not a chatbot. It is infrastructure. It connects to your warehouse, inspects your schemas, generates and executes SQL, and over time accumulates knowledge about your data that is as sensitive as the data itself. When you choose an agent, you are deciding who gets to hold that knowledge.
+
+Four concerns drive teams toward open-source agents in this category:
+
+### Auditability: you need to know what queries the agent generates
+
+A closed-source agent is a black box. It may generate a query that scans a PII column. It may use a deprecated join path that produces silently wrong results. It may make assumptions about your data that were true last quarter and are false today. Without the ability to inspect the agent's logic—not just its output—you are trusting a vendor with correctness guarantees they have not made.
+
+Open-source agents do not automatically solve this problem—reading the source is not the same as auditing every generated query. But they make it possible. You can trace how the agent constructs a query from context, understand why it chose one join path over another, and modify the logic if your environment requires different behavior. For regulated industries (finance, healthcare, publicly traded companies), this is not optional.
+
+### Self-hosting: your credentials stay on your infrastructure
+
+When you give a cloud-hosted agent access to your warehouse, you are extending your security perimeter to include the agent's infrastructure. If the agent's cloud is compromised, your warehouse is compromised. For many enterprises, this is a non-starter—vendor security reviews alone can add months to the procurement process.
+
+Open-source agents that support self-hosting let you run the agent on your own infrastructure, behind your own firewall, with your own IAM policies. The agent never leaves your network. Your warehouse credentials never touch a third-party server. This is the default posture for most enterprise data teams, and open-source agents are the only ones that fully support it.
+
+### No platform lock-in: the agent travels with your stack
+
+Platform-embedded agents (BigQuery DEA, Snowflake Cortex Code) are excellent inside their platforms and useless outside them. If you add a second warehouse—or migrate from one to another—the platform agent's context does not travel with you. You start over.
+
+Open-source agents are stack-agnostic by design. They connect to multiple warehouses, and the context they build (schemas, metrics, validated SQL, business rules) is portable. If you migrate from Snowflake to a lakehouse, the agent's understanding of your business logic survives the migration—only the physical connection changes. This is a hedge against infrastructure decisions you have not yet made.
+
+### Community sustainability: the agent outlives any single company
+
+AI data tools can change direction quickly: repos can slow down, companies can pivot, and commercial offerings can replace community-first roadmaps. Closed-source agents can disappear when the company runs out of money; open-source agents can survive a vendor shift only if the community and maintenance model are strong enough. For more on the competitive dynamics driving this cycle, see [the DE agent category overview](/posts/what-is-data-engineering-agent-2026).
+
+This is not an argument that open-source is always better. It is an argument that the stakes in data engineering agent selection are high enough to make open source worth considering. If the agent will become part of your core infrastructure, you should own the infrastructure.
+
+## 2. The three leading open-source data engineering agents
+
+### Datus — Context Engine + Subagents
+
+**License:** Apache 2.0 | **Install:** `pip install datus-agent` | **Verify:** GitHub stars and supported connectors before publication
+
+Datus is the most architecturally ambitious of the three. It is built around a persistent <a href="https://datus.ai/glossary">Context Engine</a> that organizes data knowledge along two dimensions—a physical catalog tree (databases, schemas, tables, annotated with semantic models) and a logical subject tree (business domains, topics, metrics, reference SQL). The Context Engine is not a static model; it is continuously updated through a feedback loop: agent generates SQL → user confirms or corrects → context evolves → next run is more accurate.
+
+Its subagent system is a distinctive capability: scoped chatbots (roughly 10 tables, 20 metrics, 30 validated SQL references) that package a subset of context for a specific domain. A finance subagent knows finance's definition of revenue. An operations subagent knows operations' definition. Both draw from the same context engine but are constrained to their scope.
+
+**Best for:** Teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge and delivers it through scoped, domain-specific interfaces. The feedback loop and subagent model make it the strongest option for teams that intend to use the agent as sustained infrastructure rather than a one-off tool.
+
+**Tradeoffs:** Newer than Wren AI, with a smaller community and less polished documentation. The Context Engine's value compounds with usage: early accuracy depends on the quality of the loaded context, while later accuracy depends on feedback, corrections, and validated query reuse.
+
+### Wren AI — Semantic Layer + Text-to-SQL
+
+**License:** Apache 2.0 | **Install:** Docker or Cloud | **Verify:** current GitHub activity and hosted-offering terms before publication
+
+Wren AI is the most mature open-source option by community size. Its core is an MDL-based semantic modeling layer: you define metrics, dimensions, and relationships in a modeling UI, and Wren AI generates SQL grounded in those definitions. It connects to any JDBC data source and has a polished web interface for analyst self-service.
+
+**Best for:** Teams that already have a well-maintained semantic layer (or are willing to build one) and want to add an AI query interface on top. The MDL modeling tools are more polished than any other open-source agent's, and the community is larger, which means more tutorials, more answered questions, and faster bug fixes.
+
+**Tradeoffs:** The semantic model is static—you build it once, and the agent queries against it. There is no feedback loop that updates the model based on usage. If a query surfaces a missing dimension or an incorrect join, the fix requires a human to update the model manually. For teams whose context evolves faster than their modeling sprints, this static model becomes a bottleneck. This is the central philosophical difference between Wren AI and Datus: Wren AI treats context as a model you build; Datus treats context as an asset that grows with usage. For the theoretical underpinning, see [contextual data engineering](/posts/contextual-data-engineering).
+
+### Altimate — Agentic dbt Harness
+
+**License:** MIT | **GitHub:** active | **Install:** CLI, VS Code, npm
+
+Altimate is the most focused of the three: an agentic data engineering harness built specifically for the dbt ecosystem. It parses dbt manifests directly, giving it deep understanding of models, tests, and lineage that a generic agent cannot match. It scores 74.42% on ADE-Bench—a data engineering benchmark—compared to dbt Labs' own 58.14%. Its SQL anti-pattern detection achieves 100% F1 across 1,077 queries.
+
+**Best for:** Teams that are dbt-native and want an agent that deeply understands their dbt project structure, manifest, and test framework. If dbt is the center of your transformation layer, Altimate is the most natural agent to sit on top of it.
+
+**Tradeoffs:** dbt-only. If your stack extends beyond dbt—raw SQL transformations, Python-based pipelines, or non-dbt-managed data sources—Altimate's scope is limiting. It is the strongest agent in its niche and the narrowest agent in the category.
+
+## 3. Open source agents vs. the alternatives: a tradeoff matrix
+
+| Dimension | Open Source (Datus, Wren AI, Altimate) | Platform-Embedded (BigQuery, Cortex Code) | Prompt-as-Agent (Claude Code) | Closed-Source (TextQL) |
+|---|---|---|---|---|
+| **Self-hosting** | Yes | No | Partial (local CLI) | No |
+| **Auditability** | Full source access | Black box | Prompt is visible; logic is not | Black box |
+| **Multi-warehouse** | Yes (broad) | No (single platform) | Yes (whatever is local) | Yes (broad) |
+| **Persistent context** | Yes (varies by agent) | Yes (platform metadata) | No | Yes (managed) |
+| **Setup time** | Medium (pip install or Docker) | Low (already in platform) | Low (paste a prompt) | Medium (SaaS onboarding) |
+| **Cost** | Free (OSS) | Free (pay compute) | Subscription (Claude) | $100–$250+/mo |
+| **Vendor risk** | Low (can fork) | High (platform dependency) | Medium (model dependency) | High (SaaS lock-in) |
+| **Community** | Medium–Large | Platform-driven | Ad-hoc | Vendor-driven |
+
+## 4. The cautionary tale: why some open-source agents fail
+
+The open-source data agent graveyard is already filling:
+
+- **Maintenance can slow down.** A permissive license does not guarantee active releases, responsive issues, or current documentation.
+- **Commercial priorities can change.** An open-source project may remain available while the vendor shifts roadmap energy toward a hosted product, enterprise plan, or narrower use case.
+- **Numbers Station** was acquired by Alation in May 2025. The technology survived, but the independent open-source project did not.
+
+This pattern is not unique to data agents—it mirrors the broader open-source infrastructure cycle. But it carries a specific lesson for teams evaluating open-source agents: **community size and license type are not enough. Look for a clear path to sustainability.** An agent with an Apache 2.0 license and no revenue model is more likely to archive its repo than an agent with a dual licensing model and paying enterprise customers.
+
+Of the three current leading open-source agents, Datus has the most clearly articulated sustainability model (Apache 2.0 core + free Cloud Personal tier + paid Enterprise with SSO/SLA/audit logging). Wren AI has a Cloud tier. Altimate's commercial model is still emerging. None are guaranteed to survive—but the ones with revenue are more likely to.
+
+## 5. When open source is worth the extra setup
+
+Open-source agents require more initial work than clicking "Enable" in a cloud console. You install the package, configure database connections, and build initial context. The question is whether the extra setup pays for itself.
+
+It does, reliably, in four scenarios:
+
+**You have more than one warehouse.** Platform agents work in one. Open-source agents work across all of them. The setup cost is paid once; the benefit accrues across every warehouse you add.
+
+**You handle regulated data.** PII, PHI, financial data under SOX, any data subject to GDPR with residency requirements. Self-hosting is not optional—it is a compliance requirement. Open-source agents are the only ones that fully support it.
+
+**You plan to be using this agent in two years.** The agent you choose today becomes harder to replace the longer you use it—context accumulates, workflows form around it, team members learn its patterns. If you expect the agent to be part of your infrastructure long-term, the vendor risk of closed-source options increases with time. Open-source agents can be forked, maintained by your team, or sustained by a community even if the original company changes direction.
+
+**You want the agent's context to be an asset you own.** A <a href="https://datus.ai/glossary">data engineering agent</a> that accumulates context is building an asset—a machine-readable representation of your team's institutional knowledge about your data. With an open-source agent, that asset lives on your infrastructure, in a format you can access and migrate. With a closed-source agent, it lives on the vendor's infrastructure. If you stop paying, you lose the context.
+
+If none of these apply—if you have one warehouse, no regulatory constraints, and are experimenting rather than committing—a platform agent or prompt-based agent will be faster to start with. The open-source path is for teams that view the agent as infrastructure, not as an experiment.
+
+## 6. How to get started with an open-source data engineering agent
+
+The fastest path to an initial evaluation:
+
+1. **Choose one agent** based on your stack: Datus if you have multiple warehouses and want persistent context, Wren AI if you have a semantic layer and want analyst self-service, Altimate if you are dbt-native.
+2. **Install it** (`pip install datus-agent` for Datus, Docker for Wren AI, VS Code extension for Altimate) and connect it to a non-production database.
+3. **Ask it one real question** from your actual work—not a demo query, but something you or your team asked in the past week.
+4. **Watch what context it builds.** After the first query, inspect the agent's context store. What did it learn about your schema? What metrics did it infer? What reference SQL did it capture? The quality of the context is a better predictor of long-term value than the quality of the first query.
+5. **Test a correction.** Ask a slightly wrong question, then correct the agent's output. Does the correction flow back into the context? On the next query, does the agent avoid the same mistake? This tests the feedback loop—the mechanism that separates an agent that learns from one that only responds.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> for a zero-install evaluation of an open-source agent with a persistent Context Engine.
+
+## Source notes
+
+For open-source comparisons, verify license, install path, stars, release activity, and hosted-offering terms directly from each project's GitHub repository and documentation immediately before publication. Treat star counts as volatile metadata, not proof of product quality.
+
+## Frequently asked questions
+
+### What is the best open-source data engineering agent?
+
+There is no single best—it depends on your stack. **Datus** is the strongest fit for multi-warehouse teams that want persistent, evolvable context and a subagent delivery model. **Wren AI** is stronger for teams with an existing semantic layer that want polished analyst self-service. **Altimate** is the best fit for dbt-native teams. All three are actively maintained and free under permissive licenses.
+
+### Is an open-source data engineering agent really free?
+
+The software is free. The infrastructure to run it is not—you need a machine (or cloud instance) to host it, and you pay for warehouse compute when the agent executes queries. Datus and Wren AI also offer free cloud tiers that eliminate the hosting cost. Enterprise features (SSO, audit logging, SLA) are paid.
+
+### How hard is it to set up an open-source data engineering agent?
+
+For single-user evaluation: often under 15 minutes if Python, credentials, and a supported database are ready. Install the package, configure one database connection, and ask a question. For team deployment with self-hosting, RBAC, and production warehouse connections: plan for a few days of setup and security review—comparable to deploying any new infrastructure tool like Airflow or dbt Core.
+
+### What happens if the open-source project I chose stops being maintained?
+
+If the license is permissive (Apache 2.0, MIT), you can fork the repository and maintain it yourself—or pay someone to maintain it for you. The context the agent has built (schemas, metrics, validated SQL) lives on your infrastructure and remains accessible. This is the fundamental insurance policy that open-source licenses provide and closed-source vendors do not. In practice, forking is a last resort—the most reliable protection is choosing a project with a clear sustainability model and an active community.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and four-agent comparison
+- [Best data engineering agents in 2026](/posts/best-data-engineering-agents-2026) — full landscape comparison including closed-source and platform agents
+- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model that separates durable agents from chat windows

--- a/blog/posts/subagents-domain-specific-data-agents.md
+++ b/blog/posts/subagents-domain-specific-data-agents.md
@@ -1,0 +1,164 @@
+---
+title: "Subagents: How to Ship Domain-Specific Data Agents Without Training a Model"
+description: "Subagents explained: domain-specific data agents built from scoped context, feedback, and governed access."
+author: "John Smith"
+date: 2026-06-04
+lastmod: 2026-06-04
+head:
+  - - meta
+    - name: keywords
+      content: "subagent data engineering, domain specific data agent, data engineering subagent, scoped context agent, data chatbot subagent"
+  - - meta
+    - property: og:title
+      content: "Subagents: How to Ship Domain-Specific Data Agents Without Training a Model"
+  - - meta
+    - property: og:description
+      content: "Subagents explained: domain-specific data agents built from scoped context, feedback, and governed access."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/subagents-domain-specific-data-agents
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/subagents-domain-specific-data-agents
+---
+# Subagents: How to Ship Domain-Specific Data Agents Without Training a Model
+
+A [data engineering agent](/posts/what-is-data-engineering-agent-2026) that can answer any question about your entire warehouse sounds powerful. In practice, it is a liability. Give an agent unrestricted access to every table, every metric, and every schema, and it will produce answers that are technically correct and organizationally wrong—using the operations team's definition of revenue when finance asked the question, or joining through a deprecated path because nobody told the agent not to.
+
+A subagent solves this by scoping the problem. Instead of one agent that knows everything, you create many subagents, each knowing exactly what one domain needs: roughly 10 tables, 20 metrics, 30 validated SQL references, and a set of standing business rules. Each subagent is a self-contained, shareable chatbot that delivers accurate answers within its domain—and stays silent outside it.
+
+This article explains what subagents are, how they work, and why they are the delivery unit that separates a <a href="https://datus.ai/glossary">data engineering agent</a> from a smart SQL writer. For the philosophy behind scoped context, see [contextual data engineering](/posts/contextual-data-engineering).
+
+## TL;DR
+
+- A **subagent** is a domain-specific chatbot built from scoped context: a curated subset of tables, metrics, validated SQL, and business rules relevant to one business domain.
+- Subagents solve three problems: **accuracy** (less irrelevant context = fewer wrong answers), **access control** (finance subagent cannot query HR tables), and **delivery** (analysts get a purpose-built chatbot instead of a general-purpose agent they do not know how to use).
+- The subagent lifecycle: ad-hoc exploration → generate metrics and reference SQL → configure scope → deploy chatbot → collect feedback → refine context → mature enough to export as an API.
+- Subagents are not a feature. They are the delivery model.
+
+## 1. The problem subagents solve
+
+General-purpose agents fail at domain-specific data work for three reasons:
+
+**Too much context.** A warehouse with 5,000 tables and 30,000 columns contains far more information than any agent can usefully process for a single query. If the agent loads the entire schema into its context window, it drowns in irrelevant information. If it selectively retrieves, it needs to know what is relevant. Subagents pre-define what is relevant for each domain.
+
+**Wrong definitions.** The finance team's definition of "net revenue" (gross minus refunds, locked FX rates) is not the operations team's definition (gross minus chargebacks, spot rates). A general-purpose agent with access to both will pick one arbitrarily—or produce a confused average. Subagents constrain the agent to the definitions that matter for its domain.
+
+**No guardrails.** A general-purpose agent with warehouse access can query any table, join any path, and reference any metric. It can expose PII to the wrong user. It can use deprecated tables that produce silently wrong results. It can join through paths that create duplicate rows. Subagents scope access to approved tables, join paths, and metrics—and exclude everything else.
+
+## 2. What a subagent contains
+
+A subagent is defined by its scope. A typical scope for a domain-specific subagent:
+
+| Component | Typical size | Purpose |
+|---|---|---|
+| **Tables** | ~10 | The physical tables relevant to the domain. Marketing subagent: `campaigns`, `ad_spend`, `attribution`, `channels`, `customer_segments`. |
+| **Metrics** | ~20 | Curated metric definitions drawn from the context engine. Marketing: `cac`, `roas`, `ctr`, `conversion_rate`, `ltv`. Each with its formal definition (calculation, filters, grain). |
+| **Validated SQL** | ~30 | Proven query patterns the domain's team has upvoted or the engineer has manually promoted. The subagent adapts these patterns rather than generating from scratch. |
+| **Business rules** | 5-10 | Standing constraints the subagent must follow. "Always filter `is_test = false`." "Join to `dim_customer` through `customer_id`, not `account_key`." "Never query `employee_salaries` table." |
+| **Domain description** | 1 paragraph | Natural-language description of what the subagent can answer—so users know its scope before typing a question. |
+
+This scope is not static. As the domain evolves—new tables, updated metric definitions, changing business rules—the engineer updates the scope. As users provide feedback—upvoting correct queries, reporting issues—the context engine updates the validated SQL and business rules automatically.
+
+## 3. The subagent lifecycle: from exploration to API
+
+A subagent is not created in a single step. It evolves through a lifecycle:
+
+### Stage 1: Ad-hoc exploration
+
+An engineer notices a recurring pattern of data requests from one team—marketing keeps asking for campaign performance numbers, each time with slightly different parameters. The engineer explores the relevant tables (`@catalog`), inspects their schemas (`@table campaigns`), and runs a few ad-hoc queries to understand the data landscape.
+
+### Stage 2: Generate context
+
+The engineer runs `/gen_semantic_model` on the relevant tables to generate business semantics—which columns are metrics vs. dimensions, how tables relate. Runs `/gen_metrics` to extract candidate metrics from historical SQL. Reviews and curates the output: accepts some, corrects others, rejects the rest.
+
+### Stage 3: Configure scope
+
+The engineer runs `.subagent add`, selects ~10 tables, ~20 metrics, and adds 5-10 business rules. Writes a domain description: "Answers questions about campaign performance, channel attribution, and marketing spend across paid and organic channels." The subagent is now a scoped, queryable chatbot.
+
+### Stage 4: Deploy and collect feedback
+
+The engineer shares the subagent link with the marketing team. Marketing asks questions. Correct answers get upvoted—the context engine strengthens the patterns. Wrong answers get reported—the engine updates the rules. Corrections compound: the tenth query is more accurate than the first.
+
+### Stage 5: Refine and mature
+
+After a period of active use, the engineer reviews feedback patterns, promotes validated rules into the formal context store, and expands the scope to cover edge cases that emerged from usage. Accuracy should be measured against the team's own recurring query patterns rather than assumed from a generic benchmark.
+
+### Stage 6: Export as API
+
+When the subagent is mature—high accuracy, stable scope, low rate of corrections—it can be exported as an HTTP API. Other systems (dashboards, internal tools, downstream agents) query the API to get grounded, accurate answers. The subagent has graduated from a chatbot to an infrastructure service.
+
+This lifecycle reflects a broader philosophy about how data work should scale: an engineer builds context, an agent delivers it, users refine it, and the system gets more valuable the longer it runs. For more on this philosophy, see [one-person data team](/posts/one-person-data-team).
+
+## 4. Why subagents are the right delivery unit
+
+The industry has converged on several candidate delivery models for data engineering agents:
+
+**The universal agent.** One agent with full warehouse access. Users ask anything. Problem: accuracy degrades as scope grows; access control is binary (all or nothing); metric drift is inevitable.
+
+**The per-query prompt.** Users write a natural-language prompt for each query. The agent generates SQL, executes it, returns results. Problem: no shared context; every query starts from zero; corrections do not survive sessions.
+
+**The dashboard copilot.** An agent embedded in a BI tool, answering questions about the data behind a specific dashboard. Problem: limited to one dashboard's scope; cannot answer cross-domain questions; tied to a specific BI vendor.
+
+**The subagent.** A scoped, shareable chatbot for one domain. Users ask domain-specific questions. The subagent retrieves from curated context. Corrections feed back into the shared context engine. Other subagents for other domains draw from the same engine but are constrained to their scope.
+
+Subagents win on three dimensions that matter for sustained, team-scale data work:
+
+- **Accuracy**: curated scope → less noise → more accurate answers.
+- **Access control**: scope defines the boundary → finance subagent cannot access HR data.
+- **Delivery**: non-engineers get a purpose-built chatbot with a clear domain description, not a general-purpose agent they do not know how to prompt.
+
+## 5. The subagent portfolio pattern
+
+Mature organizations do not run one subagent. They run a portfolio: finance, marketing, operations, product, each with its own scope, each drawing from the same context engine, each maintained by the engineer closest to that domain.
+
+The portfolio pattern creates organizational leverage. The context engine accumulates institutional knowledge across all domains—a validated join path discovered by the finance subagent benefits the operations subagent if they share the same table. The feedback loop operates at the engine level: corrections in one subagent improve accuracy across all subagents that reference the same context. The engineer's role shifts from answering individual questions to maintaining the portfolio—reviewing feedback, curating metrics, expanding scope as domains evolve.
+
+This is the scaling model that separates a data engineering agent from a SQL copilot. A copilot helps one person write one query. A subagent portfolio helps an organization turn data knowledge into a shared, governed, continuously improving asset.
+
+## 6. Getting started with subagents
+
+The fastest path from zero to a working subagent:
+
+1. **Pick one domain** that generates the most repetitive data requests. Finance, marketing, or operations.
+2. **Bootstrap context** from what already exists: historical SQL files, documented metric definitions, existing dbt models or semantic layers.
+3. **Create the subagent** with a tight initial scope—start with 5 tables and 10 metrics, not 50 tables. Accuracy is usually easier to evaluate and improve with a narrow scope.
+4. **Share it** with one trusted user in that domain. Collect their feedback. Refine the scope. Expand only after the subagent is handling common queries reliably.
+5. **Add the next domain** when the first subagent is mature.
+
+The pattern compounds: each subagent makes the context engine stronger, which makes the next subagent easier to create. The tenth subagent takes a fraction of the time the first one took.
+
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see the subagent lifecycle in action—connect a warehouse, create a scoped subagent, and share it with a teammate. Or follow the [15-minute tutorial](/posts/build-your-first-data-engineering-agent) to build one from the CLI.
+
+## Frequently asked questions
+
+### How is a subagent different from a ChatGPT custom GPT?
+
+A custom GPT is a prompt with instructions for a general-purpose LLM. It has no persistent data context, no connection to your warehouse, and no feedback loop that improves accuracy over time. A subagent is a scoped interface to a context engine that has accumulated validated SQL, business rules, and usage patterns from your actual warehouse. Custom GPTs help with general tasks; subagents deliver grounded, domain-specific answers backed by your team's institutional knowledge.
+
+### How many subagents should a team have?
+
+Start with one. Add a second when the first is handling common queries reliably. Most mid-size organizations stabilize at 5-10 subagents covering the core business domains (finance, marketing, operations, product, sales). The limit is not technical—it is maintenance. Each subagent requires periodic review of feedback, scope updates, and metric curation. A single engineer can maintain 5-10 subagents as part of their normal workflow.
+
+### Can subagents from different domains share context?
+
+Yes—that is the point of the shared context engine. A validated join path between `customers` and `orders`, discovered and upvoted by the finance subagent's users, becomes available to the marketing subagent the next time it generates a query involving those tables. The context engine is the shared source of truth. Subagents are scoped views into it. The feedback loop operates at the engine level, so corrections in one domain improve accuracy across all domains that share the same underlying tables and metrics.
+
+### What if a user asks a subagent a question outside its domain?
+
+A well-scoped subagent should recognize out-of-scope questions and respond with its domain description rather than attempting to answer. "I am scoped to marketing analytics—campaign performance, channel attribution, and marketing spend. For questions about revenue forecasting, please use the Finance subagent." This is better than a wrong answer and better than silence—it redirects the user to the right tool.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
+- [Contextual data engineering](/posts/contextual-data-engineering) — the context model that powers subagents
+- [One-person data team](/posts/one-person-data-team) — how subagents scale a solo engineer's output

--- a/blog/posts/what-is-data-engineering-agent-2026.md
+++ b/blog/posts/what-is-data-engineering-agent-2026.md
@@ -1,0 +1,169 @@
+---
+title: "What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison"
+description: "Four products now ship as a data engineering agent — but they are not the same thing. Working definition, side-by-side comparison, and where persistent context separates agents from chat windows."
+author: "John Smith"
+date: 2026-05-31
+lastmod: 2026-05-31
+head:
+  - - meta
+    - name: keywords
+      content: "data engineering agent, AI data engineering agent, what is a data engineering agent, data agent, open source data engineering agent, data engineering agent vs SQL copilot"
+  - - meta
+    - property: og:title
+      content: "What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison"
+  - - meta
+    - property: og:description
+      content: "Four products now ship as a data engineering agent — but they are not the same thing. Working definition, side-by-side comparison, and where persistent context separates agents from chat windows."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/what-is-data-engineering-agent-2026
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/what-is-data-engineering-agent-2026
+---
+
+# What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison
+
+Four very different products now ship as a **data engineering agent** — Google BigQuery, Adobe Experience Platform, the Claude Code *data-engineer* subagent, and the open-source <a href="https://github.com/Datus-ai/Datus-agent" rel="nofollow noopener">Datus agent</a>. Read their docs back-to-back and the surface promise sounds identical — "describe what you want, the agent builds it." Run them, and the experiences barely overlap. This guide defines the category honestly: what AI data engineering agents actually do, where they differ, and which problems the label is really trying to solve.
+
+## TL;DR
+
+- A **data engineering agent** turns natural-language intent into **executable data work** — SQL, transformations, pipelines, quality checks — against a **real stack**, with enough context to skip translating every column name by hand.
+- All four examples share basics (NL→SQL, schema inspection, multi-step plans) — but diverge on **environment lock-in**, **execution**, and especially **persistent context**.
+- **Platform-embedded** agents (BigQuery, Adobe) excel when your entire data life lives inside one vendor.
+- **Prompt-as-agent** recipes (Claude Code subagent) excel for ad-hoc local work with no infrastructure setup.
+- **Open-source frameworks** (Datus) target plural stacks and treat **context as the product** — the agent that outlives a single warehouse and quarter.
+
+In practice, the four products competing for the label today are not the same thing: one is a cloud feature, one is a SaaS capability, one is an agent persona, and one is an open-source agent framework. Here is how to tell them apart.
+
+## 1. Data engineering agent: a working definition
+
+"Data engineering agent" is a phrase that started showing up in product launches around late 2024, and by 2026 four very different things wear the label: Google's <a href="https://docs.cloud.google.com/bigquery/docs/data-engineering-agent-pipelines" rel="nofollow noopener">BigQuery Data Engineering Agent</a>, Adobe's <a href="https://business.adobe.com/blog/unlock-your-datas-full-potential-with-adobe-data-engineering-agent" rel="nofollow noopener">Data Engineering Agent</a> inside Experience Platform, a community-maintained <a href="https://github.com/VoltAgent/awesome-claude-code-subagents/blob/main/categories/05-data-ai/data-engineer.md" rel="nofollow noopener">Claude Code "data-engineer" subagent</a>, and the open-source Datus project. Read their docs back-to-back and the surface promise sounds identical — "describe what you want, the agent builds it." Run them, and the experiences barely overlap.
+
+Strip the marketing away and the useful working definition is narrower than any single vendor implies. A data engineering agent is software that does four things together:
+
+1. **Understands intent in natural language** — a question, a goal, a half-written specification — instead of requiring a complete DDL or DAG up front.
+2. **Produces executable data artifacts** — SQL queries, transformations, pipeline definitions, schema changes, test cases — not just prose explanations.
+3. **Operates against a real stack** with credentials and side effects: a warehouse, a lakehouse, a catalog, an orchestrator. Agents that only suggest code in a chat window are copilots, not engineering agents.
+4. **Carries reusable context across runs** — past queries, schema knowledge, metric definitions, business rules — so the second task is cheaper than the first.
+
+That fourth point is where most of the disagreement hides, and the rest of this piece is mostly about it. A SQL copilot that forgets your metric definitions after every session fails the fourth test even if it writes brilliant one-off queries.
+
+## 2. What every data engineering agent does
+
+Before pulling them apart, it's worth being precise about what the four agents legitimately share. Each one will, in some form:
+
+- **Translate natural language to SQL or pipeline code.** "Build me a daily revenue model joined to customer segments" is a valid input.
+- **Inspect schema metadata** from a target system to ground its suggestions — column names, types, lineage where available.
+- **Compose multi-step plans**: choose tables, draft a query, run it, react to errors, refine, and present a result.
+- **Reduce repetitive engineering toil** — boilerplate joins, type casts, partition predicates, basic transformations.
+- **Use an LLM as the planner**, not just as a text-generation endpoint, with at least one feedback step before the answer is returned.
+
+If you stopped reading here, you would walk away believing "data engineering agent" is one product category. The differences only become obvious when you ask the boring questions: who is allowed to call it, what does it actually have access to, and what does it remember tomorrow?
+
+## 3. A tour of today's data engineering agents
+
+### Google BigQuery Data Engineering Agent
+
+Google's offering is a managed capability inside BigQuery Studio and Dataform. It generates and edits pipeline code, suggests schema designs, and is wired to Google's Knowledge Catalog (formerly Dataplex) for grounding. Its strength is being absolutely native to its host: lineage, IAM, and billing all just work because everything happens inside one cloud. Its limit is the same fact — the agent is a feature *of* BigQuery, not a tool that travels with you. If your stack is Snowflake, Databricks, or anything on-premise, this agent is not the answer.
+
+### Adobe Data Engineering Agent
+
+Adobe's agent lives inside Adobe Experience Platform and targets a specific persona: customer-data engineers building audiences, schemas, and pipelines for marketing activation. It plans transformations, builds AEP data flows, and orchestrates work inside Adobe's own catalog. The framing is genuinely different from Google's — this is a vertical SaaS agent built for teams whose "warehouse" is AEP itself. Outside that world the product doesn't apply, and that is by design. (Note: Adobe's public materials describe the agent's capabilities in future-forward language — it is an announced product with an evolving GA timeline, not a multi-year GA product like BigQuery's agent.)
+
+### Claude Code data-engineer subagent
+
+The Claude Code variant is a persona configuration for Anthropic's Claude Code CLI agent — when loaded, it instructs Claude to act as a data engineer, designing pipelines, orchestration patterns, and Spark/Airflow-adjacent work against whatever files and credentials are visible in the local shell. It is the most stack-agnostic of the four: no warehouse lock-in, no platform dependency, just a terminal and an LLM. It is also the most ephemeral. Claude Code's tool-use architecture handles execution capably, but there is no dedicated context store for data artifacts, and session state does not persist between invocations in the way a data engineering team needs — schema knowledge, validated SQL, metric definitions, and business rules must be re-established or reloaded each time.
+
+### Datus — the open-source data engineering agent
+
+Datus is an open-source agent framework built around a persistent **Context Engine**. It runs as a CLI, a chat interface, an API, or a hosted Studio, and it connects to warehouses (Snowflake, StarRocks, BigQuery, DuckDB, Postgres, and more) rather than living inside one. The interesting part is structural: every artifact the agent touches — SQL it has written, schemas it has inspected, semantic definitions, validated metrics, even past business questions — becomes a recallable, evolvable asset for the next run. Datus is licensed Apache 2.0 and self-hostable, with a managed cloud as an option. In one published production deployment — a Lakehouse integration — self-service analytics rates rose from 15% to 60% and ad-hoc query time dropped from 30 minutes to 3 minutes.
+
+## 4. Data engineering agents compared, side by side
+
+Lined up against each other, the four agents diverge on almost every axis that matters operationally.
+
+| Dimension | BigQuery DEA | Adobe DEA | Claude Code subagent | Datus |
+| --- | --- | --- | --- | --- |
+| Product form | Managed cloud feature | Announced SaaS capability | CLI agent persona | Open-source agent framework |
+| Scope | BigQuery + Dataform | Adobe Experience Platform | Whatever is local | Stack-agnostic warehouses |
+| Environment | GCP console | AEP UI | Terminal (Claude Code) | CLI · Chat · API · Studio |
+| Target user | GCP data engineers | Adobe martech teams | Individual developers | Data + platform teams |
+| Open source | No | No | Prompt only | Apache 2.0 |
+| Persistent context | Knowledge Catalog | AEP platform state | None (no dedicated data store) | Context Engine |
+| Executes pipelines | Generates; review-then-run | Yes, inside AEP | Yes, via tool use | Yes, workflow mode |
+| AI / LLM | Gemini | Sensei GenAI (Adobe AI platform) | Claude | Pluggable (multi-model) |
+
+*Table notes: Adobe's agent has been announced with "will soon" language in official materials — its GA timeline differs from the other three. BigQuery's agent generates pipeline code within a human-in-the-loop review flow; "Generates; review-then-run" reflects that nuance more accurately than a binary yes/no. "None (no dedicated data store)" for Claude Code means no persistent first-class data engineering memory layer — it does not mean Claude Code is stateless.*
+
+The table reads as a single market only if you squint. Three of the four agents are bound to a specific environment — a cloud, a SaaS, or a CLI — and one is bound to none. Three of them treat "context" as whatever the host platform happens to know, and one treats context as the product itself.
+
+## 5. Four categories of data engineering agent, one label
+
+A cleaner way to think about the space is to stop comparing the four head-to-head and place them in different categories altogether. Each one is best-in-class at a different job.
+
+- **Platform-embedded agents** (BigQuery, Adobe) make the host platform faster to use. They're the right answer when your entire data life happens inside that platform and you want zero new vendors, no new credentials, and the agent's context to ride on the platform's existing metadata.
+- **Prompt-as-agent recipes** (Claude Code data-engineer) make a general-purpose coding agent behave like a data engineer for an afternoon. They're the right answer for one-off, local, exploratory work where setting up real infrastructure would cost more than the task itself.
+- **Vertical SaaS agents** (Adobe's offering is the clearest example) bring agentic workflows to a specific business function. They're the right answer when the platform *is* the customer's system of record.
+- **Open-source agent frameworks** (Datus) treat the agent as infrastructure that lives *between* tools rather than inside one. They're the right answer when you have more than one warehouse, more than one team, and more than one week of data work to do.
+
+None of these are wrong. Calling them all the same product is.
+
+## 6. Context is what separates a data engineering agent from a chat window
+
+If you only remember one thing from this article, make it this: the deepest split between today's data engineering agents is not UI or pricing or which LLM they use. It is how they handle *context*.
+
+Data engineering is a long-running discipline. The same warehouse is queried thousands of times. The same metrics get re-derived in slightly different shapes. The same join keys, partitioning quirks, and "don't use this column, it was deprecated in March" footnotes show up in every other ticket. A human engineer accrues this knowledge in their head, in a runbook, in a wiki page nobody reads. An agent without anywhere to put that knowledge has to rediscover it on every run.
+
+Platform-embedded agents partially solve this by leaning on their host's catalog. That works for schema metadata; it does not cover validated SQL, business definitions, or the institutional memory of which queries were trusted. Prompt-based agents don't solve it at all — they begin every session in the same blank state.
+
+A context-first agent treats every successful run as training data for the next one. The semantic model grows. The library of validated metrics grows. The set of business rules the agent will never violate grows. Over weeks, the agent stops being a chatty SQL writer and starts being something closer to a junior engineer who has actually worked on your codebase. For what "semantic layer" means in this stack — and how it differs from a metric layer or catalog — see [what is a semantic layer](/posts/what-is-semantic-layer). Datus describes this broader approach as contextual data engineering — treating data context as a first-class, evolvable asset rather than a one-time modeling exercise.
+
+> An agent without persistent context is a clever stranger. An agent with persistent context is a coworker.
+
+This is also why the category will, eventually, consolidate around the agents that own their own context layer. Platform agents will keep getting smarter inside their walls. Prompt agents will keep being useful for ad-hoc work. But the load-bearing "data engineering agent" for a real organization needs to outlive a single warehouse, a single quarter, and a single set of credentials. Gartner's 2025 Hype Cycle for Artificial Intelligence placed AI Agents and AI-Ready Data at the Peak of Inflated Expectations — the category is at peak noise, and the agents that ship durable context infrastructure before the trough will define the post-hype standard.
+
+## 7. Where Datus, the open-source data engineering agent, fits
+
+Datus is aimed at the fourth category: open source, stack-agnostic, built around a Context Engine that turns validated SQL, schemas, semantic models, and domain rules into a shared, evolvable asset. Subagents — scoped chatbots drawn from that context — let teams ship domain-specific data agents without retraining a model from scratch.
+
+None of this makes Datus the right answer for every team. If you're entirely on BigQuery and never plan to leave, Google's agent is closer to home. If your entire data world is AEP, Adobe's agent is closer to home. If you want a clever assistant for an evening of exploratory work, the Claude Code subagent is closer to home. Datus is for the case where the data stack is real, plural, and durable — and where you want an agent that accumulates knowledge instead of forgetting it.
+
+In other words: the four products called "data engineering agent" today answer four different questions. The most important question they collectively raise is the one Datus is trying to answer head-on — *where does the agent's memory live?*
+
+## Conclusion
+
+"Data engineering agent" is a useful label, but in 2026 it covers at least four different products with four different ambitions. Google's BigQuery Data Engineering Agent makes one warehouse faster. Adobe's makes one SaaS faster. The Claude Code subagent turns a generalist coding assistant into a data engineer for an evening. Datus treats the agent as durable infrastructure that lives between tools, with persistent context as its first-class primitive.
+
+If you are evaluating a data engineering agent today, the most honest question is not "which one is smartest?" but "whose memory do I want my data work to accumulate in?" The answer determines whether you are buying a feature, renting a workflow, borrowing a prompt — or building an asset. Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> — connect a warehouse, ask a question, and watch the Context Engine fill in.
+
+## Frequently asked questions
+
+### What is a data engineering agent, in one sentence?
+
+A **data engineering agent** is AI software that turns natural-language goals into executable data work — SQL, pipelines, schema changes, quality checks — against your real warehouse or lakehouse, using persistent context so it does not start from zero every time.
+
+### How is a data engineering agent different from a SQL copilot or text-to-SQL tool?
+
+A **SQL copilot** or **text-to-SQL** tool typically generates a query and stops. A **data engineering agent** also plans multi-step work, operates with credentials against live systems, and — critically — retains reusable context (schemas, metrics, validated SQL, business rules) across sessions. Copilots answer questions; agents accumulate institutional knowledge.
+
+### How do I evaluate which type of data engineering agent fits my team?
+
+Start with two questions about your stack. **Single warehouse or plural?** If everything lives inside one platform (BigQuery-only, Snowflake-only), a platform-embedded agent is the path of least resistance. If you have two or more warehouses, a lakehouse, or plans to add one, you need a stack-agnostic agent or a context layer that travels. **Ad-hoc or durable?** If the work is exploratory and session-bounded, a prompt-based agent works. If the same metrics, schemas, and rules will be queried thousands of times across months, you need persistent context — a system that remembers. The four-category breakdown in this guide (platform-embedded, prompt-as-agent, vertical SaaS, open-source framework) maps to these two axes.
+
+### What does an agent need to know about my data to be useful?
+
+More than column names. A useful data engineering agent needs four layers of context: **schema metadata** (tables, columns, types, join keys), **business semantics** (what "revenue" means, which dimensions are valid, which tables are deprecated), **validated SQL** (proven queries it can reuse and adapt rather than generating from scratch), and **feedback history** (which past outputs were trusted, which were corrected, and why). Without the last two layers, every query is a first attempt — and data engineering is not a discipline where first attempts are usually right.
+
+## Related articles
+
+- [What is a semantic layer?](/posts/what-is-semantic-layer) — definitions, implementations, and how semantics relate to agents

--- a/blog/posts/what-is-semantic-layer.md
+++ b/blog/posts/what-is-semantic-layer.md
@@ -1,0 +1,235 @@
+---
+title: "What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer"
+description: "Semantic layer defined: the business translation layer between raw tables and analysts, what it includes (metrics, dimensions, entities), how it differs from metric layers and catalogs, and why static models break under AI agents."
+author: "Evan Paul"
+date: 2026-05-31
+lastmod: 2026-05-31
+head:
+  - - meta
+    - name: keywords
+      content: "semantic layer, what is a semantic layer, semantic layer definition, semantic layer data engineering, semantic layer vs metric layer, headless BI semantic layer, metric layer"
+  - - meta
+    - property: og:title
+      content: "What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer"
+  - - meta
+    - property: og:description
+      content: "Semantic layer defined: the business translation layer between raw tables and analysts, what it includes (metrics, dimensions, entities), how it differs from metric layers and catalogs, and why static models break under AI agents."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/what-is-semantic-layer
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/what-is-semantic-layer
+---
+
+# What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer
+
+A **semantic layer** is a business representation of data that maps physical tables and columns to stable business concepts — metrics, dimensions, entities, and relationships — so analysts and applications can query by *revenue* and *region* instead of `fact_orders.amount_usd` and `dim_geo.region_code`. It sits between raw storage and every consumer of data: BI tools, APIs, notebooks, and increasingly **AI agents**. This glossary entry gives a practical definition, walks through common implementations, and explains where semantic layers end — and where a [data engineering agent](/posts/what-is-data-engineering-agent-2026) that *operationalizes* those definitions begins.
+
+## TL;DR
+
+- A **semantic layer** translates **physical schema** into **business language** — metrics, dimensions, entities, joins, and access rules — so consumers do not re-derive logic on every query.
+- It is **not** a data catalog (discovery metadata), **not** a warehouse (storage), and **not** always the same as a **metric layer** (metrics-only subset).
+- Common implementations include <a href="https://docs.getdbt.com/docs/build-about-metricflow" rel="nofollow noopener">dbt Semantic Layer / MetricFlow</a>, <a href="https://cube.dev/" rel="nofollow noopener">Cube</a>, LookML, and warehouse-native semantic models.
+- Most semantic layers are **static at runtime** — defined once, versioned in Git, consumed by BI. AI agents expose a new requirement: semantics that **evolve with validated SQL, feedback, and usage**.
+- Datus does not replace semantic layers — it **sits above and around them**, helping teams build, strengthen, and put semantic definitions to work in agents and workflows.
+
+## 1. Semantic layer: a working definition
+
+In plain terms, a semantic layer answers three questions that raw tables leave open:
+
+1. **What does this number mean?** — e.g. "Net revenue" excludes refunds and uses USD at daily FX rates locked at close.
+2. **How do I slice it?** — e.g. by region, product line, customer segment, or fiscal quarter.
+3. **How do tables connect?** — e.g. which join keys are authoritative, which tables are deprecated, which grain each metric requires.
+
+Without that layer, every analyst, dashboard, and agent must rediscover join paths and metric logic independently. The result is inconsistent KPIs, duplicated SQL, and — in the AI era — confident wrong answers from models that see column names but not business meaning.
+
+A useful working definition: a **semantic layer** is software (or a governed specification) that exposes **curated business objects** — primarily **metrics** and **dimensions** — backed by physical tables, with enough metadata for downstream tools to generate correct queries without exposing raw schema complexity.
+
+That definition is intentionally broader than any single vendor. LookML in Looker, MetricFlow in dbt, Cube's semantic model, Snowflake Semantic Views, and Power BI datasets all implement the same job with different runtimes and governance models.
+
+## 2. What a semantic layer contains
+
+Most mature semantic layers include overlapping components. Names vary by product, but the concepts recur:
+
+| Component | Role | Example |
+| --- | --- | --- |
+| **Entities / objects** | Business nouns the organization cares about | `Customer`, `Order`, `Subscription` |
+| **Dimensions** | Attributes you group or filter by | `region`, `plan_tier`, `acquisition_channel` |
+| **Metrics / measures** | Aggregated business quantities with defined logic | `net_revenue`, `active_users_28d`, `gross_margin_pct` |
+| **Relationships / joins** | How entities connect at the correct grain | `Order.customer_id → Customer.id` (many-to-one) |
+| **Time semantics** | Which timestamp defines "when" for a metric | `order_completed_at` vs `recognized_revenue_date` |
+| **Access & governance** | Row-level rules, PII boundaries, certified vs draft metrics | "Analysts see aggregated revenue only" |
+
+**Semantic layer vs metric layer:** A **metric layer** is often used to mean the metrics-focused subset of a semantic layer — standardized KPI definitions consumable by headless BI APIs. Not every semantic layer is metric-only (some emphasize exploratory dimensions and entities first), but in practice the terms overlap heavily, and many products use "metric layer" as shorthand for the metrics portion of a broader semantic model.
+
+**Semantic layer vs data catalog:** A **data catalog** inventories assets — tables, columns, owners, lineage tags — for human discovery. A semantic layer *consumes* catalog metadata but adds **executable business logic**. You can have a rich catalog and still lack a semantic layer if every metric is defined ad hoc in SQL.
+
+## 3. Why organizations build semantic layers
+
+The motivation is rarely "we need another abstraction." It is usually one of these failure modes:
+
+- **Metric drift** — Finance and Product both report "revenue" with different filters; leadership stops trusting dashboards.
+- **Join ambiguity** — Three paths connect users to subscriptions; only one is correct for churn, but nothing documents which.
+- **Analyst toil** — Senior analysts spend half their week rewriting the same CTEs for junior teammates and BI developers.
+- **Tool sprawl** — Snowflake, BigQuery, Postgres, and a lakehouse each expose raw tables; BI tools multiply incompatible definitions.
+- **AI readiness** — Text-to-SQL and chat BI fail when models see `amt_usd_net_v2` without a governed mapping to "net revenue."
+
+Semantic layers centralize that logic so **definition happens once** and **consumption happens many times** — through Looker explores, Cube APIs, dbt metrics, or agent-generated SQL grounded in the same YAML. Three signals suggest this pattern is becoming infrastructure rather than optional: dbt Labs shipped MetricFlow as a standard semantic specification (2023), Cube crossed ~20K GitHub stars with paying customers using its headless semantic API in production, and warehouse-native semantic features are emerging across cloud platforms — Snowflake Semantic Views being the clearest example. Governed business definitions are no longer a nice-to-have abstraction; they are the table stakes for any team running more than one consumption surface.
+
+## 4. Common semantic layer implementations
+
+### dbt Semantic Layer / MetricFlow
+
+<a href="https://docs.getdbt.com/docs/build-about-metricflow" rel="nofollow noopener">MetricFlow</a> (dbt Semantic Layer) defines metrics in YAML atop dbt models — dimensions, measures, and derived metrics with explicit grain. A minimal example:
+
+```yaml
+semantic_model:
+  name: orders
+  measures:
+    - name: net_revenue
+      expr: sum(revenue_usd) - sum(refund_usd)
+  dimensions:
+    - name: region
+      type: categorical
+      expr: dim_geo.region_name
+```
+
+Strength: metrics live in the same repo as transformations; weakness: still primarily **engineer-maintained** and **batch-updated** through PRs — a new ad-hoc query that surfaces a missing dimension or edge case has no path back into this YAML until an engineer opens a PR. This gap is the central tension between static semantic layers and agent-driven data work.
+
+### Cube
+
+<a href="https://cube.dev/" rel="nofollow noopener">Cube</a> exposes a headless semantic layer with SQL, REST, and GraphQL APIs — popular for embedded analytics and, increasingly, agentic analytics. Strength: mature multi-source semantic models and caching; teams should validate how quickly models incorporate production feedback loops.
+
+### LookML (Looker / Google Cloud)
+
+LookML defines dimensions, measures, and join relationships in a Looker project. Strength: deep integration with Looker's exploration UI; weakness: historically tied to the Looker stack — LookML semantics are deeply integrated with Looker's exploration engine, and while Looker's API can expose metric definitions externally, teams evaluating multi-tool architectures should verify the portability path before committing.
+
+### Warehouse-native semantic models
+
+Snowflake Semantic Views, BigQuery semantic layers, and similar platform features embed semantics closer to storage. Strength: IAM and performance co-location; weakness: **platform lock-in** — semantics do not travel when you add a second warehouse.
+
+### Roll-your-own: views + docs + metric repo
+
+Many teams start with **dbt docs**, **curated views**, and a spreadsheet of metric definitions. That is a semantic layer in spirit if not in product name — and it often breaks first when AI agents need machine-readable, validated context at query time.
+
+## 5. Static semantic layers and the AI agent gap
+
+Traditional semantic layers assume a **publish cycle**: engineers define metrics → review in Git → deploy → BI and APIs consume. That works when humans are the primary consumers and change is slow.
+
+**Data engineering agents** change the consumption pattern. Agents generate SQL continuously — ad-hoc questions, pipeline drafts, quality checks — and learn from successes and failures at a pace PR workflows were not designed for. Gaps appear quickly:
+
+| Static semantic layer handles… | Agents also need… |
+| --- | --- |
+| Certified metric YAML | **Validated ad-hoc SQL** that never became a formal metric |
+| Schema at last deploy | **Footnotes** — "don't use `status` before March; use `status_v2`" |
+| Documented joins | **Reference queries** that proved correct in production |
+| Versioned breaking changes | **Feedback loops** — upvotes, issue reports, corrected runs |
+
+To make this concrete, here is a representative workflow that a team running both a semantic layer and an agent might follow:
+
+> An analyst asks "weekly net revenue by region, excluding test accounts." The agent generates SQL using the semantic layer's certified `net_revenue` metric and `region` dimension. The query returns results, but the analyst notices the numbers look low — test accounts were excluded by a `WHERE account_type != 'test'` filter, which the metric YAML does not encode because it lives in engineering tribal knowledge. The analyst reports the issue. An engineer adds the filtering rule to the agent's context (not yet to the certified semantic layer, which requires a PR cycle). On the *next* query for net revenue, the agent applies both the certified metric definition *and* the learned filtering rule. Weeks later, during a quarterly modeling sprint, the engineer promotes the rule into the formal semantic layer YAML so all consumers benefit — agents, dashboards, and APIs.
+
+The key point: the agent's context layer acts as a **fast feedback buffer** between ad-hoc discovery and formal governance. It does not replace the semantic layer — it makes the semantic layer stronger by pre-validating changes before they land in the certified model.
+
+This is why "semantic layer vs AI agent" is a false choice. Agents without semantics hallucinate joins. Semantic layers without agent feedback go stale. The durable pattern is **semantics plus evolvable context** — definitions that grow with usage, not only with quarterly modeling sprints.
+
+Datus approaches this through a dual-dimension **Context Engine**: a **physical catalog tree** (databases, schemas, tables) paired with a **logical subject tree** (business domains, metrics, reference SQL). Commands like `/gen_semantic_model` and `/gen_metrics` bootstrap semantics from existing tables and historical SQL; user feedback refines them over time. The semantic layer is not discarded — it becomes **living context** agents and Subagents can trust.
+
+## 6. Semantic layer vs data engineering agent: complementary roles
+
+From Datus positioning: **semantic layers define business logic; data engineering agents operationalize it.**
+
+| Layer | Primary job | Typical owner |
+| --- | --- | --- |
+| **Semantic layer** | Governed metrics, dimensions, join rules | Analytics engineering / central data platform |
+| **Data engineering agent** | Generate SQL, pipelines, tests; accumulate validated context | Data engineers + analysts via feedback |
+| **BI / Chat UI** | Present answers | Business users |
+
+Concrete compatibility paths:
+
+- **Already have MetricFlow or Cube** — Datus can ingest and reinforce those definitions, then wrap them in Subagents scoped to a domain's tables and metrics.
+- **No formal semantic layer yet** — Datus helps bootstrap one from schema inspection and historical SQL, then evolve it through `/gen_semantic_model` and `/gen_metrics`.
+- **Multiple semantic layers across tools** — Datus acts as a **cross-stack context orchestrator** rather than forcing re-platforming.
+
+In practice today, this means Datus ingests existing metric YAML (MetricFlow-compatible), generates new semantic models alongside them, and scopes Subagents to specific domain contexts. Full cross-layer orchestration — unified governance across Cube, MetricFlow, and LookML from a single control plane — is the architectural direction, not the shipped feature set.
+
+For the full agent-side definition, read [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+
+## 7. When you need a semantic layer — signals, not dogma
+
+Rough signals a semantic layer (or equivalent governance) is worth the investment:
+
+- **More than three definitions** of the same KPI exist across teams or tools.
+- **New hires** take weeks to learn which tables and filters are "the real ones."
+- **Self-serve BI** stalls not because of tool UX but because users cannot trust metric logic.
+- **You are rolling out AI query interfaces** and need grounded business terms, not raw schema dumps.
+- **Regulatory or finance review** requires traceable metric lineage.
+
+Signals you may defer a dedicated product — temporarily:
+
+- Single small warehouse, one BI tool, one analytics engineer who owns all logic.
+- Exploratory phase where metric definitions change daily and formalization would lag reality anyway — though you still need *some* capture mechanism before knowledge walks out the door.
+
+## 8. How to evaluate semantic layer options: a 5-factor framework
+
+**1. Consumption surface — who actually consumes the semantics?**
+
+BI-only environments (Looker, Power BI) are well served by LookML or warehouse-native models. Headless API consumption across multiple tools calls for Cube or MetricFlow. If your primary consumer is AI agents — not dashboards — you need a layer that exports machine-readable context, not just human-readable metric cards.
+
+**2. Update cycle — how do definitions stay current?**
+
+Git-only semantic layers (dbt Semantic Layer) work when changes are slow and review-gated: PR → merge → deploy. But when agents generate ad-hoc SQL daily and users provide feedback weekly, a purely Git-driven model lags reality. The emerging pattern is hybrid: human-authored definitions for certified metrics, with validated production SQL and feedback loops feeding back into context over time.
+
+**3. Multi-warehouse reality — will your semantics travel?**
+
+If your entire data estate lives in one warehouse, warehouse-native semantics are fine and simplest. If you run two warehouses today — or plan to add a lakehouse — you need either a warehouse-agnostic semantic layer or a context orchestrator that sits above them. Portability is not a theoretical concern; it becomes a migration project the moment a second data source appears.
+
+**4. Grain enforcement — can it prevent the most common join errors?**
+
+A practical test: ask three analysts to independently query "monthly revenue by region" through the semantic layer. If they get three different numbers, the layer is not enforcing grain correctly. The most expensive semantic layer failure is not missing metrics — it is silently wrong joins that no one catches until a board deck looks inconsistent.
+
+**5. AI readiness — how does it ground text-to-SQL?**
+
+The minimum bar is a machine-readable API. Better: machine-readable plus human-readable documentation, so both agents and analysts share the same definitions. The emerging standard: machine-readable definitions backed by validated production SQL and a feedback loop — so when an agent generates a wrong query, the correction flows back into the system rather than waiting for the next modeling sprint.
+
+## Conclusion
+
+A **semantic layer** is the governed business translation between physical data and every downstream consumer — dashboards, APIs, notebooks, and agents. It centralizes metrics, dimensions, and join logic so "revenue" means one thing across the organization. It is essential, but it is not the whole system: static YAML alone cannot capture every validated query, deprecation note, and feedback cycle that real data work produces.
+
+Teams building **AI-native data stacks** should treat semantic layers as **foundational definitions** and invest in **evolvable context** on top — the institutional memory that turns a semantic model from a snapshot into something agents can rely on week after week. That is the problem space Datus targets: not replacing Cube or MetricFlow, but helping you build, strengthen, and operationalize semantics across agents and workflows.
+
+## Frequently asked questions
+
+### What is a semantic layer in one sentence?
+
+A **semantic layer** is a governed mapping from physical database tables to stable business concepts — metrics, dimensions, and entities — so people and software can query data using business language instead of raw schema.
+
+### What is the difference between a semantic layer and a metric layer?
+
+A **semantic layer** typically includes entities, dimensions, joins, and metrics. A **metric layer** focuses on the **metrics subset** — standardized KPI definitions for headless BI and API consumption. Many products use "metric layer" as shorthand for the metrics portion of a broader semantic model.
+
+### What is the difference between a semantic layer and a data catalog?
+
+A **data catalog** documents what data exists — tables, columns, owners, tags, lineage for discovery. A **semantic layer** defines **how to compute and slice business metrics** correctly. Catalogs help you find data; semantic layers help you use it consistently.
+
+### When does a semantic layer become a bottleneck rather than an enabler?
+
+When the update cycle can't keep up. If your team ships metric changes weekly but the semantic layer requires a PR, review, merge, and deploy cycle that takes days, the layer becomes the slowest part of the stack. The signal: analysts start bypassing the semantic layer and writing raw SQL "just to get the answer," and within weeks you have two sources of truth — the governed one (stale) and the real one (ungoverned). A semantic layer that can't ingest feedback at the speed of actual data work is governance in name only.
+
+### Can I build a semantic layer incrementally, or does it need to be comprehensive from day one?
+
+Incrementally is the only way that sticks. Start with one team, one domain, and the five metrics they argue about most. Build definitions for those, enforce them in one BI tool or API surface, and prove that "revenue" now means one thing. Expand to adjacent domains once the pattern holds. The teams that fail are the ones that try to model the entire enterprise before shipping anything — by the time the model is complete, the business has changed and trust has already eroded elsewhere.
+
+## Related articles
+
+- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — how agents differ from copilots and where context fits


### PR DESCRIPTION
## Summary

Adds the SEO hub-and-spoke content cluster around **data engineering agent** + **semantic layer**, plus two new blog categories and a post byline.

- **13 new posts** under `blog/posts/` — the pillar (2026 comparison), concept pieces, `vs` comparisons, a 15-minute how-to, persona/enterprise scenarios, and technical deep-dives (Context Engine, MCP, Subagents).
- **Two new categories** — "Data Engineering Agent" and "Semantic Layer" — wired across all three hand-maintained registration points: sidebar (`config.mts`), home (`BlogHome.vue`), and All Posts (`posts/index.md`). "What is Datus" stays first.
- **Byline component** (`PostMeta.vue`) — renders author · publish date · reading time under each post's H1, reading from frontmatter via the `doc-before` slot. Only shows on posts that declare an `author`.

## Conversion details

- CMS-style frontmatter (`slug`/`category`/`related`/`image`) → repo's VitePress `head:` meta convention; `keywords` list → single meta.
- All `/blog/{slug}` cross-links rewritten to `/posts/{slug}`; pillar remapped to `what-is-data-engineering-agent-2026`.
- `og:image` defaults to the site logo (per-article hero images don't exist in the repo).
- Authors: John Smith (DE agent), Evan Paul (semantic layer), Harrison Zhao (one-person data team). Publish dates spread 2026-05-31 → 06-04.

## Verification

- `npm run blog:build` completes clean — VitePress fails the build on any dead internal link, so every rewritten `/posts/...` cross-link is validated.
- SSR output confirmed: each new page renders with the correct byline author/date; home shows the two new category sections; sitemap (VitePress-generated) includes the new slugs.

## Not included (follow-ups discussed, intentionally out of this PR)

- Updating the hand-maintained `src/public/sitemap.xml` with the 13 new URLs.
- Short-link redirects `/blog/{slug}` → `/blog/posts/{slug}` (pending a decision on canonical direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post metadata display showing author, publication date, and estimated reading time on blog articles.

* **Documentation**
  * Published 12 new blog articles covering data engineering agents, semantic layers, enterprise requirements, open-source options, and practical guides including a 15-minute build tutorial and product comparisons.
  * Reorganized blog navigation and homepage sections for improved discoverability of agent-focused content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->