### PR TITLE
Add Datus SQL trust workflow blog post

### DIFF
--- a/blog/.vitepress/config.mts
+++ b/blog/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
       {
         text: 'Data Engineering Agent',
         items: [
+          { text: 'SQL Was Never the Hard Part', link: '/posts/sql-was-never-the-hard-part' },
           { text: 'What Is a Data Engineering Agent? (2026 Comparison)', link: '/posts/what-is-data-engineering-agent-2026' },
           { text: 'What Is a Data Engineering Agent? (Practical Guide)', link: '/posts/what-is-data-engineering-agent' },
           { text: 'Contextual Data Engineering', link: '/posts/contextual-data-engineering' },

--- a/blog/.vitepress/theme/BlogHome.vue
+++ b/blog/.vitepress/theme/BlogHome.vue
@@ -3,6 +3,7 @@ import { withBase } from 'vitepress'
 
 // All posts with dates, sorted newest first — used to compute "latest"
 const allPosts = [
+  { title: 'SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust', description: 'Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation.', date: '2026-06-11', display: 'Jun 11, 2026', tag: 'Practice', link: '/posts/sql-was-never-the-hard-part' },
   { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', description: 'Four products now ship as a data engineering agent — but they are not the same thing. Definition, side-by-side comparison, and where persistent context separates agents from chat windows.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Research', link: '/posts/what-is-data-engineering-agent-2026' },
   { title: 'What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer', description: 'The business translation layer between raw tables and analysts: what it includes, how it differs from metric layers and catalogs, and why static models break under AI agents.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Glossary', link: '/posts/what-is-semantic-layer' },
   { title: 'Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context', description: 'Contextual data engineering explained: schemas, semantics, and feedback loops for durable data agents.', date: '2026-06-01', display: 'Jun 1, 2026', tag: 'Research', link: '/posts/contextual-data-engineering' },
@@ -67,6 +68,7 @@ const sections = [
     label: 'Data Engineering Agent',
     description: 'The category, the comparisons, and how to build with one — our core cluster.',
     posts: [
+      { title: 'SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust', date: 'Jun 11, 2026', link: '/posts/sql-was-never-the-hard-part' },
       { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', date: 'May 31, 2026', link: '/posts/what-is-data-engineering-agent-2026' },
       { title: 'What Is a Data Engineering Agent? A Practical Guide with Datus', date: 'Mar 2, 2026', link: '/posts/what-is-data-engineering-agent' },
       { title: 'Contextual Data Engineering: Why Every Agent Needs Evolvable Context', date: 'Jun 1, 2026', link: '/posts/contextual-data-engineering' },

--- a/blog/.vitepress/theme/BlogHome.vue
+++ b/blog/.vitepress/theme/BlogHome.vue
@@ -3,7 +3,7 @@ import { withBase } from 'vitepress'
 
 // All posts with dates, sorted newest first — used to compute "latest"
 const allPosts = [
-  { title: 'SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust', description: 'Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation.', date: '2026-06-11', display: 'Jun 11, 2026', tag: 'Practice', link: '/posts/sql-was-never-the-hard-part' },
+  { title: 'How Datus Turns AI-Generated SQL into Trusted Data', description: 'Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation.', date: '2026-06-11', display: 'Jun 11, 2026', tag: 'Practice', link: '/posts/sql-was-never-the-hard-part' },
   { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', description: 'Four products now ship as a data engineering agent — but they are not the same thing. Definition, side-by-side comparison, and where persistent context separates agents from chat windows.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Research', link: '/posts/what-is-data-engineering-agent-2026' },
   { title: 'What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer', description: 'The business translation layer between raw tables and analysts: what it includes, how it differs from metric layers and catalogs, and why static models break under AI agents.', date: '2026-05-31', display: 'May 31, 2026', tag: 'Glossary', link: '/posts/what-is-semantic-layer' },
   { title: 'Contextual Data Engineering: Why Every Data Engineering Agent Needs Evolvable Context', description: 'Contextual data engineering explained: schemas, semantics, and feedback loops for durable data agents.', date: '2026-06-01', display: 'Jun 1, 2026', tag: 'Research', link: '/posts/contextual-data-engineering' },
@@ -68,7 +68,7 @@ const sections = [
     label: 'Data Engineering Agent',
     description: 'The category, the comparisons, and how to build with one — our core cluster.',
     posts: [
-      { title: 'SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust', date: 'Jun 11, 2026', link: '/posts/sql-was-never-the-hard-part' },
+      { title: 'How Datus Turns AI-Generated SQL into Trusted Data', date: 'Jun 11, 2026', link: '/posts/sql-was-never-the-hard-part' },
       { title: 'What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison', date: 'May 31, 2026', link: '/posts/what-is-data-engineering-agent-2026' },
       { title: 'What Is a Data Engineering Agent? A Practical Guide with Datus', date: 'Mar 2, 2026', link: '/posts/what-is-data-engineering-agent' },
       { title: 'Contextual Data Engineering: Why Every Agent Needs Evolvable Context', date: 'Jun 1, 2026', link: '/posts/contextual-data-engineering' },

--- a/blog/posts/index.md
+++ b/blog/posts/index.md
@@ -22,7 +22,7 @@ The problem, the product, and the thesis behind it.
 
 The category, the comparisons, and how to build with one — our core cluster.
 
-- [SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust](/posts/sql-was-never-the-hard-part) — Jun 11, 2026
+- [How Datus Turns AI-Generated SQL into Trusted Data](/posts/sql-was-never-the-hard-part) — Jun 11, 2026
 - [What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison](/posts/what-is-data-engineering-agent-2026) — May 31, 2026
 - [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) — Mar 2, 2026
 - [Contextual Data Engineering: Why Every Agent Needs Evolvable Context](/posts/contextual-data-engineering) — Jun 1, 2026

--- a/blog/posts/index.md
+++ b/blog/posts/index.md
@@ -22,6 +22,7 @@ The problem, the product, and the thesis behind it.
 
 The category, the comparisons, and how to build with one — our core cluster.
 
+- [SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust](/posts/sql-was-never-the-hard-part) — Jun 11, 2026
 - [What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison](/posts/what-is-data-engineering-agent-2026) — May 31, 2026
 - [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) — Mar 2, 2026
 - [Contextual Data Engineering: Why Every Agent Needs Evolvable Context](/posts/contextual-data-engineering) — Jun 1, 2026

--- a/blog/posts/sql-was-never-the-hard-part.md
+++ b/blog/posts/sql-was-never-the-hard-part.md
@@ -1,0 +1,157 @@
+---
+title: "SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust"
+description: "Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation."
+date: 2026-06-11
+lastmod: 2026-06-11
+author: Datus Team
+tags:
+  - data engineering agent
+  - agentic data engineering
+  - SQL
+  - reconciliation
+head:
+  - - meta
+    - name: keywords
+      content: "AI-generated SQL, data engineering agent, agentic data engineering, SQL reconciliation, data quality, Datus workflow"
+  - - meta
+    - property: og:title
+      content: "SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust"
+  - - meta
+    - property: og:description
+      content: "Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:image
+      content: https://datus.ai/blog/images/sql-was-never-the-hard-part/datus-workflow.svg
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/posts/sql-was-never-the-hard-part
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - meta
+    - name: twitter:image
+      content: https://datus.ai/blog/images/sql-was-never-the-hard-part/datus-workflow.svg
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/posts/sql-was-never-the-hard-part
+---
+
+# SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust
+
+*Why we built data development around knowledge, plans, reviews, and reconciliation, not just generation.*
+
+Any LLM can write SQL today. Paste in a schema, describe a metric, and you get something that runs. That was never the hard part.
+
+The hard part is what data teams actually get paid for: understanding the business definition behind a metric, respecting the conventions buried in years of historical SQL, adapting logic across database dialects, handling NULLs the way the business expects, and then **proving the output reconciles with a trusted reference, row by row, column by column**.
+
+This is the gap between a text-to-SQL demo and a data engineer. Datus is built to close it. This post explains how, using a real development task as the running example: building a product adoption mart from Pendo-style usage events, then reconciling it against a reference table of 24,995 rows at sub-1e-9 numeric tolerance.
+
+The core idea is a workflow, not a model trick:
+
+![Datus data development workflow: knowledge, plan, review, execute, reconcile](/images/sql-was-never-the-hard-part/datus-workflow.svg)
+
+Five phases: initialize knowledge, plan and approve, review, execute, and reconcile. Each phase is enforced by a skill that constrains what the agent is allowed to do. The premise behind all five is simple: **"the SQL ran" is not done; "the SQL reconciles" is done.**
+
+## A Task Where the Details Bite
+
+To make the discussion concrete, consider the task we use throughout: build `marts.pendo__product_adoption_summary`, a table that tells Product and Customer Success teams which accounts have adopted which features, and how deeply. One row per **feature x account x application**, 13 output fields.
+
+Most of the columns are aggregations any model can write. The trouble is concentrated in two derived fields that no model can guess without reading the requirement.
+
+**Adoption level** classifies each row into five segments, evaluated in strict order:
+
+| Segment | Rule |
+|---|---|
+| Power Users | `active_days >= 20 AND total_events >= 100` |
+| Regular Users | `active_days >= 10 AND total_events >= 50` |
+| Casual Users | `active_days >= 5 AND total_events >= 20` |
+| Trial Users | `active_days >= 1 AND total_events >= 5` |
+| Minimal Users | everything else, including rows where `total_events` is NULL |
+
+**Feature health score** is a weighted composite, capped at 100, explicitly not rounded, and NULL when there are no non-null event counts:
+
+```text
+feature_health_score = total_users * 2 + avg_events_per_session * 5 + active_days * 3
+```
+
+Rule ordering. The cap. The no-rounding rule. NULL propagating through averages instead of collapsing to zero. These are exactly the details that silently diverge when SQL is generated from plausibility instead of from a requirement. A table that is 98% right is, for the business, simply wrong. Every phase of the workflow below exists to keep details like these from slipping through.
+
+## Phase 1: Knowledge Before Generation
+
+The first thing Datus does in a project is not write SQL. It reads the project's historical SQL: staging models, intermediate transforms, existing marts, and reference queries. Then it distills that work into a persistent, human-readable knowledge base: a project overview and asset index (`AGENTS.md`), extracted business rules and metric definitions, technical standards, and table- and field-level lineage.
+
+This step is what most AI-SQL demos skip, and it is why most of them do not survive contact with a real warehouse. A warehouse is not a blank schema; it is an accumulation of decisions. How feature history gets deduplicated. What a "session" means in this company. Which filters are always applied and never written down anywhere except in the SQL itself.
+
+After initialization, when Datus decides how to name a staging table or how to deduplicate a slowly changing source, it cites this knowledge base rather than its own habits. The knowledge base is also auditable: a human can read it and verify that the extraction was faithful before any of it influences generated code.
+
+## Phase 2: No SQL Before an Approved Plan
+
+The second rule is blunt: until a written plan is explicitly approved by a human, Datus will not write business SQL, create database objects, or modify ETL code.
+
+For our adoption mart, a plan worth approving has to state the requirement boundary, the full object chain from raw sources through staging to the target mart, the grain and all 13 fields, the segment rules and score logic, the job files to be created, and the validation approach.
+
+The point of the gate is economic. A misunderstanding caught at the plan stage costs one round of conversation. The same misunderstanding caught after execution costs a rerun; caught in production, it costs trust. The plan moves human judgment to where it is cheapest and forces ambiguity to surface as a question to the user rather than a guess inside a CTE.
+
+Datus's planning rules encode this directly: explore project knowledge and metadata first, ask only about what remains genuinely unknown, and never guess a business definition.
+
+## Phase 3: Review Before Execution
+
+Generated SQL is reviewed against the plan and the requirement before anything runs. Not a vague "looks good" pass, but a targeted check where each axis maps to a real failure mode we see in practice:
+
+| Review axis | The trap it catches |
+|---|---|
+| Requirement coverage | Segment rules evaluated in the wrong order, the 100-point cap forgotten, or a missing output field |
+| Dialect compatibility | Reference SQL written for one engine, such as DuckDB, carried verbatim into another, such as PostgreSQL |
+| NULL handling | Averages and scores returning 0 where the business definition says NULL |
+| Type consistency | A score that should be DOUBLE silently cast to integer, passing row-count checks but failing reconciliation |
+
+That last row is worth dwelling on. An integer-cast health score produces a table with the right shape, the right row count, and wrong numbers. Nothing about "the query succeeded" tells you this. Only review or reconciliation does.
+
+## Phase 4: Execution as a Controlled Step
+
+Execution is deliberately the most boring phase. Jobs live in version-controlled files, run through a consistent path, and are rerunnable. Historical reference SQL is read-only and never executed directly.
+
+Boring is the point. When reconciliation later demands a fix-and-rerun loop, rerunning must be safe and cheap.
+
+## Phase 5: Reconciliation Is the Definition of Done
+
+The final phase compares the generated mart against a trusted reference, and it is where the workflow shows its character. The comparison is strict: row counts, column-by-column equality, numeric tolerance, and bidirectional `EXCEPT` checks, both rows in the result but not the reference and rows in the reference but not the result.
+
+For the adoption mart, done means: 24,995 rows match, all 13 columns match, numerics agree within 1e-9, and both difference checks return zero rows.
+
+When differences appear, and on a first pass they usually do, Datus enters a loop: compare, diagnose, fix the job SQL, rerun, and compare again. The rules governing this loop encode real data-engineering discipline:
+
+- **Reference data is evidence, not an oracle.** It calibrates business logic, but even reference data gets its grain, filters, and extraction time questioned.
+- **No cheating for a match.** Hard-coding keys, writing expected values into SQL, or excluding difference rows to force agreement are explicitly forbidden.
+- **Every fix names its logic.** Each iteration must state which business rule changed and on what evidence: difference statistics, samples, source fields, or user confirmation.
+- **Uncertainty gets escalated.** When a difference cannot be resolved from evidence, the agent asks instead of deciding.
+
+A matching result is the success signal, not the goal. The goal is correct, rerunnable, explainable SQL. What reconciliation actually produces is an **evidence chain**: requirement -> knowledge base -> approved plan -> reviewed SQL -> reconciled output. That chain is what lets a human sign off on AI-built data without re-deriving every number by hand.
+
+## Skills: Workflow as Code
+
+Each phase is enforced by a Datus skill: `project-set-up`, `etl-plan`, `sql-review`, `execute-job`, and `data-compare`. A skill is a versioned, readable definition of what the agent may and may not do in that phase.
+
+The constraints described above are not prompt-engineering folklore. They are written down in skill files, shipped with the project, and adjustable per team.
+
+This is the part we think matters most for the next few years of AI data engineering. Model capability will keep rising on its own. What teams control is the process their agents follow. Encoding that process as explicit, inspectable skills is how "the agent did it" becomes an acceptable answer in a data-quality review.
+
+## The Takeaway
+
+Three principles matter more than which model you run:
+
+1. **Knowledge before generation.** Mine the project's historical SQL first, so generated code inherits the team's actual conventions and lineage rather than the model's habits.
+2. **Gates before execution.** Plan approval and SQL review place human judgment where it is cheap, before anything runs.
+3. **Reconciliation as the definition of done.** A bidirectional, tolerance-bounded comparison against trusted reference data is the difference between SQL that runs and SQL you would ship.
+
+Any LLM can write SQL. The question that decides whether AI belongs in your data platform is what happens between the prompt and the moment you trust the table. That middle part is what Datus is built for.
+
+## Start with Datus
+
+- Studio: [Datus Studio Overview](https://studio.datus.ai/overview)
+- GitHub: [Datus Agent](https://github.com/Datus-ai/Datus-agent)
+- Docs: [Datus Docs](https://docs.datus.ai)
+- Main site: [Datus.ai](https://datus.ai)

--- a/blog/posts/sql-was-never-the-hard-part.md
+++ b/blog/posts/sql-was-never-the-hard-part.md
@@ -1,5 +1,5 @@
 ---
-title: "SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust"
+title: "How Datus Turns AI-Generated SQL into Trusted Data"
 description: "Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation."
 date: 2026-06-11
 lastmod: 2026-06-11
@@ -15,7 +15,7 @@ head:
       content: "AI-generated SQL, data engineering agent, agentic data engineering, SQL reconciliation, data quality, Datus workflow"
   - - meta
     - property: og:title
-      content: "SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust"
+      content: "How Datus Turns AI-Generated SQL into Trusted Data"
   - - meta
     - property: og:description
       content: "Why reliable AI data engineering needs knowledge, planning, review, controlled execution, and reconciliation, not just SQL generation."
@@ -27,7 +27,7 @@ head:
       content: https://datus.ai/blog/images/sql-was-never-the-hard-part/datus-workflow.svg
   - - meta
     - property: og:url
-      content: https://datus.ai/blog/posts/sql-was-never-the-hard-part
+      content: https://datus.ai/blog/posts/sql-was-never-the-hard-part.html
   - - meta
     - name: twitter:card
       content: summary_large_image
@@ -36,10 +36,10 @@ head:
       content: https://datus.ai/blog/images/sql-was-never-the-hard-part/datus-workflow.svg
   - - link
     - rel: canonical
-      href: https://datus.ai/blog/posts/sql-was-never-the-hard-part
+      href: https://datus.ai/blog/posts/sql-was-never-the-hard-part.html
 ---
 
-# SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust
+# How Datus Turns AI-Generated SQL into Trusted Data
 
 *Why we built data development around knowledge, plans, reviews, and reconciliation, not just generation.*
 

--- a/blog/public/images/sql-was-never-the-hard-part/datus-workflow.svg
+++ b/blog/public/images/sql-was-never-the-hard-part/datus-workflow.svg
@@ -1,0 +1,100 @@
+<svg width="1200" height="600" viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+    <marker id="arrowAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b45309"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#15803d"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1200" height="600" fill="#ffffff"/>
+
+  <!-- Title -->
+  <text x="600" y="44" text-anchor="middle" font-size="26" font-weight="700" fill="#0f172a">Datus Data Development Workflow</text>
+  <text x="600" y="70" text-anchor="middle" font-size="15" fill="#64748b">knowledge → plan → review → execute → reconcile</text>
+
+  <!-- Inputs -->
+  <rect x="120" y="100" width="300" height="58" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="270" y="124" text-anchor="middle" font-size="14" font-weight="700" fill="#334155">ref_sql/</text>
+  <text x="270" y="144" text-anchor="middle" font-size="12.5" fill="#64748b">historical SQL of the project</text>
+
+  <rect x="460" y="100" width="380" height="58" rx="10" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="650" y="124" text-anchor="middle" font-size="14" font-weight="700" fill="#334155">docs/…requirements.md</text>
+  <text x="650" y="144" text-anchor="middle" font-size="12.5" fill="#64748b">business source of truth</text>
+
+  <!-- Input arrows -->
+  <line x1="270" y1="158" x2="148" y2="232" stroke="#475569" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="650" y1="158" x2="380" y2="232" stroke="#475569" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="650" y1="158" x2="610" y2="232" stroke="#475569" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrow)"/>
+
+  <!-- Stage boxes -->
+  <!-- 1 project-set-up -->
+  <rect x="40" y="238" width="200" height="128" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="140" y="268" text-anchor="middle" font-size="12" font-weight="700" fill="#2563eb">PHASE 1</text>
+  <text x="140" y="294" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">project-set-up</text>
+  <text x="140" y="318" text-anchor="middle" font-size="13" fill="#334155">Initialize Knowledge</text>
+  <text x="140" y="346" text-anchor="middle" font-size="11" fill="#64748b">lineage · rules · conventions</text>
+
+  <!-- 2 etl-plan -->
+  <rect x="270" y="238" width="200" height="128" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="370" y="268" text-anchor="middle" font-size="12" font-weight="700" fill="#2563eb">PHASE 2</text>
+  <text x="370" y="294" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">etl-plan</text>
+  <text x="370" y="318" text-anchor="middle" font-size="13" fill="#334155">Plan &amp; Approve</text>
+  <text x="370" y="346" text-anchor="middle" font-size="11" fill="#64748b">no SQL before approval</text>
+
+  <!-- 3 sql-review -->
+  <rect x="500" y="238" width="200" height="128" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="600" y="268" text-anchor="middle" font-size="12" font-weight="700" fill="#2563eb">PHASE 3</text>
+  <text x="600" y="294" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">sql-review</text>
+  <text x="600" y="318" text-anchor="middle" font-size="13" fill="#334155">Review SQL</text>
+  <text x="600" y="346" text-anchor="middle" font-size="11" fill="#64748b">dialect · NULL · types · scope</text>
+
+  <!-- 4 execute-job -->
+  <rect x="730" y="238" width="200" height="128" rx="12" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="830" y="268" text-anchor="middle" font-size="12" font-weight="700" fill="#2563eb">PHASE 4</text>
+  <text x="830" y="294" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">execute-job</text>
+  <text x="830" y="318" text-anchor="middle" font-size="13" fill="#334155">Execute Jobs</text>
+  <text x="830" y="346" text-anchor="middle" font-size="11" fill="#64748b">staging + mart in PostgreSQL</text>
+
+  <!-- 5 data-compare -->
+  <rect x="960" y="238" width="200" height="128" rx="12" fill="#fffbeb" stroke="#d97706" stroke-width="2"/>
+  <text x="1060" y="268" text-anchor="middle" font-size="12" font-weight="700" fill="#b45309">PHASE 5</text>
+  <text x="1060" y="294" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a">data-compare</text>
+  <text x="1060" y="318" text-anchor="middle" font-size="13" fill="#334155">Reconcile</text>
+  <text x="1060" y="346" text-anchor="middle" font-size="11" fill="#64748b">vs expected table · no hard-coding</text>
+
+  <!-- Pipeline arrows -->
+  <line x1="240" y1="302" x2="266" y2="302" stroke="#475569" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <line x1="470" y1="302" x2="496" y2="302" stroke="#475569" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <line x1="700" y1="302" x2="726" y2="302" stroke="#475569" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <line x1="930" y1="302" x2="956" y2="302" stroke="#475569" stroke-width="2.5" marker-end="url(#arrow)"/>
+
+  <!-- Human gate badge on etl-plan -->
+  <rect x="315" y="226" width="110" height="24" rx="12" fill="#0f172a"/>
+  <text x="370" y="242" text-anchor="middle" font-size="11.5" font-weight="700" fill="#ffffff">human gate</text>
+
+  <!-- Feedback loop: data-compare -> execute-job -->
+  <path d="M 1040 366 C 1010 430, 880 430, 852 370" fill="none" stroke="#b45309" stroke-width="2.5" stroke-dasharray="7 5" marker-end="url(#arrowAmber)"/>
+  <text x="947" y="448" text-anchor="middle" font-size="12.5" font-weight="600" fill="#b45309">compare → diagnose → fix SQL → rerun</text>
+
+  <!-- Acceptance box -->
+  <line x1="1110" y1="366" x2="1110" y2="496" stroke="#15803d" stroke-width="2.5" marker-end="url(#arrowGreen)"/>
+  <rect x="690" y="500" width="470" height="64" rx="12" fill="#f0fdf4" stroke="#16a34a" stroke-width="2"/>
+  <text x="925" y="526" text-anchor="middle" font-size="14.5" font-weight="700" fill="#15803d">✓ marts.pendo__product_adoption_summary reconciled</text>
+  <text x="925" y="548" text-anchor="middle" font-size="12.5" fill="#166534">24,995 rows · 13 columns · &lt;1e-9 tolerance · 0 bidirectional diffs</text>
+
+  <!-- Knowledge base note under step 1 -->
+  <rect x="40" y="500" width="430" height="64" rx="12" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="255" y="526" text-anchor="middle" font-size="13" font-weight="700" fill="#334155">Project knowledge base</text>
+  <text x="255" y="548" text-anchor="middle" font-size="12" fill="#64748b">AGENTS.md · business_knowledge · technical_standards · table_lineage</text>
+  <line x1="140" y1="366" x2="140" y2="496" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrow)"/>
+  <text x="152" y="440" font-size="11.5" fill="#64748b">generates</text>
+
+  <!-- Knowledge base feeds later stages -->
+  <path d="M 470 532 C 560 532, 600 460, 600 372" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="6 5" marker-end="url(#arrow)"/>
+  <text x="520" y="500" font-size="11.5" fill="#64748b">grounds every step</text>
+</svg>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Published new blog post "SQL Was Never the Hard Part: How Datus Turns AI-Generated SQL into Data You Can Trust" under the Data Engineering Agent section
  * Post now accessible from blog navigation and homepage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->