### PR TITLE
fix(blog): repair broken internal links + add llms.txt

### DIFF
--- a/blog/data-engineering-agent/index.md
+++ b/blog/data-engineering-agent/index.md
@@ -42,12 +42,12 @@ head:
 Data Engineering Agents represent a paradigm shift in how organizations build, maintain, and scale data infrastructure. Unlike traditional ETL tools that simply move data from point A to point B, Data Engineering Agents leverage artificial intelligence to understand context, learn from interactions, and evolve with your data systems.
 
 If you're evaluating practical implementation paths, start with these companion guides:
-- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs)
-- [Agentic Data Engineering vs Traditional Data Engineering](/posts/agentic-data-engineering-vs-traditional-data-engineering)
-- [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
+- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/blog/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs/)
+- [Agentic Data Engineering vs Traditional Data Engineering](/blog/agentic-data-engineering-vs-traditional-data-engineering/)
+- [From Human-First Data Systems to the Agentic Data Stack](/blog/agentic-data-stack/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
 
 ## What Is a Data Engineering Agent?
 
@@ -103,7 +103,7 @@ Data Engineering Agents improve through continuous feedback:
 
 #### 3. Subagent Architecture
 
-Rather than building one monolithic AI system, modern Data Engineering Agents use **subagents**—specialized agents scoped to specific domains. If you want a deep dive specifically on this pattern, read [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent).
+Rather than building one monolithic AI system, modern Data Engineering Agents use **subagents**—specialized agents scoped to specific domains. If you want a deep dive specifically on this pattern, read [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/).
 
 - **Retention Analytics Subagent**: Focused on user retention metrics, cohort analysis
 - **Financial Reporting Subagent**: Handles revenue, costs, margin calculations
@@ -276,7 +276,7 @@ Data Engineering Agents **preserve and evolve knowledge**:
 
 ### Start Small, Prove Value, Scale
 
-Don't try to build a comprehensive agent for all data on day one. For a concrete rollout blueprint, see [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture).
+Don't try to build a comprehensive agent for all data on day one. For a concrete rollout blueprint, see [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/).
 
 **Recommended Approach**:
 
@@ -675,10 +675,10 @@ Ready to transform your data workflows with AI-powered agents?
 
 ### Learn More
 
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus) - Deep dive into why context matters
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) - Business + technical primer
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture) - Architecture and rollout path
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases) - Practical scenarios and ROI
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/) - Deep dive into why context matters
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/) - Business + technical primer
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/) - Architecture and rollout path
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/) - Practical scenarios and ROI
 - [Contextual Data Engineering Tutorial](https://docs.datus.ai/getting_started/contextual_data_engineering/) - Step-by-step guide
 - [Architecture Overview](https://docs.datus.ai/concepts/architecture/) - Technical details
 

--- a/blog/posts/agentic-data-engineering-vs-traditional-data-engineering.md
+++ b/blog/posts/agentic-data-engineering-vs-traditional-data-engineering.md
@@ -277,7 +277,7 @@ That matters because agentic data engineering only becomes useful when context c
 
 If you’re mapping this space in more detail, the next useful reads are:
 
-- [What Is a Data Engineering Agent?](/posts/what-is-data-engineering-agent) for the core definition layer
+- [What Is a Data Engineering Agent?](/blog/what-is-data-engineering-agent/) for the core definition layer
 - Data Engineering Agent Architecture: From Prototype to Production with Datus for implementation patterns
 - 7 High-Impact Data Engineering Agent Use Cases (Powered by Datus) for workflow-level examples
 - The Layered Subagent Architecture for Data Engineering Agents for team and system design
@@ -314,10 +314,10 @@ If the environment is small, stable, heavily regulated, or not yet well-modeled,
 
 ## Related Reading
 
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
 
 ## Start with Datus
 

--- a/blog/posts/agentic-data-stack.md
+++ b/blog/posts/agentic-data-stack.md
@@ -63,7 +63,7 @@ This is why the category starts to break down as soon as the scope expands from 
 
 ## What makes a data engineering agent different
 
-A [data engineering agent](/posts/what-is-data-engineering-agent) is not just a better query assistant.
+A [data engineering agent](/blog/what-is-data-engineering-agent/) is not just a better query assistant.
 
 A real agent needs a richer operating environment. It needs access to structured context and the ability to reason across the system it is acting inside.
 
@@ -165,11 +165,11 @@ If you're exploring how metadata, semantics, lineage, and orchestration can beco
 
 ## Related Reading
 
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 
 ## Start with Datus
 
@@ -179,5 +179,5 @@ If you're exploring how metadata, semantics, lineage, and orchestration can beco
 
 ## Continue Reading
 
-- Previous: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- Next: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
+- Previous: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- Next: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)

--- a/blog/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs.md
+++ b/blog/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs.md
@@ -341,14 +341,14 @@ If you are building toward production-grade automation, that is the bar. Not gen
 
 - Start with the [Datus quickstart and workflow docs](https://docs.datus.ai/)
 - Then read the supporting article: How to Automate Data Pipelines with AI Agents
-- Related reading: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
+- Related reading: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
 
 ## Related Reading
 
-- [Agentic Data Engineering vs Traditional Data Engineering](/posts/agentic-data-engineering-vs-traditional-data-engineering)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
+- [Agentic Data Engineering vs Traditional Data Engineering](/blog/agentic-data-engineering-vs-traditional-data-engineering/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
 
 ## Start with Datus
 

--- a/blog/posts/ai-native-data-platforms.md
+++ b/blog/posts/ai-native-data-platforms.md
@@ -33,14 +33,14 @@ head:
 
 # AI-Native Data Platforms: Why the Next Generation Needs Data Engineering Agents, Not Just Copilots
 
-Every major data platform now has an AI feature — a copilot, a chat interface, an assistant. But bolting a text-to-SQL chatbot onto a warehouse does not make a platform **AI-native**. An AI-native data platform is one where AI agents are not features added to the product — they are **the architecture through which the product operates**. And the central infrastructure component of that architecture is not a better model or a smarter copilot — it is a [data engineering agent](/posts/what-is-data-engineering-agent) that builds and evolves the context all other agents depend on. This article defines the category, separates AI-native from AI-augmented, and explains what the transition means for data teams.
+Every major data platform now has an AI feature — a copilot, a chat interface, an assistant. But bolting a text-to-SQL chatbot onto a warehouse does not make a platform **AI-native**. An AI-native data platform is one where AI agents are not features added to the product — they are **the architecture through which the product operates**. And the central infrastructure component of that architecture is not a better model or a smarter copilot — it is a [data engineering agent](/blog/what-is-data-engineering-agent/) that builds and evolves the context all other agents depend on. This article defines the category, separates AI-native from AI-augmented, and explains what the transition means for data teams.
 
 ## TL;DR
 
 - An **AI-native data platform** is one where AI agents are the primary operating model — generating queries, building context, managing pipelines, and orchestrating workflows — not a bolt-on chat interface added to a traditional platform.
 - Most "AI features" in data platforms today are **AI-augmented**, not AI-native: a copilot sidebar in a SQL editor, a natural-language dashboard builder, a documentation generator. These add AI to existing workflows rather than restructuring the workflow around AI.
 - The defining characteristic of an AI-native platform: **the platform gets better with every agent interaction** — context accumulates, accuracy improves, and downstream agents inherit richer grounding.
-- The missing infrastructure layer is a **data engineering agent**: an AI system whose primary job is not answering questions but building and evolving the context — [semantic models](/posts/what-is-semantic-model), [metric definitions](/posts/what-is-metric-layer), reference SQL, validation rules — that makes all other agents more accurate.
+- The missing infrastructure layer is a **data engineering agent**: an AI system whose primary job is not answering questions but building and evolving the context — [semantic models](/blog/what-is-semantic-model/), [metric definitions](/blog/what-is-metric-layer/), reference SQL, validation rules — that makes all other agents more accurate.
 - Datus is purpose-built for this: a data engineering agent that generates context from schema and SQL, refines it through feedback, and packages it into domain-scoped Subagents — the producer tier in an AI-native data architecture.
 
 ## 1. AI-augmented vs AI-native: the distinction that matters
@@ -152,6 +152,6 @@ A **data engineering agent** is the producer tier — the system that builds and
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — the producer tier in detail
-- [What is a data agent?](/posts/what-is-data-agent) — the full taxonomy of data agents
-- [Contextual Data Engineering: Why Your Agent Needs Evolvable Context](/posts/contextual-data-engineering) — the core concept
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the producer tier in detail
+- [What is a data agent?](/blog/what-is-data-agent/) — the full taxonomy of data agents
+- [Contextual Data Engineering: Why Your Agent Needs Evolvable Context](/blog/contextual-data-engineering/) — the core concept

--- a/blog/posts/best-data-engineering-agents-2026.md
+++ b/blog/posts/best-data-engineering-agents-2026.md
@@ -36,7 +36,7 @@ At this point, eight different products call themselves a **data engineering age
 
 One lives inside a cloud console. One is a SaaS capability for martech teams. One is a community prompt you paste into a terminal. One is an open-source framework that treats context as infrastructure. Three more occupy the independent space between. They all claim to "turn natural language into data work," and technically, they all do. But the differences that matter—who is allowed to use it, what it actually has access to, and what it remembers tomorrow—are invisible on product pages.
 
-The best data engineering agent depends on your stack: single-warehouse teams are best served by platform-native agents; multi-warehouse teams need stack-agnostic, context-persistent alternatives. This guide compares the eight most notable options side by side and gives you a decision framework—no demo video required. If you are new to the category, start with [what a data engineering agent is](/posts/what-is-data-engineering-agent-2026).
+The best data engineering agent depends on your stack: single-warehouse teams are best served by platform-native agents; multi-warehouse teams need stack-agnostic, context-persistent alternatives. This guide compares the eight most notable options side by side and gives you a decision framework—no demo video required. If you are new to the category, start with [what a data engineering agent is](/blog/what-is-data-engineering-agent-2026/).
 
 ## TL;DR
 
@@ -47,7 +47,7 @@ The best data engineering agent depends on your stack: single-warehouse teams ar
 
 ## 1. The four categories, briefly
 
-Before listing products, it helps to understand that the eight agents fall into four categories with fundamentally different design philosophies. For a detailed breakdown of these categories, see [the category definition article](/posts/what-is-data-engineering-agent-2026). Here is the short version:
+Before listing products, it helps to understand that the eight agents fall into four categories with fundamentally different design philosophies. For a detailed breakdown of these categories, see [the category definition article](/blog/what-is-data-engineering-agent-2026/). Here is the short version:
 
 **Platform-embedded agents** (BigQuery DEA, Snowflake Cortex Code) live inside a single cloud platform. They are deeply integrated with their host's metadata, IAM, and billing. They are the path of least resistance when your entire data life happens inside that platform. They are not an option when it does not.
 
@@ -92,7 +92,7 @@ This is a community-maintained persona configuration for Claude Code—a prompt 
 
 ### Datus
 
-Datus is the open-source agent built around a persistent [Context Engine](/posts/contextual-data-engineering)—a dual-dimension context store (physical catalog tree + logical subject tree) that treats every successful query as training data for the next one. It runs as a CLI, chat, API, or hosted Studio, and connects to ten database types (Snowflake, BigQuery, Postgres, DuckDB, StarRocks, and more). Its subagent system packages scoped context into domain-specific chatbots. In Datus's Lakehouse deployment narrative, context feedback is tied to materially higher self-service usage and faster repeated query work. Datus is strongest for teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge rather than rediscovering it on every query.
+Datus is the open-source agent built around a persistent [Context Engine](/blog/contextual-data-engineering/)—a dual-dimension context store (physical catalog tree + logical subject tree) that treats every successful query as training data for the next one. It runs as a CLI, chat, API, or hosted Studio, and connects to ten database types (Snowflake, BigQuery, Postgres, DuckDB, StarRocks, and more). Its subagent system packages scoped context into domain-specific chatbots. In Datus's Lakehouse deployment narrative, context feedback is tied to materially higher self-service usage and faster repeated query work. Datus is strongest for teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge rather than rediscovering it on every query.
 
 ### Wren AI
 
@@ -183,6 +183,6 @@ Yes, several. Datus is Apache 2.0 (free CLI + free Cloud Personal tier). Wren AI
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and four-agent comparison
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model beneath every durable agent
-- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — auditability, self-hosting, and the case for open source
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition and four-agent comparison
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer context model beneath every durable agent
+- [Open source data engineering agents](/blog/open-source-data-engineering-agents/) — auditability, self-hosting, and the case for open source

--- a/blog/posts/best-data-engineering-agents.md
+++ b/blog/posts/best-data-engineering-agents.md
@@ -37,7 +37,7 @@ At this point, eight different products call themselves a **data engineering age
 
 One lives inside a cloud console. One is a SaaS capability for martech teams. One is a community prompt you paste into a terminal. One is an open-source framework that treats context as infrastructure. Three more occupy the independent space between. They all claim to "turn natural language into data work," and technically, they all do. But the differences that matter—who is allowed to use it, what it actually has access to, and what it remembers tomorrow—are invisible on product pages.
 
-The best data engineering agent depends on your stack: single-warehouse teams are best served by platform-native agents; multi-warehouse teams need stack-agnostic, context-persistent alternatives. This guide compares the eight most notable options side by side and gives you a decision framework—no demo video required. If you are new to the category, start with [what a data engineering agent is](/posts/what-is-data-engineering-agent).
+The best data engineering agent depends on your stack: single-warehouse teams are best served by platform-native agents; multi-warehouse teams need stack-agnostic, context-persistent alternatives. This guide compares the eight most notable options side by side and gives you a decision framework—no demo video required. If you are new to the category, start with [what a data engineering agent is](/blog/what-is-data-engineering-agent/).
 
 ## TL;DR
 
@@ -48,7 +48,7 @@ The best data engineering agent depends on your stack: single-warehouse teams ar
 
 ## 1. The four categories, briefly
 
-Before listing products, it helps to understand that the eight agents fall into four categories with fundamentally different design philosophies. For a detailed breakdown of these categories, see [the category definition article](/posts/what-is-data-engineering-agent). Here is the short version:
+Before listing products, it helps to understand that the eight agents fall into four categories with fundamentally different design philosophies. For a detailed breakdown of these categories, see [the category definition article](/blog/what-is-data-engineering-agent/). Here is the short version:
 
 **Platform-embedded agents** (BigQuery DEA, Snowflake Cortex Code) live inside a single cloud platform. They are deeply integrated with their host's metadata, IAM, and billing. They are the path of least resistance when your entire data life happens inside that platform. They are not an option when it does not.
 
@@ -93,7 +93,7 @@ This is a community-maintained persona configuration for Claude Code—a prompt 
 
 ### Datus
 
-Datus is the open-source agent built around a persistent [Context Engine](/posts/contextual-data-engineering)—a dual-dimension context store (physical catalog tree + logical subject tree) that treats every successful query as training data for the next one. It runs as a CLI, chat, API, or hosted Studio, and connects to ten database types (Snowflake, BigQuery, Postgres, DuckDB, StarRocks, and more). Its subagent system packages scoped context into domain-specific chatbots. In Datus's Lakehouse deployment narrative, context feedback is tied to materially higher self-service usage and faster repeated query work. Datus is strongest for teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge rather than rediscovering it on every query.
+Datus is the open-source agent built around a persistent [Context Engine](/blog/contextual-data-engineering/)—a dual-dimension context store (physical catalog tree + logical subject tree) that treats every successful query as training data for the next one. It runs as a CLI, chat, API, or hosted Studio, and connects to ten database types (Snowflake, BigQuery, Postgres, DuckDB, StarRocks, and more). Its subagent system packages scoped context into domain-specific chatbots. In Datus's Lakehouse deployment narrative, context feedback is tied to materially higher self-service usage and faster repeated query work. Datus is strongest for teams with multi-warehouse stacks who want an agent that accumulates institutional knowledge rather than rediscovering it on every query.
 
 ### Wren AI
 
@@ -184,6 +184,6 @@ Yes, several. Datus is Apache 2.0 (free CLI + free Cloud Personal tier). Wren AI
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — the category definition and four-agent comparison
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model beneath every durable agent
-- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — auditability, self-hosting, and the case for open source
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the category definition and four-agent comparison
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer context model beneath every durable agent
+- [Open source data engineering agents](/blog/open-source-data-engineering-agents/) — auditability, self-hosting, and the case for open source

--- a/blog/posts/build-your-first-data-engineering-agent.md
+++ b/blog/posts/build-your-first-data-engineering-agent.md
@@ -34,7 +34,7 @@ head:
 
 You do not need a procurement approval. You do not need a cloud budget. You do not need to know how LLMs work. You need a terminal, Python 3.12 or later, and roughly 15 minutes if your environment is ready. By the end of this guide, you will have a working <a href="https://datus.ai/glossary">data engineering agent</a> connected to a real database, a generated semantic model, and a scoped chatbot you can share with a teammate.
 
-We will use Datus for this tutorial because it is free (Apache 2.0), installs with a single pip command, and ships with a built-in tutorial dataset so you do not need to connect a production warehouse to try it. If you want to understand what a data engineering agent is before building one, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+We will use Datus for this tutorial because it is free (Apache 2.0), installs with a single pip command, and ships with a built-in tutorial dataset so you do not need to connect a production warehouse to try it. If you want to understand what a data engineering agent is before building one, start with [what is a data engineering agent](/blog/what-is-data-engineering-agent-2026/).
 
 ## TL;DR
 
@@ -124,7 +124,7 @@ This shows you the database structure the agent has learned: databases → schem
 @subject
 ```
 
-This shows you the business-domain view: topics the agent has inferred, metrics it has identified, and reference SQL it has captured from your queries. This is the [contextual data engineering](/posts/contextual-data-engineering) layer—the institutional memory that makes the next query more accurate than the first.
+This shows you the business-domain view: topics the agent has inferred, metrics it has identified, and reference SQL it has captured from your queries. This is the [contextual data engineering](/blog/contextual-data-engineering/) layer—the institutional memory that makes the next query more accurate than the first.
 
 **Explore a specific table:**
 
@@ -150,7 +150,7 @@ The agent will scan the California Schools schema and produce a semantic model i
 
 You can edit this model—add business definitions, correct wrong inferences, mark deprecated columns—and the corrections will feed back into the context engine, making future queries more accurate.
 
-For a deeper understanding of semantic models and how they relate to agent accuracy, see [what is a semantic layer](/posts/what-is-semantic-layer).
+For a deeper understanding of semantic models and how they relate to agent accuracy, see [what is a semantic layer](/blog/what-is-semantic-layer/).
 
 ## Step 6: Create a subagent
 
@@ -278,7 +278,7 @@ The same context engine powers both. The CLI is your cockpit; the subagent chat 
 - **Connect your real warehouse:** Run `datus-agent configure` and add your Snowflake, BigQuery, or Postgres credentials. The agent will inspect your actual schemas and begin building context from your real data environment.
 - **Bootstrap from historical SQL:** Run `datus-agent bootstrap-kb /path/to/sql/files` to seed the Context Engine with your team's existing query patterns. The agent will learn which tables, joins, and metrics your team actually uses—not just what the schema says.
 - **Set up feedback collection:** Share your subagent link with analysts and encourage them to upvote correct answers and report issues. Every feedback signal makes the context stronger.
-- **Read the deep dives:** [Contextual data engineering](/posts/contextual-data-engineering) for the theory behind the Context Engine, [best data engineering agents 2026](/posts/best-data-engineering-agents-2026) for the full landscape, and [open source data engineering agents](/posts/open-source-data-engineering-agents) for the case for self-hosting.
+- **Read the deep dives:** [Contextual data engineering](/blog/contextual-data-engineering/) for the theory behind the Context Engine, [best data engineering agents 2026](/blog/best-data-engineering-agents-2026/) for the full landscape, and [open source data engineering agents](/blog/open-source-data-engineering-agents/) for the case for self-hosting.
 
 Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> for a zero-install version of everything in this tutorial—connect a warehouse, ask questions, and watch context build in your browser.
 
@@ -294,14 +294,14 @@ The California Schools dataset is representative—it has multiple tables, joins
 
 ### How does the agent handle corrections when it generates wrong SQL?
 
-When you receive an incorrect result in Datus Chat, you can file an issue report describing what was wrong. The correction flows back into the Context Engine: the agent notes which join path, filter condition, or metric definition produced the error, and it adjusts future queries to avoid the same mistake. Over time, the agent's accuracy improves—not because the underlying LLM changed, but because the context it operates on accumulated corrections. This is the feedback loop central to [contextual data engineering](/posts/contextual-data-engineering).
+When you receive an incorrect result in Datus Chat, you can file an issue report describing what was wrong. The correction flows back into the Context Engine: the agent notes which join path, filter condition, or metric definition produced the error, and it adjusts future queries to avoid the same mistake. Over time, the agent's accuracy improves—not because the underlying LLM changed, but because the context it operates on accumulated corrections. This is the feedback loop central to [contextual data engineering](/blog/contextual-data-engineering/).
 
 ### Can I run this on my company's data without sending anything to a third party?
 
-Yes. Datus is self-hosted (Apache 2.0). When you run `datus-agent` locally, all data—your queries, your schemas, the agent's context—stays on your machine. When you use Datus Studio (the browser version), your queries are sent to Datus's cloud for processing. For teams with strict data residency requirements, self-hosting the open-source version is the recommended path. See [open source data engineering agents](/posts/open-source-data-engineering-agents) for more on the self-hosting tradeoff.
+Yes. Datus is self-hosted (Apache 2.0). When you run `datus-agent` locally, all data—your queries, your schemas, the agent's context—stays on your machine. When you use Datus Studio (the browser version), your queries are sent to Datus's cloud for processing. For teams with strict data residency requirements, self-hosting the open-source version is the recommended path. See [open source data engineering agents](/blog/open-source-data-engineering-agents/) for more on the self-hosting tradeoff.
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and how agents differ from copilots
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model behind the agent you just built
-- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — why self-hosting matters for data infrastructure
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition and how agents differ from copilots
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer context model behind the agent you just built
+- [Open source data engineering agents](/blog/open-source-data-engineering-agents/) — why self-hosting matters for data infrastructure

--- a/blog/posts/context-engine-data-engineering-agent-accuracy.md
+++ b/blog/posts/context-engine-data-engineering-agent-accuracy.md
@@ -32,9 +32,9 @@ head:
 ---
 # How a Context Engine Makes Data Engineering Agents More Accurate
 
-Every [data engineering agent](/posts/what-is-data-engineering-agent-2026) uses an LLM to generate SQL. The LLM is not the differentiator. Any modern model—GPT-4o, Claude, Gemini, DeepSeek—can produce syntactically correct SQL against a well-described schema. The accuracy gap between agents is not about which model they use. It is about what context they give the model before asking it to generate a query.
+Every [data engineering agent](/blog/what-is-data-engineering-agent-2026/) uses an LLM to generate SQL. The LLM is not the differentiator. Any modern model—GPT-4o, Claude, Gemini, DeepSeek—can produce syntactically correct SQL against a well-described schema. The accuracy gap between agents is not about which model they use. It is about what context they give the model before asking it to generate a query.
 
-A context engine is the component that prepares, retrieves, and continuously updates that context. This article explains how it works, why it is the single largest lever for agent accuracy, and what separates a well-designed context engine from a thin wrapper around a model API. For the theoretical foundation, see [contextual data engineering](/posts/contextual-data-engineering).
+A context engine is the component that prepares, retrieves, and continuously updates that context. This article explains how it works, why it is the single largest lever for agent accuracy, and what separates a well-designed context engine from a thin wrapper around a model API. For the theoretical foundation, see [contextual data engineering](/blog/contextual-data-engineering/).
 
 ## TL;DR
 
@@ -95,7 +95,7 @@ To be precise about what makes a context engine different from adjacent concepts
 
 - **It is not a data catalog.** A <a href="https://datus.ai/glossary">data catalog</a> inventories assets for human discovery. A context engine organizes context for machine retrieval at query time. The catalog tells a person where to look. The context engine tells an agent what to use.
 
-- **It is not a semantic layer.** A [semantic layer](/posts/what-is-semantic-layer) defines governed metrics and dimensions. A context engine includes semantic definitions but extends them with validated SQL, deprecation notes, feedback history, and business rules that move faster than governance cycles. The semantic layer is the certified foundation; the context engine is the living layer on top.
+- **It is not a semantic layer.** A [semantic layer](/blog/what-is-semantic-layer/) defines governed metrics and dimensions. A context engine includes semantic definitions but extends them with validated SQL, deprecation notes, feedback history, and business rules that move faster than governance cycles. The semantic layer is the certified foundation; the context engine is the living layer on top.
 
 - **It is not a vector database.** Some context engines use vector search for retrieval—finding semantically similar queries and schemas. But a context engine is more than its retrieval mechanism. It includes the inspection logic that builds context, the organizational model that structures it, the feedback loop that updates it, and the delivery mechanisms that package it for consumption.
 
@@ -124,7 +124,7 @@ The questions that predict long-term accuracy are:
 
 The answers to these questions determine whether the agent's accuracy plateaus at its demo-quality baseline or improves toward production reliability over weeks of real use. A stronger LLM paired with shallow context will still plateau on ambiguous warehouse-specific questions. A modest LLM paired with a deep context engine can outperform it on repeated domain patterns because it has better local facts.
 
-For a practical comparison of how different agents handle these questions, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+For a practical comparison of how different agents handle these questions, see the [best data engineering agents comparison](/blog/best-data-engineering-agents-2026/).
 
 ## Conclusion
 
@@ -132,7 +132,7 @@ A context engine is the slow brain of a data engineering agent: the component th
 
 The agents that will define this category are the ones that invest in context infrastructure: deep schema inspection, dual-dimension context organization, feedback-driven updates, and reference SQL pattern storage. Agents that treat the LLM as the whole product can produce brilliant demos and still plateau. Agents that treat context as the product have a clearer path to improving on repeated production workloads.
 
-This is the practical implication of [contextual data engineering](/posts/contextual-data-engineering): accuracy is not a feature of the model. It is a property of the context.
+This is the practical implication of [contextual data engineering](/blog/contextual-data-engineering/): accuracy is not a feature of the model. It is a property of the context.
 
 Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see a context engine in action—ask ten questions against a connected warehouse and watch how the answers improve.
 
@@ -152,6 +152,6 @@ Partially. A well-maintained dbt project or semantic layer provides excellent sc
 
 ## Related articles
 
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer model behind context engines
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — definitions, implementations, and the gap agents fill
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer model behind context engines
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — definitions, implementations, and the gap agents fill

--- a/blog/posts/contextual-data-engineering.md
+++ b/blog/posts/contextual-data-engineering.md
@@ -36,7 +36,7 @@ The largest cost in data engineering is not writing SQL. It is re-learning the s
 
 This is not a tooling problem. It is a context problem. And it is the problem that **contextual data engineering** is designed to solve.
 
-If you have read [what a data engineering agent is](/posts/what-is-data-engineering-agent-2026), you already know the rough shape of what follows. That article argued that the deepest split between today's data engineering agents is how they handle context. This article gives the idea its own name and its own definition.
+If you have read [what a data engineering agent is](/blog/what-is-data-engineering-agent-2026/), you already know the rough shape of what follows. That article argued that the deepest split between today's data engineering agents is how they handle context. This article gives the idea its own name and its own definition.
 
 ## TL;DR
 
@@ -153,7 +153,7 @@ It is worth being precise about what contextual data engineering is not, because
 
 **It is not a semantic layer—but it reinforces one.** A semantic layer defines governed metrics, dimensions, and joins. It is essential infrastructure. But it is static at runtime: defined in Git, deployed on a schedule, consumed by BI tools. Contextual data engineering adds a fast feedback buffer on top: validated ad-hoc SQL, deprecation notes, usage patterns, and corrections that have not yet been promoted to the formal semantic layer. The two are complementary: the semantic layer provides the governed foundation; the context layer captures the institutional knowledge that moves faster than governance cycles.
 
-For more on this relationship, see [what is a semantic layer](/posts/what-is-semantic-layer).
+For more on this relationship, see [what is a semantic layer](/blog/what-is-semantic-layer/).
 
 ## 7. What a contextual data engineering system looks like in practice
 
@@ -209,6 +209,6 @@ No—it makes your documentation more accurate over time. Traditional documentat
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition this article builds on
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the governed semantics that contextual systems extend
-- [How a Context Engine improves accuracy](/posts/context-engine-data-engineering-agent-accuracy) — the architecture behind context retrieval and feedback
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition this article builds on
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the governed semantics that contextual systems extend
+- [How a Context Engine improves accuracy](/blog/context-engine-data-engineering-agent-accuracy/) — the architecture behind context retrieval and feedback

--- a/blog/posts/cube-agentic-analytics.md
+++ b/blog/posts/cube-agentic-analytics.md
@@ -33,7 +33,7 @@ head:
 
 # Cube.dev: From Semantic Layer Pioneer to Agentic Analytics Platform
 
-In 2019, Cube was an open-source framework for building analytics dashboards — a React component library with a caching layer. By 2022, it had repositioned as a headless semantic layer — the dashboards were still there, but the real product was the API that served governed metrics to any frontend. In June 2025, it launched D3, a platform built around AI agents that consume those metrics — not as an add-on feature, but as the primary interface. That arc — from dashboard framework to semantic infrastructure to agentic platform — is not a pivot. It is a thesis playing out in three acts: the dashboard is a commodity, the semantic layer is the durable asset, and AI agents are its natural consumers. This article traces Cube's evolution, examines its architecture, and explains what its trajectory toward agentic analytics means for the [data engineering agent](/posts/what-is-data-engineering-agent) category — including where Cube and Datus converge and where they make fundamentally different architectural bets.
+In 2019, Cube was an open-source framework for building analytics dashboards — a React component library with a caching layer. By 2022, it had repositioned as a headless semantic layer — the dashboards were still there, but the real product was the API that served governed metrics to any frontend. In June 2025, it launched D3, a platform built around AI agents that consume those metrics — not as an add-on feature, but as the primary interface. That arc — from dashboard framework to semantic infrastructure to agentic platform — is not a pivot. It is a thesis playing out in three acts: the dashboard is a commodity, the semantic layer is the durable asset, and AI agents are its natural consumers. This article traces Cube's evolution, examines its architecture, and explains what its trajectory toward agentic analytics means for the [data engineering agent](/blog/what-is-data-engineering-agent/) category — including where Cube and Datus converge and where they make fundamentally different architectural bets.
 
 ## TL;DR
 
@@ -111,7 +111,7 @@ Cube and Datus are moving toward the same destination — a world where AI agent
 | **Caching strategy** | CubeStore (Rust OLAP) — materialized pre-aggregation | Context caching — validated SQL and semantic models reused across queries |
 | **Feedback loop** | Query-level — agent-generated SQL validated by semantic constraints | Continuous — user upvotes, issue reports, and corrections feed back into context evolution |
 
-The two are not direct competitors — they occupy different tiers of the data agent stack (see [what is a data agent](/posts/what-is-data-agent)). Cube is the **consumer tier**: a platform for serving governed metrics to any tool, including AI agents. Datus is the **producer tier**: a system for building and continuously evolving the context that both human analysts and AI agents consume.
+The two are not direct competitors — they occupy different tiers of the data agent stack (see [what is a data agent](/blog/what-is-data-agent/)). Cube is the **consumer tier**: a platform for serving governed metrics to any tool, including AI agents. Datus is the **producer tier**: a system for building and continuously evolving the context that both human analysts and AI agents consume.
 
 In a fully realized architecture, they are complementary: Datus generates and evolves semantic models and metrics; Cube serves them through APIs with caching, access control, and multi-tool distribution. An organization could use both — Datus for context creation and evolution, Cube for context distribution and consumption.
 
@@ -119,7 +119,7 @@ In a fully realized architecture, they are complementary: Datus generates and ev
 
 Cube's evolution from dashboard framework → headless semantic layer → agentic analytics platform is not a unique path — it reflects a broader market pattern:
 
-**Signal 1: The semantic layer is infrastructure, not a feature.** Cube bet its entire product on this thesis years ago, and the market has validated it. When Databricks Ventures invested $25M in Cube, they were investing in semantic infrastructure — not dashboard tooling. The OSI standard (see [Open Semantic Interchange explained](/posts/open-semantic-interchange-osi)) further validates this: metrics are becoming portable infrastructure, not tool-specific features.
+**Signal 1: The semantic layer is infrastructure, not a feature.** Cube bet its entire product on this thesis years ago, and the market has validated it. When Databricks Ventures invested $25M in Cube, they were investing in semantic infrastructure — not dashboard tooling. The OSI standard (see [Open Semantic Interchange explained](/blog/open-semantic-interchange-osi/)) further validates this: metrics are becoming portable infrastructure, not tool-specific features.
 
 **Signal 2: AI agents need a governed semantic layer to be trustworthy.** Cube's "LLMs query semantic layers, not databases" argument is increasingly the consensus. Giving an AI agent raw database access produces confident wrong answers. Routing agent queries through a governed semantic layer produces answers grounded in certified business logic. This is not a Cube-specific insight — it is an architectural requirement for any production AI analytics deployment.
 
@@ -161,6 +161,6 @@ Not directly — they occupy different tiers of the data agent stack. Cube is th
 
 ## Related articles
 
-- [dbt Semantic Layer & MetricFlow: A Complete Guide](/posts/dbt-semantic-layer-metricflow) — the Git-managed alternative to Cube
-- [What is a metric layer?](/posts/what-is-metric-layer) — the concept Cube implements
-- [Open Semantic Interchange (OSI) explained](/posts/open-semantic-interchange-osi) — the standard that makes semantics portable
+- [dbt Semantic Layer & MetricFlow: A Complete Guide](/blog/dbt-semantic-layer-metricflow/) — the Git-managed alternative to Cube
+- [What is a metric layer?](/blog/what-is-metric-layer/) — the concept Cube implements
+- [Open Semantic Interchange (OSI) explained](/blog/open-semantic-interchange-osi/) — the standard that makes semantics portable

--- a/blog/posts/data-engineering-agent-architecture.md
+++ b/blog/posts/data-engineering-agent-architecture.md
@@ -96,13 +96,13 @@ Clear structure helps both human readers and AI answer engines:
 
 ## Related Reading
 
-- [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- [From Human-First Data Systems to the Agentic Data Stack](/blog/agentic-data-stack/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 
 ## Continue Reading
 
-- Previous: [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- Next: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
+- Previous: [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- Next: [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)

--- a/blog/posts/data-engineering-agent-use-cases.md
+++ b/blog/posts/data-engineering-agent-use-cases.md
@@ -84,11 +84,11 @@ Start with one domain subagent and one measurable KPI, then expand only after we
 
 ## Related Reading
 
-- [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- [From Human-First Data Systems to the Agentic Data Stack](/blog/agentic-data-stack/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 
 ## Learn more
 
@@ -98,5 +98,5 @@ Start with one domain subagent and one measurable KPI, then expand only after we
 
 ## Continue Reading
 
-- Previous: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
+- Previous: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
 - Next: [Data Engineering Agent: The Complete Guide](/data-engineering-agent/)

--- a/blog/posts/data-engineering-agent-vs-claude-code.md
+++ b/blog/posts/data-engineering-agent-vs-claude-code.md
@@ -36,7 +36,7 @@ Claude Code is one of the best general-purpose coding agents available. It can w
 
 This distinction is not a dig at Claude Code. It is an acknowledgment that data engineering has requirements that general-purpose coding agents were not built to handle: persistent schema knowledge across sessions, validated SQL patterns that compound in accuracy, business metric definitions that survive beyond a single conversation, and delivery mechanisms that turn context into something a non-engineer can use.
 
-This article explains the real differences, the scenarios where each tool wins, and the pattern that turns them from competitors into complements. For a broader comparison of available agents, see the [best data engineering agents in 2026](/posts/best-data-engineering-agents-2026).
+This article explains the real differences, the scenarios where each tool wins, and the pattern that turns them from competitors into complements. For a broader comparison of available agents, see the [best data engineering agents in 2026](/blog/best-data-engineering-agents-2026/).
 
 ## TL;DR
 
@@ -58,7 +58,7 @@ Data engineering tasks are different. The most important context is not in the r
 - "Filter out `account_type = 'test'` on all revenue queries"
 - "The `status` column was deprecated in March; use `status_v2`"
 
-A human engineer learns these rules over weeks and applies them unconsciously. A [data engineering agent](/posts/what-is-data-engineering-agent-2026) with a persistent context engine learns them the same way—not in a single prompt, but across sessions, as it sees which queries were upvoted, which were corrected, and which patterns repeat. Claude Code cannot do this because it does not have anywhere to put that knowledge between sessions.
+A human engineer learns these rules over weeks and applies them unconsciously. A [data engineering agent](/blog/what-is-data-engineering-agent-2026/) with a persistent context engine learns them the same way—not in a single prompt, but across sessions, as it sees which queries were upvoted, which were corrected, and which patterns repeat. Claude Code cannot do this because it does not have anywhere to put that knowledge between sessions.
 
 ## 2. When Claude Code is the right tool
 
@@ -84,7 +84,7 @@ A dedicated data engineering agent wins when the task requires context that outl
 
 **The team is larger than one person.** When multiple people query the same data, persistent shared context becomes essential—not optional. Without it, two analysts querying "revenue" get two different numbers because they are using two different definitions, two different join paths, and two different filter conditions. A data engineering agent provides a single source of context truth that every query is grounded in.
 
-**Accuracy improvement over time matters.** If the first query is expected to be merely plausible and the hundredth query should be grounded in corrected team patterns, you need a feedback loop. Claude Code starts every session at the same baseline accuracy. A [contextual data engineering](/posts/contextual-data-engineering) agent improves baseline accuracy every time a user confirms or corrects a result.
+**Accuracy improvement over time matters.** If the first query is expected to be merely plausible and the hundredth query should be grounded in corrected team patterns, you need a feedback loop. Claude Code starts every session at the same baseline accuracy. A [contextual data engineering](/blog/contextual-data-engineering/) agent improves baseline accuracy every time a user confirms or corrects a result.
 
 ## 4. The complementary pattern: DE agent as the context layer for Claude Code
 
@@ -143,7 +143,7 @@ Start with the tool that matches your primary workflow. If you spend most of you
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — why context persistence is the core differentiator
-- [Best data engineering agents in 2026](/posts/best-data-engineering-agents-2026) — full landscape comparison
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — why context persistence is the core differentiator
+- [Best data engineering agents in 2026](/blog/best-data-engineering-agents-2026/) — full landscape comparison
                                                                    

--- a/blog/posts/data-engineering-agent-vs-sql-copilot.md
+++ b/blog/posts/data-engineering-agent-vs-sql-copilot.md
@@ -36,7 +36,7 @@ Every SQL copilot and every data engineering agent will generate a query from a 
 
 A SQL copilot is a clever stranger. It can write a brilliant query on first meeting. But it forgets you the moment the session ends. A <a href="https://datus.ai/glossary">data engineering agent</a> is a coworker. It gets better at your data the longer it works with you.
 
-This article explains what that difference actually means in practice—and why it matters for any team running more than a few queries a week. If you are new to the category, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+This article explains what that difference actually means in practice—and why it matters for any team running more than a few queries a week. If you are new to the category, start with [what is a data engineering agent](/blog/what-is-data-engineering-agent-2026/).
 
 ## TL;DR
 
@@ -68,7 +68,7 @@ A SQL copilot can write a `SELECT` statement with `GROUP BY` and `WHERE` clauses
 
 A human data engineer learns these rules over weeks and applies them unconsciously. A SQL copilot has no mechanism to learn them at all. It treats every query as a fresh problem, because it has nowhere to store what it learned from the last one.
 
-This is the architectural gap: **a copilot generates. An agent generates, captures feedback, and accumulates context.** The first query from both might be similar. The hundredth query from an agent with a [persistent context engine](/posts/contextual-data-engineering) will be materially more accurate than the hundredth query from a copilot—not because the underlying model improved, but because the context it operates on accumulated.
+This is the architectural gap: **a copilot generates. An agent generates, captures feedback, and accumulates context.** The first query from both might be similar. The hundredth query from an agent with a [persistent context engine](/blog/contextual-data-engineering/) will be materially more accurate than the hundredth query from a copilot—not because the underlying model improved, but because the context it operates on accumulated.
 
 ## 3. The three things a data engineering agent has that a SQL copilot lacks
 
@@ -88,7 +88,7 @@ A copilot has no feedback loop. Upvotes, corrections, and usage patterns are los
 
 A data engineering agent can package a scoped subset of context—roughly 10 tables, 20 metrics, 30 validated SQL patterns—into a subagent: a domain-specific chatbot that an analyst or business user can query without knowing SQL. The subagent inherits the context's accuracy and is scoped so it cannot access tables outside its domain. A finance subagent knows finance's definition of revenue. An operations subagent knows operations' definition. Both draw from the same context engine.
 
-A copilot generates SQL for one person. An agent packages context for a team. For a comparison of how different agents handle this, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+A copilot generates SQL for one person. An agent packages context for a team. For a comparison of how different agents handle this, see the [best data engineering agents comparison](/blog/best-data-engineering-agents-2026/).
 
 ## 4. How to tell which you are using
 
@@ -118,7 +118,7 @@ A SQL copilot helps you write queries. A data engineering agent helps you build 
 
 The difference is not about which one is "smarter." The most advanced LLM in the world, used as a copilot with no persistent context, will make the same mistakes on the hundredth query that it made on the first. A modest LLM, backed by a context engine that has accumulated six months of validated SQL, business rules, and feedback history from real usage, will outperform it on the data that matters.
 
-This is the core insight of [contextual data engineering](/posts/contextual-data-engineering): in data work, context compounds. For repeated, team-scale data work, the tool that remembers has a structural advantage over the tool that forgets.
+This is the core insight of [contextual data engineering](/blog/contextual-data-engineering/): in data work, context compounds. For repeated, team-scale data work, the tool that remembers has a structural advantage over the tool that forgets.
 
 Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see the difference between generating queries and building context—ask ten questions against a connected warehouse and watch what the agent learns.
 
@@ -138,6 +138,6 @@ Not necessarily. If the copilot is meeting your needs—you use it for ad-hoc qu
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer model behind persistent context
-- [Data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code) — another comparison that turns competitors into complements
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer model behind persistent context
+- [Data engineering agent vs. Claude Code](/blog/data-engineering-agent-vs-claude-code/) — another comparison that turns competitors into complements

--- a/blog/posts/dbt-semantic-layer-metricflow.md
+++ b/blog/posts/dbt-semantic-layer-metricflow.md
@@ -33,7 +33,7 @@ head:
 
 # dbt Semantic Layer & MetricFlow: A Complete Guide for Data Engineers
 
-Last year, defining a new metric in a dbt project worked like this: write the transformation SQL in a dbt model, document the business logic in a YAML description field (if you remembered), repeat the same logic in Looker's LookML for the dashboard layer, and hope that whoever queries the data six months later understands that `mktg_analytics.fact_attrib_daily.attrib_windows_30d_v2` means "30-day attribution window revenue." The metric existed in four places — the dbt model, the docs, the LookML, and the analyst's head — and keeping them synchronized was a manual process that everyone agreed was valuable and nobody had time to maintain. MetricFlow — the open-source engine behind dbt's Semantic Layer — changes this by making metric definitions a standalone, governed artifact: define `net_revenue` once in YAML, and every BI tool, notebook, API, and AI agent queries the same definition. This article explains how MetricFlow works, what it does well, where it hits its limits, and how it fits into a broader architecture that includes [data engineering agents](/posts/what-is-data-engineering-agent).
+Last year, defining a new metric in a dbt project worked like this: write the transformation SQL in a dbt model, document the business logic in a YAML description field (if you remembered), repeat the same logic in Looker's LookML for the dashboard layer, and hope that whoever queries the data six months later understands that `mktg_analytics.fact_attrib_daily.attrib_windows_30d_v2` means "30-day attribution window revenue." The metric existed in four places — the dbt model, the docs, the LookML, and the analyst's head — and keeping them synchronized was a manual process that everyone agreed was valuable and nobody had time to maintain. MetricFlow — the open-source engine behind dbt's Semantic Layer — changes this by making metric definitions a standalone, governed artifact: define `net_revenue` once in YAML, and every BI tool, notebook, API, and AI agent queries the same definition. This article explains how MetricFlow works, what it does well, where it hits its limits, and how it fits into a broader architecture that includes [data engineering agents](/blog/what-is-data-engineering-agent/).
 
 ## TL;DR
 
@@ -195,6 +195,6 @@ Yes. Datus `/gen_semantic_model` and `/gen_metrics` generate MetricFlow-compatib
 
 ## Related articles
 
-- [What is a metric layer?](/posts/what-is-metric-layer) — the KPI catalog MetricFlow implements
-- [What is a semantic model?](/posts/what-is-semantic-model) — the building block MetricFlow queries
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the full business dictionary
+- [What is a metric layer?](/blog/what-is-metric-layer/) — the KPI catalog MetricFlow implements
+- [What is a semantic model?](/blog/what-is-semantic-model/) — the building block MetricFlow queries
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the full business dictionary

--- a/blog/posts/enterprise-data-engineering-agent.md
+++ b/blog/posts/enterprise-data-engineering-agent.md
@@ -32,9 +32,9 @@ head:
 ---
 # What an Enterprise Data Engineering Agent Actually Needs
 
-A [data engineering agent](/posts/what-is-data-engineering-agent-2026) that works for a single engineer on a single laptop is a productivity tool. A data engineering agent that works for fifty engineers, three hundred analysts, and a security team that audits every database query is infrastructure. The gap between the two is not a matter of scale. It is a matter of architecture.
+A [data engineering agent](/blog/what-is-data-engineering-agent-2026/) that works for a single engineer on a single laptop is a productivity tool. A data engineering agent that works for fifty engineers, three hundred analysts, and a security team that audits every database query is infrastructure. The gap between the two is not a matter of scale. It is a matter of architecture.
 
-This article outlines the six requirements that separate an agent suitable for enterprise deployment from one suitable for personal use—and what each requirement means in practice. For the broader agent landscape, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+This article outlines the six requirements that separate an agent suitable for enterprise deployment from one suitable for personal use—and what each requirement means in practice. For the broader agent landscape, see the [best data engineering agents comparison](/blog/best-data-engineering-agents-2026/).
 
 ## TL;DR
 
@@ -48,7 +48,7 @@ For a personal agent, context lives on one machine. If the engineer's laptop die
 
 For an enterprise, context is an organizational asset. If the agent has accumulated six months of validated SQL, business rules, and metric definitions across three teams, losing that context is a business continuity problem. The context must be shared across the organization (so the finance team's subagent and the marketing team's subagent draw from the same validated source of truth), backed up, and versioned (so teams can trace how a metric definition changed in week 12 and whether queries generated before the change need to be re-run).
 
-This is the architectural difference between local storage and a shared context store. Local storage is simpler. A shared, versioned context store requires database infrastructure, conflict resolution, and access patterns that support concurrent reads and writes from multiple subagents. For the theory behind this, see [contextual data engineering](/posts/contextual-data-engineering).
+This is the architectural difference between local storage and a shared context store. Local storage is simpler. A shared, versioned context store requires database infrastructure, conflict resolution, and access patterns that support concurrent reads and writes from multiple subagents. For the theory behind this, see [contextual data engineering](/blog/contextual-data-engineering/).
 
 ## 2. Access control at the subagent level
 
@@ -79,7 +79,7 @@ This requires a different reliability model. A personal agent that crashes mid-q
 - **Alerting** when an agent task fails or produces anomalous results
 - **Resource isolation** so one team's long-running agent does not degrade another team's interactive queries
 
-This is the operational layer that separates a CLI tool from an infrastructure service. It is also where integration with existing orchestration tools (Airflow, Dagster, Prefect) through [MCP](/posts/mcp-data-engineering) becomes valuable—not every agent needs to build its own scheduler.
+This is the operational layer that separates a CLI tool from an infrastructure service. It is also where integration with existing orchestration tools (Airflow, Dagster, Prefect) through [MCP](/blog/mcp-data-engineering/) becomes valuable—not every agent needs to build its own scheduler.
 
 ## 5. Integration with existing governance
 
@@ -103,7 +103,7 @@ A data engineering agent's commercial model should answer three questions:
 - **What does Enterprise add, and is it worth the money?** SSO, audit logging, shared context store, RBAC, SLA, long-running agent support. These are features enterprises need and will pay for.
 - **Is the vendor sustainable?** AI data tooling changes quickly. Enterprise buyers evaluating agents in 2026 should look for active maintenance, a clear revenue model, and a roadmap that does not depend on community goodwill alone.
 
-For the open-source perspective on this, see [open source data engineering agents](/posts/open-source-data-engineering-agents).
+For the open-source perspective on this, see [open source data engineering agents](/blog/open-source-data-engineering-agents/).
 
 ## 7. The enterprise readiness checklist
 
@@ -148,6 +148,6 @@ Common enterprise expectations include SOC 2 Type II for vendor controls, GDPR r
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — the context architecture that enterprises need
-- [Open source data engineering agents](/posts/open-source-data-engineering-agents) — the self-hosting option for enterprises with strict data residency requirements
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the context architecture that enterprises need
+- [Open source data engineering agents](/blog/open-source-data-engineering-agents/) — the self-hosting option for enterprises with strict data residency requirements

--- a/blog/posts/how-mcp-changes-data-workflow-automation.md
+++ b/blog/posts/how-mcp-changes-data-workflow-automation.md
@@ -295,10 +295,10 @@ That is why MCP matters now. It does not make data workflow automation effortles
 
 ## Related Reading
 
-- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs)
-- [Agentic Data Engineering vs Traditional Data Engineering](/posts/agentic-data-engineering-vs-traditional-data-engineering)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
+- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/blog/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs/)
+- [Agentic Data Engineering vs Traditional Data Engineering](/blog/agentic-data-engineering-vs-traditional-data-engineering/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
 
 ## Start with Datus
 

--- a/blog/posts/how-structured-context-improves-ai-agent-output.md
+++ b/blog/posts/how-structured-context-improves-ai-agent-output.md
@@ -265,8 +265,8 @@ More grounded output.
 
 ## Next steps
 
-- [Why AI Agents Need Semantic Context to Work Reliably](/posts/why-ai-agents-need-semantic-context-to-work-reliably)
-- [Why Reliable Data Agents Need More Than Good Prompts](/posts/why-reliable-data-agents-need-more-than-good-prompts)
+- [Why AI Agents Need Semantic Context to Work Reliably](/blog/why-ai-agents-need-semantic-context-to-work-reliably/)
+- [Why Reliable Data Agents Need More Than Good Prompts](/blog/why-reliable-data-agents-need-more-than-good-prompts/)
 - Explore [Datus Docs](https://docs.datus.ai) for semantic models, metrics, and workflow context
 
 ## FAQ

--- a/blog/posts/index.md
+++ b/blog/posts/index.md
@@ -13,104 +13,104 @@ head:
 
 The problem, the product, and the thesis behind it.
 
-- [Make Data Agents Usable: Ask, Explore, and Control with Confidence](/posts/make-data-agents-truly-usable-ask-explore-and-control-with-confidence) — Apr 2, 2026
-- [Meet the General Chat Agent: Your Data Co-Pilot That Actually Thinks](/posts/meet-the-general-chat-agent) — Mar 25, 2026
-- [SQL Agents Are Broken Without Context. Meet Datus.](/posts/meet_datus) — Oct 21, 2025
-- [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack) — Mar 11, 2026
+- [Make Data Agents Usable: Ask, Explore, and Control with Confidence](/blog/make-data-agents-truly-usable-ask-explore-and-control-with-confidence/) — Apr 2, 2026
+- [Meet the General Chat Agent: Your Data Co-Pilot That Actually Thinks](/blog/meet-the-general-chat-agent/) — Mar 25, 2026
+- [SQL Agents Are Broken Without Context. Meet Datus.](/blog/meet_datus/) — Oct 21, 2025
+- [From Human-First Data Systems to the Agentic Data Stack](/blog/agentic-data-stack/) — Mar 11, 2026
 
 ## Data Engineering Agent
 
 The category, the comparisons, and how to build with one — our core cluster.
 
-- [How Datus Turns AI-Generated SQL into Trusted Data](/posts/sql-was-never-the-hard-part) — Jun 11, 2026
-- [What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison](/posts/what-is-data-engineering-agent-2026) — May 31, 2026
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent) — Mar 2, 2026
-- [Contextual Data Engineering: Why Every Agent Needs Evolvable Context](/posts/contextual-data-engineering) — Jun 1, 2026
-- [Best Data Engineering Agents in 2026: An Honest Comparison](/posts/best-data-engineering-agents-2026) — Jun 2, 2026
-- [Open Source Data Engineering Agents](/posts/open-source-data-engineering-agents) — Jun 2, 2026
-- [How to Build Your First Data Engineering Agent in 15 Minutes](/posts/build-your-first-data-engineering-agent) — Jun 3, 2026
-- [Data Engineering Agent vs. Claude Code: When to Use Which](/posts/data-engineering-agent-vs-claude-code) — Jun 3, 2026
-- [Data Engineering Agent vs. SQL Copilot: What's the Real Difference?](/posts/data-engineering-agent-vs-sql-copilot) — Jun 4, 2026
-- [One-Person Data Team: How a Data Engineering Agent Multiplies Your Output](/posts/one-person-data-team) — Jun 4, 2026
-- [How a Context Engine Makes Data Engineering Agents More Accurate](/posts/context-engine-data-engineering-agent-accuracy) — Jun 1, 2026
-- [MCP and Data Engineering: The Protocol That Connects Your Entire Stack](/posts/mcp-data-engineering) — Jun 2, 2026
-- [What an Enterprise Data Engineering Agent Actually Needs](/posts/enterprise-data-engineering-agent) — Jun 3, 2026
-- [Subagents: How to Ship Domain-Specific Data Agents Without Training a Model](/posts/subagents-domain-specific-data-agents) — Jun 4, 2026
-- [Best Data Engineering Agents in 2026: An Honest Comparison](/posts/best-data-engineering-agents) — Jun 10, 2026
-- [AI-Native Data Platforms: Why the Next Generation Needs Agents, Not Just Copilots](/posts/ai-native-data-platforms) — Jun 10, 2026
-- [Platform-Native Data Engineering Agents Compared: Cortex Code, Genie Code, and BigQuery DE Agent](/posts/platform-native-data-agents-compared) — Jun 10, 2026
+- [How Datus Turns AI-Generated SQL into Trusted Data](/blog/sql-was-never-the-hard-part/) — Jun 11, 2026
+- [What Is a Data Engineering Agent? Definition, Examples & a 2026 Comparison](/blog/what-is-data-engineering-agent-2026/) — May 31, 2026
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/) — Mar 2, 2026
+- [Contextual Data Engineering: Why Every Agent Needs Evolvable Context](/blog/contextual-data-engineering/) — Jun 1, 2026
+- [Best Data Engineering Agents in 2026: An Honest Comparison](/blog/best-data-engineering-agents-2026/) — Jun 2, 2026
+- [Open Source Data Engineering Agents](/blog/open-source-data-engineering-agents/) — Jun 2, 2026
+- [How to Build Your First Data Engineering Agent in 15 Minutes](/blog/build-your-first-data-engineering-agent/) — Jun 3, 2026
+- [Data Engineering Agent vs. Claude Code: When to Use Which](/blog/data-engineering-agent-vs-claude-code/) — Jun 3, 2026
+- [Data Engineering Agent vs. SQL Copilot: What's the Real Difference?](/blog/data-engineering-agent-vs-sql-copilot/) — Jun 4, 2026
+- [One-Person Data Team: How a Data Engineering Agent Multiplies Your Output](/blog/one-person-data-team/) — Jun 4, 2026
+- [How a Context Engine Makes Data Engineering Agents More Accurate](/blog/context-engine-data-engineering-agent-accuracy/) — Jun 1, 2026
+- [MCP and Data Engineering: The Protocol That Connects Your Entire Stack](/blog/mcp-data-engineering/) — Jun 2, 2026
+- [What an Enterprise Data Engineering Agent Actually Needs](/blog/enterprise-data-engineering-agent/) — Jun 3, 2026
+- [Subagents: How to Ship Domain-Specific Data Agents Without Training a Model](/blog/subagents-domain-specific-data-agents/) — Jun 4, 2026
+- [Best Data Engineering Agents in 2026: An Honest Comparison](/blog/best-data-engineering-agents/) — Jun 10, 2026
+- [AI-Native Data Platforms: Why the Next Generation Needs Agents, Not Just Copilots](/blog/ai-native-data-platforms/) — Jun 10, 2026
+- [Platform-Native Data Engineering Agents Compared: Cortex Code, Genie Code, and BigQuery DE Agent](/blog/platform-native-data-agents-compared/) — Jun 10, 2026
 
 ## Semantic Layer
 
 What a semantic layer is, and how it differs from a metric layer, model, ontology, or catalog.
 
-- [What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer](/posts/what-is-semantic-layer) — May 31, 2026
-- [What Is a Metric Layer? Definition, Examples & How It Differs From a Semantic Layer](/posts/what-is-metric-layer) — Jun 8, 2026
-- [What Is a Semantic Model? Definition, Examples & How It Differs From a Semantic View](/posts/what-is-semantic-model) — Jun 8, 2026
-- [Semantic Layer vs Ontology: What's the Difference and Why It Matters for AI Agents](/posts/semantic-layer-vs-ontology) — Jun 9, 2026
-- [Open Semantic Interchange (OSI): What the New Standard Means for Data Engineering and AI Agents](/posts/open-semantic-interchange-osi) — Jun 9, 2026
-- [dbt Semantic Layer & MetricFlow: A Complete Guide for Data Engineers](/posts/dbt-semantic-layer-metricflow) — Jun 9, 2026
-- [Cube.dev: From Semantic Layer Pioneer to Agentic Analytics Platform](/posts/cube-agentic-analytics) — Jun 9, 2026
-- [GoodData: How a 17-Year BI Company Became an AI-Native Analytics Platform](/posts/what-is-gooddata) — Jun 10, 2026
+- [What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer](/blog/what-is-semantic-layer/) — May 31, 2026
+- [What Is a Metric Layer? Definition, Examples & How It Differs From a Semantic Layer](/blog/what-is-metric-layer/) — Jun 8, 2026
+- [What Is a Semantic Model? Definition, Examples & How It Differs From a Semantic View](/blog/what-is-semantic-model/) — Jun 8, 2026
+- [Semantic Layer vs Ontology: What's the Difference and Why It Matters for AI Agents](/blog/semantic-layer-vs-ontology/) — Jun 9, 2026
+- [Open Semantic Interchange (OSI): What the New Standard Means for Data Engineering and AI Agents](/blog/open-semantic-interchange-osi/) — Jun 9, 2026
+- [dbt Semantic Layer & MetricFlow: A Complete Guide for Data Engineers](/blog/dbt-semantic-layer-metricflow/) — Jun 9, 2026
+- [Cube.dev: From Semantic Layer Pioneer to Agentic Analytics Platform](/blog/cube-agentic-analytics/) — Jun 9, 2026
+- [GoodData: How a 17-Year BI Company Became an AI-Native Analytics Platform](/blog/what-is-gooddata/) — Jun 10, 2026
 
 ## Glossary
 
 Core data engineering terms — defined, with how they connect to agents and context.
 
-- [What Is Text-to-SQL? Definition, How It Works & Why Context Matters](/posts/what-is-text-to-sql) — Jun 7, 2026
-- [What Is Schema Linking? Definition, Challenges & How Agents Map NL to Columns](/posts/what-is-schema-linking) — Jun 7, 2026
-- [What Is RAG for Data Engineering? Retrieval, Context & Agent Accuracy](/posts/rag-data-engineering) — Jun 7, 2026
-- [What Is a Data Catalog? Definition, Tools & How It Differs From Agent Context](/posts/what-is-data-catalog) — Jun 7, 2026
-- [What Is Data Mesh? Definition, Principles & How Domain Agents Map to It](/posts/what-is-data-mesh) — Jun 8, 2026
-- [What Is a Data Agent? How It Differs From a Data Engineering Agent](/posts/what-is-data-agent) — Jun 8, 2026
+- [What Is Text-to-SQL? Definition, How It Works & Why Context Matters](/blog/what-is-text-to-sql/) — Jun 7, 2026
+- [What Is Schema Linking? Definition, Challenges & How Agents Map NL to Columns](/blog/what-is-schema-linking/) — Jun 7, 2026
+- [What Is RAG for Data Engineering? Retrieval, Context & Agent Accuracy](/blog/rag-data-engineering/) — Jun 7, 2026
+- [What Is a Data Catalog? Definition, Tools & How It Differs From Agent Context](/blog/what-is-data-catalog/) — Jun 7, 2026
+- [What Is Data Mesh? Definition, Principles & How Domain Agents Map to It](/blog/what-is-data-mesh/) — Jun 8, 2026
+- [What Is a Data Agent? How It Differs From a Data Engineering Agent](/blog/what-is-data-agent/) — Jun 8, 2026
 
 ## Why agents, not copilots
 
 The shift from assistive AI to autonomous data workflows.
 
-- [Why Data Engineering Needs Agents, Not Just Copilots](/posts/why-data-engineering-needs-agents-not-just-copilots) — Mar 16, 2026
-- [Agentic Data Engineering vs Traditional Data Engineering](/posts/agentic-data-engineering-vs-traditional-data-engineering) — Mar 16, 2026
-- [What Autonomous Data Engineering Actually Looks Like in Practice](/posts/what-autonomous-data-engineering-actually-looks-like-in-practice) — Mar 16, 2026
+- [Why Data Engineering Needs Agents, Not Just Copilots](/blog/why-data-engineering-needs-agents-not-just-copilots/) — Mar 16, 2026
+- [Agentic Data Engineering vs Traditional Data Engineering](/blog/agentic-data-engineering-vs-traditional-data-engineering/) — Mar 16, 2026
+- [What Autonomous Data Engineering Actually Looks Like in Practice](/blog/what-autonomous-data-engineering-actually-looks-like-in-practice/) — Mar 16, 2026
 
 ## Architecture and pipelines
 
 How Datus works under the hood — agent design, storage, ETL, and pipeline automation.
 
-- [Datus Storage Layer: A Foundation Built for Every Environment](/posts/datus-storage-layer) — Mar 25, 2026
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture) — Mar 2, 2026
-- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs) — Mar 16, 2026
-- [Agentic ETL: What Changes Beyond Traditional ETL](/posts/agentic-etl-what-changes-beyond-traditional-etl) — Mar 16, 2026
+- [Datus Storage Layer: A Foundation Built for Every Environment](/blog/datus-storage-layer/) — Mar 25, 2026
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/) — Mar 2, 2026
+- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/blog/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs/) — Mar 16, 2026
+- [Agentic ETL: What Changes Beyond Traditional ETL](/blog/agentic-etl-what-changes-beyond-traditional-etl/) — Mar 16, 2026
 
 ## Why context is everything
 
 Semantic models, structured context, and what makes agents reliable.
 
-- [Why AI Agents Need Semantic Context to Work Reliably](/posts/why-ai-agents-need-semantic-context-to-work-reliably) — Mar 16, 2026
-- [How Structured Context Improves AI Agent Output](/posts/how-structured-context-improves-ai-agent-output) — Mar 16, 2026
-- [Semantic Modeling for Agentic Analytics Workflows](/posts/semantic-modeling-for-agentic-analytics-workflows) — Mar 16, 2026
-- [Why Reliable Data Agents Need More Than Good Prompts](/posts/why-reliable-data-agents-need-more-than-good-prompts) — Mar 16, 2026
+- [Why AI Agents Need Semantic Context to Work Reliably](/blog/why-ai-agents-need-semantic-context-to-work-reliably/) — Mar 16, 2026
+- [How Structured Context Improves AI Agent Output](/blog/how-structured-context-improves-ai-agent-output/) — Mar 16, 2026
+- [Semantic Modeling for Agentic Analytics Workflows](/blog/semantic-modeling-for-agentic-analytics-workflows/) — Mar 16, 2026
+- [Why Reliable Data Agents Need More Than Good Prompts](/blog/why-reliable-data-agents-need-more-than-good-prompts/) — Mar 16, 2026
 
 ## Tooling and integrations
 
 MCP, extensions, and how agents connect to real data systems.
 
-- [Beyond SQL: How Datus Integrates With Your Entire Data Toolchain](/posts/beyond-sql-how-datus-integrates-with-your-entire-data-toolchain) — Apr 2, 2026
-- [How MCP Changes Data Workflow Automation](/posts/how-mcp-changes-data-workflow-automation) — Mar 16, 2026
-- [Using MCP Extensions in Data Engineering Workflows](/posts/using-mcp-extensions-in-data-engineering-workflows) — Mar 16, 2026
+- [Beyond SQL: How Datus Integrates With Your Entire Data Toolchain](/blog/beyond-sql-how-datus-integrates-with-your-entire-data-toolchain/) — Apr 2, 2026
+- [How MCP Changes Data Workflow Automation](/blog/how-mcp-changes-data-workflow-automation/) — Mar 16, 2026
+- [Using MCP Extensions in Data Engineering Workflows](/blog/using-mcp-extensions-in-data-engineering-workflows/) — Mar 16, 2026
 
 ## In practice
 
 Real use cases and how agentic data teams operate.
 
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases) — Mar 2, 2026
-- [The Operating Model of an Agentic Data Team](/posts/the-operating-model-of-an-agentic-data-team) — Mar 16, 2026
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/) — Mar 2, 2026
+- [The Operating Model of an Agentic Data Team](/blog/the-operating-model-of-an-agentic-data-team/) — Mar 16, 2026
 
 ## Releases
 
-- [Datus 0.2.6 Release: Equipping the Agent with a Brain](/posts/datus-0-2-6-release-equipping-the-agent-with-a-brain) — Mar 20, 2026
+- [Datus 0.2.6 Release: Equipping the Agent with a Brain](/blog/datus-0-2-6-release-equipping-the-agent-with-a-brain/) — Mar 20, 2026
 
 ## Reference
 
 - [Data Engineering Agent: The Complete Guide](/data-engineering-agent/)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
-- [Welcome to Datus Blog](/posts/welcome) — Jan 20, 2025
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
+- [Welcome to Datus Blog](/blog/welcome/) — Jan 20, 2025

--- a/blog/posts/mcp-data-engineering.md
+++ b/blog/posts/mcp-data-engineering.md
@@ -34,7 +34,7 @@ head:
 
 The Model Context Protocol (MCP), introduced by Anthropic and maintained as an open protocol, is the closest thing the AI agent ecosystem has to a shared connector standard. It standardizes how agents discover and use external tools—databases, APIs, file systems, orchestrators—through a client-server model that works across vendors. For data engineering, it matters because it turns a fragmented stack of tools that do not talk to each other into a set of composable capabilities that an agent can orchestrate.
 
-This article explains what MCP means for data engineering specifically, how agents use it as both clients and servers, and where the protocol's current limitations leave room for native tooling. If you are new to the agent side, start with [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+This article explains what MCP means for data engineering specifically, how agents use it as both clients and servers, and where the protocol's current limitations leave room for native tooling. If you are new to the agent side, start with [what is a data engineering agent](/blog/what-is-data-engineering-agent-2026/).
 
 ## TL;DR
 
@@ -71,7 +71,7 @@ A data engineering agent exposes its own capabilities as an MCP server, making i
 - **Claude Code queries Datus context:** Claude Code, working on a data pipeline refactor, calls Datus's MCP server to retrieve validated join paths and metric definitions—so the code it generates is grounded in the team's actual data context.
 - **A dashboard tool queries agent context:** A BI tool calls the agent's MCP server to retrieve metric definitions, ensuring that dashboard KPIs match the definitions the agent uses.
 
-This pattern is about making the agent's accumulated knowledge available to the rest of the ecosystem. The context engine becomes a shared service, not a silo. For more on how this complements general-purpose agents, see [data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code).
+This pattern is about making the agent's accumulated knowledge available to the rest of the ecosystem. The context engine becomes a shared service, not a silo. For more on how this complements general-purpose agents, see [data engineering agent vs. Claude Code](/blog/data-engineering-agent-vs-claude-code/).
 
 ## 3. The MCP data engineering ecosystem in 2026
 
@@ -106,7 +106,7 @@ This is not a criticism of MCP. It is a design tradeoff inherent in any abstract
 
 The most strategically interesting MCP pattern for data engineering is not "agent calls database through MCP." It is "agent exposes its accumulated context through MCP."
 
-A [context engine](/posts/contextual-data-engineering) that has accumulated six months of validated SQL, business rules, and feedback history is a valuable asset. MCP turns that asset into a service. Instead of the context being locked inside one agent, it becomes available to every tool that speaks MCP:
+A [context engine](/blog/contextual-data-engineering/) that has accumulated six months of validated SQL, business rules, and feedback history is a valuable asset. MCP turns that asset into a service. Instead of the context being locked inside one agent, it becomes available to every tool that speaks MCP:
 
 - Claude Code generates a dbt model and retrieves the correct join path from the context engine.
 - A dashboard tool retrieves metric definitions to ensure consistency.
@@ -124,7 +124,7 @@ Questions worth asking:
 - **MCP Server:** Does the agent expose its context engine through MCP? Can other agents query the accumulated context—validated SQL, metrics, business rules?
 - **Core vs. MCP boundary:** Which capabilities are native (fast, deep, integrated) and which are MCP-mediated (broad, flexible, slower)? A clear boundary is a sign of architectural maturity; treating everything as MCP-mediated is a sign the agent has no native depth.
 
-For a comparison of how current agents handle this boundary, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+For a comparison of how current agents handle this boundary, see the [best data engineering agents comparison](/blog/best-data-engineering-agents-2026/).
 
 ## Source notes
 
@@ -154,6 +154,6 @@ MCP servers run with the permissions of the process that hosts them. When an age
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — the context model that MCP makes available to other agents
-- [Data engineering agent vs. Claude Code](/posts/data-engineering-agent-vs-claude-code) — the MCP-mediated complementary architecture
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the context model that MCP makes available to other agents
+- [Data engineering agent vs. Claude Code](/blog/data-engineering-agent-vs-claude-code/) — the MCP-mediated complementary architecture

--- a/blog/posts/meet_datus.md
+++ b/blog/posts/meet_datus.md
@@ -116,10 +116,10 @@ Ultimately, Datus is about building this evolvable context—a living foundation
 
 ## Related Reading
 
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
 
 ## Getting started
 - [Installation and quickstart](https://docs.datus.ai/getting_started/Quickstart/)
@@ -128,5 +128,5 @@ Ultimately, Datus is about building this evolvable context—a living foundation
 
 ## Continue Reading
 
-- Previous: [Welcome to the Datus Blog](/posts/welcome)
-- Next: [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
+- Previous: [Welcome to the Datus Blog](/blog/welcome/)
+- Next: [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)

--- a/blog/posts/one-person-data-team.md
+++ b/blog/posts/one-person-data-team.md
@@ -36,7 +36,7 @@ The modern data stack was designed for teams. dbt, Airflow, Snowflake, Looker, M
 
 That one person is not underperforming. They are outnumbered. The bottleneck is not their speed; it is the volume of context-switching, the repetitive nature of data requests, and the impossibility of being the sole carrier of institutional knowledge about the warehouse.
 
-A [data engineering agent](/posts/what-is-data-engineering-agent-2026) changes the math. Not by replacing the engineer, but by handling the repetitive work, accumulating context so the engineer does not have to re-explain the same tables every week, and delivering self-service access to people who would otherwise file tickets. This article explains how—and what it actually looks like in daily practice.
+A [data engineering agent](/blog/what-is-data-engineering-agent-2026/) changes the math. Not by replacing the engineer, but by handling the repetitive work, accumulating context so the engineer does not have to re-explain the same tables every week, and delivering self-service access to people who would otherwise file tickets. This article explains how—and what it actually looks like in daily practice.
 
 ## TL;DR
 
@@ -58,7 +58,7 @@ A data engineering agent does not solve all of these problems. But it takes aim 
 
 ## 2. How an agent changes the daily workflow
 
-Here is what a typical week looks like for a solo data engineer, before and after adopting an agent with a [persistent context engine](/posts/contextual-data-engineering).
+Here is what a typical week looks like for a solo data engineer, before and after adopting an agent with a [persistent context engine](/blog/contextual-data-engineering/).
 
 ### Before: the ticket treadmill
 
@@ -96,7 +96,7 @@ A <a href="https://datus.ai/glossary">data engineering agent</a> with a context 
 
 With an agent, the context engine stores every validated query, every corrected definition, and every business rule. When a new request arrives, the agent retrieves relevant context before generating SQL—so the first attempt is already grounded in what the team has learned. The finance subagent does not need to be told, every time, that "net revenue excludes refunds and uses locked FX rates." It knows, because that rule is in its context.
 
-This is [contextual data engineering](/posts/contextual-data-engineering) in practice: the agent does not just answer questions. It accumulates the institutional knowledge that makes answers consistently correct. For a one-person team, this is the difference between being the bottleneck and being the enabler.
+This is [contextual data engineering](/blog/contextual-data-engineering/) in practice: the agent does not just answer questions. It accumulates the institutional knowledge that makes answers consistently correct. For a one-person team, this is the difference between being the bottleneck and being the enabler.
 
 ## 4. What the agent does not replace
 
@@ -129,7 +129,7 @@ The path from ticket treadmill to agent-assisted team:
 
 The goal is not to automate yourself out of a job. It is to automate the part of the job that is not engineering—the translation, the repetition, the re-explaining—so you can spend your time on the engineering that moves the company forward.
 
-Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see how an agent handles domain-specific context, or follow the [15-minute tutorial](/posts/build-your-first-data-engineering-agent) to set one up yourself.
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see how an agent handles domain-specific context, or follow the [15-minute tutorial](/blog/build-your-first-data-engineering-agent/) to set one up yourself.
 
 ## Frequently asked questions
 
@@ -147,6 +147,6 @@ The analyst files an issue report describing what was wrong. The correction flow
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — the feedback loop that makes one-person teams work
-- [Build your first data engineering agent](/posts/build-your-first-data-engineering-agent) — a 15-minute tutorial
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the feedback loop that makes one-person teams work
+- [Build your first data engineering agent](/blog/build-your-first-data-engineering-agent/) — a 15-minute tutorial

--- a/blog/posts/open-semantic-interchange-osi.md
+++ b/blog/posts/open-semantic-interchange-osi.md
@@ -33,7 +33,7 @@ head:
 
 # Open Semantic Interchange (OSI): What the New Standard Means for Data Engineering and AI Agents
 
-Until January 2026, if your team defined `net_revenue` in MetricFlow inside a dbt project, that definition was trapped in the dbt ecosystem. Your Looker dashboard had a separate copy — same metric name, independently maintained logic. Your Python analytics stack had a third. Your AI agent, deprived of any of these, queried raw schema and guessed at the business logic. Three copies of the same metric, three maintenance surfaces, three opportunities to drift — and each new consumption tool added another. The **Open Semantic Interchange (OSI)** specification — finalized in January 2026 under Apache 2.0 with over 30 participating organizations — is the industry's answer to this fragmentation. It does not replace MetricFlow, Cube, or LookML. It provides an interchange format so a metric authored in any of them can be consumed by all of them. This article explains what OSI standardizes, who is behind it, and why portable semantics change the architecture conversation for [data engineering agents](/posts/what-is-data-engineering-agent) — not by solving every problem, but by making the problems that remain more visible.
+Until January 2026, if your team defined `net_revenue` in MetricFlow inside a dbt project, that definition was trapped in the dbt ecosystem. Your Looker dashboard had a separate copy — same metric name, independently maintained logic. Your Python analytics stack had a third. Your AI agent, deprived of any of these, queried raw schema and guessed at the business logic. Three copies of the same metric, three maintenance surfaces, three opportunities to drift — and each new consumption tool added another. The **Open Semantic Interchange (OSI)** specification — finalized in January 2026 under Apache 2.0 with over 30 participating organizations — is the industry's answer to this fragmentation. It does not replace MetricFlow, Cube, or LookML. It provides an interchange format so a metric authored in any of them can be consumed by all of them. This article explains what OSI standardizes, who is behind it, and why portable semantics change the architecture conversation for [data engineering agents](/blog/what-is-data-engineering-agent/) — not by solving every problem, but by making the problems that remain more visible.
 
 ## TL;DR
 
@@ -163,6 +163,6 @@ Now, for architectural direction. Start building semantic infrastructure with th
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the business dictionary OSI makes portable
-- [What is a metric layer?](/posts/what-is-metric-layer) — the KPI catalog OSI standardizes
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — how agents operationalize semantics
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the business dictionary OSI makes portable
+- [What is a metric layer?](/blog/what-is-metric-layer/) — the KPI catalog OSI standardizes
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — how agents operationalize semantics

--- a/blog/posts/open-source-data-engineering-agents.md
+++ b/blog/posts/open-source-data-engineering-agents.md
@@ -36,7 +36,7 @@ Not every category needs an open-source option. Most people do not need an open-
 
 Data engineering is different. The agent you choose will have credentials to your warehouse. It will read your schemas, generate your SQL, and—in some configurations—execute queries against production data. It will become part of your data infrastructure the way dbt or Airflow is part of your infrastructure. When a tool sits that deep in your stack, the questions that matter are not just about features. They are about control, auditability, and what happens if the vendor changes direction.
 
-This article explains why open-source data engineering agents exist as a category, when the tradeoff of self-hosting is worth it, and how to choose among the three leading open-source options. For the full landscape including closed-source and platform-embedded agents, see the [best data engineering agents comparison](/posts/best-data-engineering-agents-2026).
+This article explains why open-source data engineering agents exist as a category, when the tradeoff of self-hosting is worth it, and how to choose among the three leading open-source options. For the full landscape including closed-source and platform-embedded agents, see the [best data engineering agents comparison](/blog/best-data-engineering-agents-2026/).
 
 ## TL;DR
 
@@ -71,7 +71,7 @@ Open-source agents are stack-agnostic by design. They connect to multiple wareho
 
 ### Community sustainability: the agent outlives any single company
 
-AI data tools can change direction quickly: repos can slow down, companies can pivot, and commercial offerings can replace community-first roadmaps. Closed-source agents can disappear when the company runs out of money; open-source agents can survive a vendor shift only if the community and maintenance model are strong enough. For more on the competitive dynamics driving this cycle, see [the DE agent category overview](/posts/what-is-data-engineering-agent-2026).
+AI data tools can change direction quickly: repos can slow down, companies can pivot, and commercial offerings can replace community-first roadmaps. Closed-source agents can disappear when the company runs out of money; open-source agents can survive a vendor shift only if the community and maintenance model are strong enough. For more on the competitive dynamics driving this cycle, see [the DE agent category overview](/blog/what-is-data-engineering-agent-2026/).
 
 This is not an argument that open-source is always better. It is an argument that the stakes in data engineering agent selection are high enough to make open source worth considering. If the agent will become part of your core infrastructure, you should own the infrastructure.
 
@@ -97,7 +97,7 @@ Wren AI is the most mature open-source option by community size. Its core is an 
 
 **Best for:** Teams that already have a well-maintained semantic layer (or are willing to build one) and want to add an AI query interface on top. The MDL modeling tools are more polished than any other open-source agent's, and the community is larger, which means more tutorials, more answered questions, and faster bug fixes.
 
-**Tradeoffs:** The semantic model is static—you build it once, and the agent queries against it. There is no feedback loop that updates the model based on usage. If a query surfaces a missing dimension or an incorrect join, the fix requires a human to update the model manually. For teams whose context evolves faster than their modeling sprints, this static model becomes a bottleneck. This is the central philosophical difference between Wren AI and Datus: Wren AI treats context as a model you build; Datus treats context as an asset that grows with usage. For the theoretical underpinning, see [contextual data engineering](/posts/contextual-data-engineering).
+**Tradeoffs:** The semantic model is static—you build it once, and the agent queries against it. There is no feedback loop that updates the model based on usage. If a query surfaces a missing dimension or an incorrect join, the fix requires a human to update the model manually. For teams whose context evolves faster than their modeling sprints, this static model becomes a bottleneck. This is the central philosophical difference between Wren AI and Datus: Wren AI treats context as a model you build; Datus treats context as an asset that grows with usage. For the theoretical underpinning, see [contextual data engineering](/blog/contextual-data-engineering/).
 
 ### Altimate — Agentic dbt Harness
 
@@ -186,6 +186,6 @@ If the license is permissive (Apache 2.0, MIT), you can fork the repository and 
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition and four-agent comparison
-- [Best data engineering agents in 2026](/posts/best-data-engineering-agents-2026) — full landscape comparison including closed-source and platform agents
-- [Contextual data engineering](/posts/contextual-data-engineering) — the three-layer context model that separates durable agents from chat windows
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition and four-agent comparison
+- [Best data engineering agents in 2026](/blog/best-data-engineering-agents-2026/) — full landscape comparison including closed-source and platform agents
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the three-layer context model that separates durable agents from chat windows

--- a/blog/posts/platform-native-data-agents-compared.md
+++ b/blog/posts/platform-native-data-agents-compared.md
@@ -185,6 +185,6 @@ Single-platform team (all Snowflake, all Databricks, all BigQuery) → platform-
 
 ## Related articles
 
-- [Best Data Engineering Agents](/posts/best-data-engineering-agents) — full category comparison
-- [Open Source Data Engineering Agents](/posts/open-source-data-engineering-agents) — the open alternative
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — the category definition
+- [Best Data Engineering Agents](/blog/best-data-engineering-agents/) — full category comparison
+- [Open Source Data Engineering Agents](/blog/open-source-data-engineering-agents/) — the open alternative
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the category definition

--- a/blog/posts/rag-data-engineering.md
+++ b/blog/posts/rag-data-engineering.md
@@ -71,7 +71,7 @@ High-value retrieval sources:
 
 | Source | Retrieved content | Helps with |
 | --- | --- | --- |
-| **Table/column metadata** | Names, types, keys | [Schema linking](/posts/what-is-schema-linking) |
+| **Table/column metadata** | Names, types, keys | [Schema linking](/blog/what-is-schema-linking/) |
 | **Semantic layer exports** | Metric YAML, dimensions | Business terms → logic |
 | **Reference SQL** | Past correct queries | Join paths, filters, grain |
 | **Issue / feedback notes** | Corrections, deprecations | Institutional memory |
@@ -95,7 +95,7 @@ Step 7 separates **agent RAG** from demo RAG. Without feedback into the index, r
 
 Let's trace this pipeline with a real scenario. An analyst asks "month-over-month new customer ARPU by acquisition channel." The indexing step (1) has already chunked the Finance domain's schema, the Marketing domain's attribution tables, and 40 validated reference SQL queries tagged with "customer" and "ARPU." The query step (2) runs a hybrid search: keyword search matches "ARPU" against metadata and SQL text, while vector search finds semantically similar questions like "average revenue per user by signup source." The ranking step (3) surfaces the top 15 chunks — including a reference SQL query from last month that computed new customer ARPU using `fact_subscription.first_payment / COUNT(DISTINCT dim_user.user_id)` — and filters out chunks from the Sales domain that use a different ARPU definition. The compose step (4) assembles a prompt with the Finance domain rules, the retrieved reference SQL as few-shot examples, and the analyst's question. The generate step (5) produces SQL that uses the same join path and filter logic as the reference example. The validate step (6) executes the query and compares the result count against a cached approximate answer from the BI dashboard. The re-index step (7) stores this validated query as a new retrieval candidate for future ARPU questions — so next month's ARPU question retrieves an even richer set of examples.
 
-[Contextual data engineering](/posts/contextual-data-engineering) describes that evolution loop as the operating system for agents.
+[Contextual data engineering](/blog/contextual-data-engineering/) describes that evolution loop as the operating system for agents.
 
 ## 5. Failure modes specific to data RAG
 
@@ -117,11 +117,11 @@ New column not indexed; model never sees it. Mitigation: catalog sync jobs and i
 
 ### No execution grounding
 
-Model cites retrieved SQL but does not run it. Mitigation: agent tools that execute, inspect errors, and retry — as in [build your first data engineering agent](/posts/build-your-first-data-engineering-agent). The retrieval provides a plausible join path; execution validates whether that path actually works on today's data. Without execution, the RAG pipeline is a citation engine, not a verification engine — it tells the model what someone did last month without checking whether that approach still applies.
+Model cites retrieved SQL but does not run it. Mitigation: agent tools that execute, inspect errors, and retry — as in [build your first data engineering agent](/blog/build-your-first-data-engineering-agent/). The retrieval provides a plausible join path; execution validates whether that path actually works on today's data. Without execution, the RAG pipeline is a citation engine, not a verification engine — it tells the model what someone did last month without checking whether that approach still applies.
 
 ## 6. RAG and the semantic layer
 
-A [semantic layer](/posts/what-is-semantic-layer) is a high-quality retrieval source for **certified metrics**. It is incomplete for **ad-hoc validated SQL** and **tribal rules** that never became YAML.
+A [semantic layer](/blog/what-is-semantic-layer/) is a high-quality retrieval source for **certified metrics**. It is incomplete for **ad-hoc validated SQL** and **tribal rules** that never became YAML.
 
 | Context source | Strength | Gap |
 | --- | --- | --- |
@@ -144,7 +144,7 @@ Common vector backends used in data RAG pipelines include LanceDB, pgvector, and
 
 When a general-purpose agent calls a data tool via <a href="https://modelcontextprotocol.io/" rel="nofollow noopener">MCP</a>, the **data side** still needs RAG — the host model does not magically know your warehouse. The data tool must expose the same retrieval index to the MCP client that it uses for its own generations.
 
-See [MCP and data engineering](/posts/mcp-data-engineering) for the integration pattern.
+See [MCP and data engineering](/blog/mcp-data-engineering/) for the integration pattern.
 
 ## 9. A RAG failure timeline: how stale retrieval produces wrong SQL
 
@@ -162,7 +162,7 @@ This pattern — stale index producing confident wrong answers — is the most c
 
 ## Conclusion
 
-**RAG for data engineering** is not "connect a PDF to ChatGPT." It is a governed retrieval layer over schema, semantics, and validated SQL that makes [text-to-SQL](/posts/what-is-text-to-sql) and agents accurate at scale. The differentiator is not retrieval itself — everyone has embeddings in 2026 — but whether retrieved context **updates with production feedback** and **respects domain scope**. That is the move from demo RAG to contextual data engineering.
+**RAG for data engineering** is not "connect a PDF to ChatGPT." It is a governed retrieval layer over schema, semantics, and validated SQL that makes [text-to-SQL](/blog/what-is-text-to-sql/) and agents accurate at scale. The differentiator is not retrieval itself — everyone has embeddings in 2026 — but whether retrieved context **updates with production feedback** and **respects domain scope**. That is the move from demo RAG to contextual data engineering.
 
 ## Frequently asked questions
 
@@ -184,9 +184,9 @@ Usually **stale or noisy indexes**, **no scope**, and **no feedback loop** — n
 
 ## Related articles
 
-- [What is text-to-SQL?](/posts/what-is-text-to-sql) — generation task RAG supports
-- [What is schema linking?](/posts/what-is-schema-linking) — retrieval quality determines link quality
-- [How a context engine improves agent accuracy](/posts/context-engine-data-engineering-agent-accuracy) — RAG as part of persistent context
+- [What is text-to-SQL?](/blog/what-is-text-to-sql/) — generation task RAG supports
+- [What is schema linking?](/blog/what-is-schema-linking/) — retrieval quality determines link quality
+- [How a context engine improves agent accuracy](/blog/context-engine-data-engineering-agent-accuracy/) — RAG as part of persistent context
 
 ---
 

--- a/blog/posts/semantic-layer-vs-ontology.md
+++ b/blog/posts/semantic-layer-vs-ontology.md
@@ -33,7 +33,7 @@ head:
 
 # Semantic Layer vs Ontology: What's the Difference and Why It Matters for AI Agents
 
-An AI agent is asked: "Which customer segments contributed most to revenue growth last quarter, and how do they relate to our product lines?" It identifies the `net_revenue` metric from the [semantic layer](/posts/what-is-semantic-layer), slices it by `customer_segment`, and returns a number. The SQL is flawless. The result is wrong — because the agent joined customers to contracts through a billing relationship instead of the ownership relationship, conflated physical products (SKUs in a warehouse) with SaaS products (plan tiers in a subscription table), and attributed revenue from multi-product contracts entirely to the first product on the invoice. The semantic layer ensured the metric was computed correctly. What was missing — and what caused every downstream error — was an **ontology**: a formal model of what kinds of things exist in this business domain and how they relate to each other. This article defines each concept, maps where they overlap and where they diverge, and explains why the distinction stops being academic the moment you deploy an AI agent against real enterprise data.
+An AI agent is asked: "Which customer segments contributed most to revenue growth last quarter, and how do they relate to our product lines?" It identifies the `net_revenue` metric from the [semantic layer](/blog/what-is-semantic-layer/), slices it by `customer_segment`, and returns a number. The SQL is flawless. The result is wrong — because the agent joined customers to contracts through a billing relationship instead of the ownership relationship, conflated physical products (SKUs in a warehouse) with SaaS products (plan tiers in a subscription table), and attributed revenue from multi-product contracts entirely to the first product on the invoice. The semantic layer ensured the metric was computed correctly. What was missing — and what caused every downstream error — was an **ontology**: a formal model of what kinds of things exist in this business domain and how they relate to each other. This article defines each concept, maps where they overlap and where they diverge, and explains why the distinction stops being academic the moment you deploy an AI agent against real enterprise data.
 
 ## TL;DR
 
@@ -54,7 +54,7 @@ A semantic layer is the business translation of physical data. It defines:
 
 The semantic layer is **implementation-aware**. It knows that `net_revenue` lives in the `fact_orders` table, filtered by `order_status = 'completed'`, aggregated as `SUM(revenue_usd - refund_usd)`. It is a practical, executable mapping from business language to database operations.
 
-For a thorough treatment, see [what is a semantic layer](/posts/what-is-semantic-layer).
+For a thorough treatment, see [what is a semantic layer](/blog/what-is-semantic-layer/).
 
 ## 2. Ontology: definition and role
 
@@ -189,6 +189,6 @@ Datus's **Subject Tree** serves an ontology-like function: it organizes business
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the execution layer
-- [What is a semantic model?](/posts/what-is-semantic-model) — the building block of the semantic layer
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — how agents operationalize both layers
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the execution layer
+- [What is a semantic model?](/blog/what-is-semantic-model/) — the building block of the semantic layer
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — how agents operationalize both layers

--- a/blog/posts/subagents-domain-specific-data-agents.md
+++ b/blog/posts/subagents-domain-specific-data-agents.md
@@ -32,11 +32,11 @@ head:
 ---
 # Subagents: How to Ship Domain-Specific Data Agents Without Training a Model
 
-A [data engineering agent](/posts/what-is-data-engineering-agent-2026) that can answer any question about your entire warehouse sounds powerful. In practice, it is a liability. Give an agent unrestricted access to every table, every metric, and every schema, and it will produce answers that are technically correct and organizationally wrong—using the operations team's definition of revenue when finance asked the question, or joining through a deprecated path because nobody told the agent not to.
+A [data engineering agent](/blog/what-is-data-engineering-agent-2026/) that can answer any question about your entire warehouse sounds powerful. In practice, it is a liability. Give an agent unrestricted access to every table, every metric, and every schema, and it will produce answers that are technically correct and organizationally wrong—using the operations team's definition of revenue when finance asked the question, or joining through a deprecated path because nobody told the agent not to.
 
 A subagent solves this by scoping the problem. Instead of one agent that knows everything, you create many subagents, each knowing exactly what one domain needs: roughly 10 tables, 20 metrics, 30 validated SQL references, and a set of standing business rules. Each subagent is a self-contained, shareable chatbot that delivers accurate answers within its domain—and stays silent outside it.
 
-This article explains what subagents are, how they work, and why they are the delivery unit that separates a <a href="https://datus.ai/glossary">data engineering agent</a> from a smart SQL writer. For the philosophy behind scoped context, see [contextual data engineering](/posts/contextual-data-engineering).
+This article explains what subagents are, how they work, and why they are the delivery unit that separates a <a href="https://datus.ai/glossary">data engineering agent</a> from a smart SQL writer. For the philosophy behind scoped context, see [contextual data engineering](/blog/contextual-data-engineering/).
 
 ## TL;DR
 
@@ -97,7 +97,7 @@ After a period of active use, the engineer reviews feedback patterns, promotes v
 
 When the subagent is mature—high accuracy, stable scope, low rate of corrections—it can be exported as an HTTP API. Other systems (dashboards, internal tools, downstream agents) query the API to get grounded, accurate answers. The subagent has graduated from a chatbot to an infrastructure service.
 
-This lifecycle reflects a broader philosophy about how data work should scale: an engineer builds context, an agent delivers it, users refine it, and the system gets more valuable the longer it runs. For more on this philosophy, see [one-person data team](/posts/one-person-data-team).
+This lifecycle reflects a broader philosophy about how data work should scale: an engineer builds context, an agent delivers it, users refine it, and the system gets more valuable the longer it runs. For more on this philosophy, see [one-person data team](/blog/one-person-data-team/).
 
 ## 4. Why subagents are the right delivery unit
 
@@ -137,7 +137,7 @@ The fastest path from zero to a working subagent:
 
 The pattern compounds: each subagent makes the context engine stronger, which makes the next subagent easier to create. The tenth subagent takes a fraction of the time the first one took.
 
-Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see the subagent lifecycle in action—connect a warehouse, create a scoped subagent, and share it with a teammate. Or follow the [15-minute tutorial](/posts/build-your-first-data-engineering-agent) to build one from the CLI.
+Try <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Datus Studio</a> to see the subagent lifecycle in action—connect a warehouse, create a scoped subagent, and share it with a teammate. Or follow the [15-minute tutorial](/blog/build-your-first-data-engineering-agent/) to build one from the CLI.
 
 ## Frequently asked questions
 
@@ -159,6 +159,6 @@ A well-scoped subagent should recognize out-of-scope questions and respond with 
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — the category definition
-- [Contextual data engineering](/posts/contextual-data-engineering) — the context model that powers subagents
-- [One-person data team](/posts/one-person-data-team) — how subagents scale a solo engineer's output
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — the category definition
+- [Contextual data engineering](/blog/contextual-data-engineering/) — the context model that powers subagents
+- [One-person data team](/blog/one-person-data-team/) — how subagents scale a solo engineer's output

--- a/blog/posts/welcome.md
+++ b/blog/posts/welcome.md
@@ -76,16 +76,16 @@ Datus is more than a tool—it's a new paradigm for data engineering. We're buil
 
 ## Recommended Reading
 
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 - [Data Engineering Agent: The Complete Guide](/data-engineering-agent/)
 
 ---
 
 ## Continue Reading
 
-- Next: [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- Next: [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 
 Stay tuned for our next post where we'll dive into the fundamentals of context engineering!

--- a/blog/posts/what-is-data-agent.md
+++ b/blog/posts/what-is-data-agent.md
@@ -33,7 +33,7 @@ head:
 
 # What Is a Data Agent? How It Differs From a Data Engineering Agent
 
-If you attended three data conferences in 2026, you heard at least a dozen tools described as "AI agents for data." One generates SQL from natural language. One monitors pipeline health and suggests fixes. One auto-generates dashboards. One discovers metadata across catalogs. One builds and evolves the context that all the others depend on. They share a label and almost nothing else — not architecture, not user, not failure mode, not the problem they actually solve. This article proposes a six-type taxonomy that separates them by what they actually do, maps the consumer/producer tier architecture that connects them, and explains why one type — the [data engineering agent](/posts/what-is-data-engineering-agent) — matters more for long-term accuracy than the other five combined.
+If you attended three data conferences in 2026, you heard at least a dozen tools described as "AI agents for data." One generates SQL from natural language. One monitors pipeline health and suggests fixes. One auto-generates dashboards. One discovers metadata across catalogs. One builds and evolves the context that all the others depend on. They share a label and almost nothing else — not architecture, not user, not failure mode, not the problem they actually solve. This article proposes a six-type taxonomy that separates them by what they actually do, maps the consumer/producer tier architecture that connects them, and explains why one type — the [data engineering agent](/blog/what-is-data-engineering-agent/) — matters more for long-term accuracy than the other five combined.
 
 ## TL;DR
 
@@ -221,6 +221,6 @@ No — and teams that try to find a single agent that covers all six types will 
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — the producer-tier subclass in detail
-- [What is text-to-SQL?](/posts/what-is-text-to-sql) — the core capability behind query agents
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the context tier that agents consume
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the producer-tier subclass in detail
+- [What is text-to-SQL?](/blog/what-is-text-to-sql/) — the core capability behind query agents
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the context tier that agents consume

--- a/blog/posts/what-is-data-catalog.md
+++ b/blog/posts/what-is-data-catalog.md
@@ -42,7 +42,7 @@ A **data catalog** inventories and describes data assets — tables, columns, ow
 - A **data catalog** answers **what exists, who owns it, and where it came from** — optimized for human discovery.
 - Popular platforms include <a href="https://datahubproject.io/" rel="nofollow noopener">DataHub</a>, <a href="https://atlan.com/" rel="nofollow noopener">Atlan</a>, and <a href="https://www.selectstar.com/" rel="nofollow noopener">Select Star</a> — plus native features in cloud warehouses.
 - **Data dictionary** = column-level definitions; **catalog** = searchable asset graph with governance metadata.
-- A **[semantic layer](/posts/what-is-semantic-layer)** adds executable metric logic; catalogs rarely encode "net revenue" computation completely.
+- A **[semantic layer](/blog/what-is-semantic-layer/)** adds executable metric logic; catalogs rarely encode "net revenue" computation completely.
 - A catalog alone is not an AI grounding layer — agents need **executable context** (reference SQL, semantic models, feedback) layered on top of catalog metadata to generate correct queries reliably.
 
 ## 1. Data catalog: a working definition
@@ -77,7 +77,7 @@ A catalog tells you **`fact_orders` exists**. A semantic layer tells you **how t
 
 The progression from catalog to context engine is a progression from descriptive metadata to executable knowledge. A catalog entry for `fact_orders.net_amount` says "Net order amount in USD." A semantic layer definition says "Net revenue = SUM(net_amount) WHERE order_status IN ('completed', 'shipped')." A context engine, retrieving from reference SQL, adds "last quarter, the CFO's revenue query used `dim_fiscal_calendar.fiscal_quarter` rather than `DATE_TRUNC('quarter', order_date)` because the company's fiscal calendar offsets by two weeks — and if you use calendar quarters, the numbers will not match the board deck." That third piece of knowledge — the join authority on the time dimension — lives in neither the catalog nor the semantic layer but is the difference between a correct answer and a plausible-looking wrong answer.
 
-[Contextual data engineering](/posts/contextual-data-engineering) walks through those layers for agents.
+[Contextual data engineering](/blog/contextual-data-engineering/) walks through those layers for agents.
 
 ## 3. Why organizations buy data catalogs
 
@@ -99,7 +99,7 @@ Many 2025–2026 products advertise "AI on the catalog." Typical pattern:
 2. Chat UI retrieves snippets
 3. Model suggests tables or generates SQL
 
-That is [RAG for data engineering](/posts/rag-data-engineering) with catalog documents as the corpus. Quality limits:
+That is [RAG for data engineering](/blog/rag-data-engineering/) with catalog documents as the corpus. Quality limits:
 
 - Descriptions are **empty or stale** on half of columns
 - **Metric logic** lives in dbt repos, not catalog fields
@@ -108,7 +108,7 @@ That is [RAG for data engineering](/posts/rag-data-engineering) with catalog doc
 
 Consider a real scenario: a 500-person SaaS company deploys Atlan, populates it with dbt-generated descriptions, and adds an AI chat feature on top. An analyst asks "monthly churn rate by product line" and the AI retrieves `dim_product_line.name` and `fact_subscription.churn_flag` from the catalog. It generates SQL that divides churned subscriptions by total subscriptions — a reasonable formula but wrong for this company, which defines churn rate as "subscriptions cancelled divided by subscriptions at risk of churn (active at month start)," meaning the denominator excludes new subscriptions added mid-month. The catalog had the right tables. It did not have the metric's business logic — which lived in a dbt model file 17 directories deep, unindexed by the catalog's AI feature. The AI produced a confident wrong answer because retrieval found tables but missed the metric definition that would have produced the correct denominator.
 
-Improving AI query success requires **reference SQL**, **semantic models**, and **feedback loops** — the context engine pattern in [how a context engine improves accuracy](/posts/context-engine-data-engineering-agent-accuracy).
+Improving AI query success requires **reference SQL**, **semantic models**, and **feedback loops** — the context engine pattern in [how a context engine improves accuracy](/blog/context-engine-data-engineering-agent-accuracy/).
 
 ## 5. Data catalog vs context engine
 
@@ -130,7 +130,7 @@ The coexistence model is not either-or. Many enterprises run a catalog for organ
 
 Agents need lineage to assess **blast radius** ("if I change this column, what breaks?") and to choose **trusted paths**. Context engines build implicit lineage relationships through catalog structure and reference SQL co-occurrence patterns — full enterprise lineage visualization remains a common roadmap item across the category.
 
-For agents, the bar is often lower than a perfect enterprise graph: **knowing which tables co-occur in validated queries** already improves [schema linking](/posts/what-is-schema-linking). If every validated query involving "revenue" co-occurs with `fact_orders` and `dim_fiscal_calendar`, those co-occurrence patterns function as lightweight lineage — the agent learns that revenue questions should not touch `fact_payments` even without a formal lineage graph saying "revenue does not flow through payments."
+For agents, the bar is often lower than a perfect enterprise graph: **knowing which tables co-occur in validated queries** already improves [schema linking](/blog/what-is-schema-linking/). If every validated query involving "revenue" co-occurs with `fact_orders` and `dim_fiscal_calendar`, those co-occurrence patterns function as lightweight lineage — the agent learns that revenue questions should not touch `fact_payments` even without a formal lineage graph saying "revenue does not flow through payments."
 
 ## 7. Evaluation checklist: catalog maturity for AI readiness
 
@@ -176,7 +176,7 @@ Yes — and this is the most common architecture in enterprises running both. Th
 
 ### How does a data catalog relate to a semantic layer?
 
-Catalogs document **what exists** — the inventory of tables, columns, and pipelines. Semantic layers define **how to compute business metrics** — the formula for "net revenue" or "monthly active users." Agents need both: the catalog to find tables, the semantic layer to compute correctly, and institutional knowledge (reference SQL, feedback) to handle everything neither catalog nor semantic layer encodes. See [what is a semantic layer](/posts/what-is-semantic-layer).
+Catalogs document **what exists** — the inventory of tables, columns, and pipelines. Semantic layers define **how to compute business metrics** — the formula for "net revenue" or "monthly active users." Agents need both: the catalog to find tables, the semantic layer to compute correctly, and institutional knowledge (reference SQL, feedback) to handle everything neither catalog nor semantic layer encodes. See [what is a semantic layer](/blog/what-is-semantic-layer/).
 
 ### What's the most common mistake when betting AI on a catalog?
 
@@ -184,9 +184,9 @@ Assuming that catalog coverage equals AI readiness. A catalog with 100% table co
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — executable business logic above catalog metadata
-- [How a context engine improves agent accuracy](/posts/context-engine-data-engineering-agent-accuracy) — beyond catalog browsing
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — operationalizes context, not just inventory
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — executable business logic above catalog metadata
+- [How a context engine improves agent accuracy](/blog/context-engine-data-engineering-agent-accuracy/) — beyond catalog browsing
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — operationalizes context, not just inventory
 
 ---
 

--- a/blog/posts/what-is-data-engineering-agent-2026.md
+++ b/blog/posts/what-is-data-engineering-agent-2026.md
@@ -126,7 +126,7 @@ Data engineering is a long-running discipline. The same warehouse is queried tho
 
 Platform-embedded agents partially solve this by leaning on their host's catalog. That works for schema metadata; it does not cover validated SQL, business definitions, or the institutional memory of which queries were trusted. Prompt-based agents don't solve it at all — they begin every session in the same blank state.
 
-A context-first agent treats every successful run as training data for the next one. The semantic model grows. The library of validated metrics grows. The set of business rules the agent will never violate grows. Over weeks, the agent stops being a chatty SQL writer and starts being something closer to a junior engineer who has actually worked on your codebase. For what "semantic layer" means in this stack — and how it differs from a metric layer or catalog — see [what is a semantic layer](/posts/what-is-semantic-layer). Datus describes this broader approach as contextual data engineering — treating data context as a first-class, evolvable asset rather than a one-time modeling exercise.
+A context-first agent treats every successful run as training data for the next one. The semantic model grows. The library of validated metrics grows. The set of business rules the agent will never violate grows. Over weeks, the agent stops being a chatty SQL writer and starts being something closer to a junior engineer who has actually worked on your codebase. For what "semantic layer" means in this stack — and how it differs from a metric layer or catalog — see [what is a semantic layer](/blog/what-is-semantic-layer/). Datus describes this broader approach as contextual data engineering — treating data context as a first-class, evolvable asset rather than a one-time modeling exercise.
 
 > An agent without persistent context is a clever stranger. An agent with persistent context is a coworker.
 
@@ -166,4 +166,4 @@ More than column names. A useful data engineering agent needs four layers of con
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — definitions, implementations, and how semantics relate to agents
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — definitions, implementations, and how semantics relate to agents

--- a/blog/posts/what-is-data-engineering-agent.md
+++ b/blog/posts/what-is-data-engineering-agent.md
@@ -83,11 +83,11 @@ Yes. Datus is designed to integrate with modern warehouses, catalogs, and orches
 
 ## Related Reading
 
-- [From Human-First Data Systems to the Agentic Data Stack](/posts/agentic-data-stack)
-- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
-- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/posts/data-engineering-agent-use-cases)
-- [The Layered Subagent Architecture for Data Engineering Agents](/data-engineering-agent/data-engineering-agent-layered-subagent)
-- [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
+- [From Human-First Data Systems to the Agentic Data Stack](/blog/agentic-data-stack/)
+- [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](/blog/data-engineering-agent-use-cases/)
+- [The Layered Subagent Architecture for Data Engineering Agents](/blog/data-engineering-agent/data-engineering-agent-layered-subagent/)
+- [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
 
 ## Start with Datus
 
@@ -97,5 +97,5 @@ Yes. Datus is designed to integrate with modern warehouses, catalogs, and orches
 
 ## Continue Reading
 
-- Previous: [SQL agents are broken without context. Meet Datus.](/posts/meet_datus)
-- Next: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/posts/data-engineering-agent-architecture)
+- Previous: [SQL agents are broken without context. Meet Datus.](/blog/meet_datus/)
+- Next: [Data Engineering Agent Architecture: From Prototype to Production with Datus](/blog/data-engineering-agent-architecture/)

--- a/blog/posts/what-is-data-mesh.md
+++ b/blog/posts/what-is-data-mesh.md
@@ -93,7 +93,7 @@ Mesh-aligned agent design:
 | Self-serve platform | Engineers spin up Subagents without retraining a monolith |
 | Federated governance | Global policies (PII, audit) + domain rules in Subagent config |
 
-Read [subagents: domain-specific data agents](/posts/subagents-domain-specific-data-agents) for the delivery model.
+Read [subagents: domain-specific data agents](/blog/subagents-domain-specific-data-agents/) for the delivery model.
 
 ## 5. Mesh-aligned agent design: domain scoping as implementation
 
@@ -122,7 +122,7 @@ Federated governance applies at the platform level: global policies for PII dete
 
 ## 7. Data mesh vs contextual data engineering
 
-Mesh answers **who owns and publishes** data products. [Contextual data engineering](/posts/contextual-data-engineering) answers **how agent context evolves** after those products ship.
+Mesh answers **who owns and publishes** data products. [Contextual data engineering](/blog/contextual-data-engineering/) answers **how agent context evolves** after those products ship.
 
 Together: domains publish products; agents **learn from usage** within each domain's scoped context; promoted learnings flow back into semantic models and reference SQL — faster than quarterly central modeling alone. This is how mesh thinking about ownership combines with agent thinking about continuous learning — each domain's context evolves at the speed of its own usage, not at the speed of a central modeling team's quarterly planning cycle.
 
@@ -170,9 +170,9 @@ Data contracts formalize the interface between data producers and consumers — 
 
 ## Related articles
 
-- [Subagents: domain-specific data agents](/posts/subagents-domain-specific-data-agents) — mesh-aligned delivery unit
-- [Contextual data engineering](/posts/contextual-data-engineering) — evolving context per domain
-- [What is a data catalog?](/posts/what-is-data-catalog) — shared discovery layer under domain products
+- [Subagents: domain-specific data agents](/blog/subagents-domain-specific-data-agents/) — mesh-aligned delivery unit
+- [Contextual data engineering](/blog/contextual-data-engineering/) — evolving context per domain
+- [What is a data catalog?](/blog/what-is-data-catalog/) — shared discovery layer under domain products
 
 ---
 

--- a/blog/posts/what-is-gooddata.md
+++ b/blog/posts/what-is-gooddata.md
@@ -126,7 +126,7 @@ GoodData occupies a different tier of the data agent stack than Datus:
 | **Deployment** | Cloud platform (SaaS), multi-tenant | Open-source core (Apache 2.0) + Cloud Personal + Enterprise |
 | **AI approach** | Semantic-grounded AI on top of existing platform | AI as the operating model — context evolves with every agent interaction |
 
-The relationship is complementary, not competitive: GoodData provides a mature, governed semantic consumption layer. Datus provides a context creation and evolution layer. A team could use Datus to generate and evolve [semantic models](/posts/what-is-semantic-model) and metrics, and GoodData to serve them through governed APIs with multi-tenant access control — the creation tier and the distribution tier working together.
+The relationship is complementary, not competitive: GoodData provides a mature, governed semantic consumption layer. Datus provides a context creation and evolution layer. A team could use Datus to generate and evolve [semantic models](/blog/what-is-semantic-model/) and metrics, and GoodData to serve them through governed APIs with multi-tenant access control — the creation tier and the distribution tier working together.
 
 ## 5. What data teams can learn from GoodData's arc
 
@@ -162,6 +162,6 @@ Not directly. GoodData is a **semantic consumption and distribution platform** �
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the infrastructure GoodData built its platform on
-- [What is a metric layer?](/posts/what-is-metric-layer) — the KPI catalog MAQL implements
-- [AI-Native Data Platforms: Why the Next Generation Needs Data Engineering Agents](/posts/ai-native-data-platforms) — the category GoodData.AI is entering
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the infrastructure GoodData built its platform on
+- [What is a metric layer?](/blog/what-is-metric-layer/) — the KPI catalog MAQL implements
+- [AI-Native Data Platforms: Why the Next Generation Needs Data Engineering Agents](/blog/ai-native-data-platforms/) — the category GoodData.AI is entering

--- a/blog/posts/what-is-metric-layer.md
+++ b/blog/posts/what-is-metric-layer.md
@@ -105,7 +105,7 @@ Key characteristics that make MetricFlow the reference implementation:
 - **Multi-engine** — generates queries for Snowflake, BigQuery, Databricks, Postgres, and DuckDB from the same metric definitions.
 - **API-consumable** — dbt Cloud exposes a query API so BI tools, notebooks, and agents can request metric values without knowing SQL.
 
-MetricFlow's limitation — and this is where agent-driven approaches differ — is that it is **engineer-maintained and batch-updated**. A new ad-hoc query that surfaces a missing edge case has no path into MetricFlow YAML until someone opens a PR. In a team running a [data engineering agent](/posts/what-is-data-engineering-agent), validated production SQL and user feedback can feed back into metric definitions continuously — closing the loop between discovery and governance.
+MetricFlow's limitation — and this is where agent-driven approaches differ — is that it is **engineer-maintained and batch-updated**. A new ad-hoc query that surfaces a missing edge case has no path into MetricFlow YAML until someone opens a PR. In a team running a [data engineering agent](/blog/what-is-data-engineering-agent/), validated production SQL and user feedback can feed back into metric definitions continuously — closing the loop between discovery and governance.
 
 ## 4. Cube and the headless BI metric layer
 
@@ -200,6 +200,6 @@ Dramatically. The #1 failure mode of text-to-SQL is not SQL syntax — it's **se
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the full business dictionary that contains the metric layer
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent) — how agents operationalize metric definitions
-- [What is text-to-SQL?](/posts/what-is-text-to-sql) — the generation layer grounded in metric definitions
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the full business dictionary that contains the metric layer
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — how agents operationalize metric definitions
+- [What is text-to-SQL?](/blog/what-is-text-to-sql/) — the generation layer grounded in metric definitions

--- a/blog/posts/what-is-schema-linking.md
+++ b/blog/posts/what-is-schema-linking.md
@@ -76,13 +76,13 @@ Weak linking poisons step 3: the model confidently joins tables that never shoul
 
 In practice, schema linking and intent parsing interact more than the linear pipeline suggests. Parsing "revenue by channel" requires some schema awareness to recognize that "revenue" is a metric requiring aggregation and "channel" is a dimension requiring grouping — but if the parser pre-commits to the wrong interpretation of "channel" before seeing the schema, the linker receives a poisoned input. Production systems often iterate between steps 1 and 2 rather than executing them sequentially.
 
-See [what is text-to-SQL](/posts/what-is-text-to-sql) for the full pipeline.
+See [what is text-to-SQL](/blog/what-is-text-to-sql/) for the full pipeline.
 
 ## 3. Why schema linking breaks in production
 
 ### Schema size and noise
 
-Enterprise warehouses expose thousands of tables. Dumping full DDL into a prompt exceeds context windows and dilutes signal. Retrieval must surface **relevant** fragments — a RAG problem discussed in [RAG for data engineering](/posts/rag-data-engineering). The noise problem is asymmetric: including one irrelevant table in the prompt is mildly wasteful; including one table that is relevant but incorrectly described is catastrophically misleading. A catalog entry that lists `dim_customer.status` as "customer status (active, inactive, churned)" when the column actually stores billing status codes (1, 2, 3, 7) causes the linker to select the table for every "churned" query while misinterpreting what "churned" means in that context.
+Enterprise warehouses expose thousands of tables. Dumping full DDL into a prompt exceeds context windows and dilutes signal. Retrieval must surface **relevant** fragments — a RAG problem discussed in [RAG for data engineering](/blog/rag-data-engineering/). The noise problem is asymmetric: including one irrelevant table in the prompt is mildly wasteful; including one table that is relevant but incorrectly described is catastrophically misleading. A catalog entry that lists `dim_customer.status` as "customer status (active, inactive, churned)" when the column actually stores billing status codes (1, 2, 3, 7) causes the linker to select the table for every "churned" query while misinterpreting what "churned" means in that context.
 
 ### Ambiguous naming
 
@@ -94,7 +94,7 @@ Users to orders to subscriptions can traverse several foreign-key graphs. Only o
 
 ### Business language ≠ column names
 
-Analysts say "ARPU" and "net revenue"; schemas say `avg_rev_per_sub_v3`. A [semantic layer](/posts/what-is-semantic-layer) bridges that gap with governed metrics and dimensions. But a semantic layer only bridges what has been formally modeled. When an analyst asks "what percentage of our power users churned after the pricing change," none of "power users," "churned," or "after the pricing change" have formal metric definitions — they are ad-hoc concepts that exist in tribal knowledge and reference SQL, not in YAML. Schema linking must handle both the governed path (metrics from the semantic layer) and the ungoverned path (ad-hoc phrases mapped through reference SQL and contextual inference).
+Analysts say "ARPU" and "net revenue"; schemas say `avg_rev_per_sub_v3`. A [semantic layer](/blog/what-is-semantic-layer/) bridges that gap with governed metrics and dimensions. But a semantic layer only bridges what has been formally modeled. When an analyst asks "what percentage of our power users churned after the pricing change," none of "power users," "churned," or "after the pricing change" have formal metric definitions — they are ad-hoc concepts that exist in tribal knowledge and reference SQL, not in YAML. Schema linking must handle both the governed path (metrics from the semantic layer) and the ungoverned path (ad-hoc phrases mapped through reference SQL and contextual inference).
 
 ### Drift and deprecation
 
@@ -114,7 +114,7 @@ The durable pattern combines **retrieval**, **governed semantics**, and **valida
 
 ## 5. Physical vs semantic linking
 
-**Physical linking** uses catalog metadata: table names, column types, foreign keys. Tools like <a href="https://datahubproject.io/" rel="nofollow noopener">DataHub</a> and <a href="https://atlan.com/" rel="nofollow noopener">Atlan</a> excel at inventory — see [what is a data catalog](/posts/what-is-data-catalog) for how that differs from agent context.
+**Physical linking** uses catalog metadata: table names, column types, foreign keys. Tools like <a href="https://datahubproject.io/" rel="nofollow noopener">DataHub</a> and <a href="https://atlan.com/" rel="nofollow noopener">Atlan</a> excel at inventory — see [what is a data catalog](/blog/what-is-data-catalog/) for how that differs from agent context.
 
 **Semantic linking** maps business terms to metric definitions and entity relationships — often via MetricFlow, Cube, or LookML.
 
@@ -183,9 +183,9 @@ Partially. Startup-stage linking — small schemas, one domain, active maintenan
 
 ## Related articles
 
-- [What is text-to-SQL?](/posts/what-is-text-to-sql) — where schema linking fits in the pipeline
-- [RAG for data engineering](/posts/rag-data-engineering) — retrieval that feeds linking
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — governed business terms for linking
+- [What is text-to-SQL?](/blog/what-is-text-to-sql/) — where schema linking fits in the pipeline
+- [RAG for data engineering](/blog/rag-data-engineering/) — retrieval that feeds linking
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — governed business terms for linking
 
 ---
 

--- a/blog/posts/what-is-semantic-layer.md
+++ b/blog/posts/what-is-semantic-layer.md
@@ -33,7 +33,7 @@ head:
 
 # What Is a Semantic Layer? Definition, Examples & How It Differs From a Metric Layer
 
-A **semantic layer** is a business representation of data that maps physical tables and columns to stable business concepts — metrics, dimensions, entities, and relationships — so analysts and applications can query by *revenue* and *region* instead of `fact_orders.amount_usd` and `dim_geo.region_code`. It sits between raw storage and every consumer of data: BI tools, APIs, notebooks, and increasingly **AI agents**. This glossary entry gives a practical definition, walks through common implementations, and explains where semantic layers end — and where a [data engineering agent](/posts/what-is-data-engineering-agent-2026) that *operationalizes* those definitions begins.
+A **semantic layer** is a business representation of data that maps physical tables and columns to stable business concepts — metrics, dimensions, entities, and relationships — so analysts and applications can query by *revenue* and *region* instead of `fact_orders.amount_usd` and `dim_geo.region_code`. It sits between raw storage and every consumer of data: BI tools, APIs, notebooks, and increasingly **AI agents**. This glossary entry gives a practical definition, walks through common implementations, and explains where semantic layers end — and where a [data engineering agent](/blog/what-is-data-engineering-agent-2026/) that *operationalizes* those definitions begins.
 
 ## TL;DR
 
@@ -163,7 +163,7 @@ Concrete compatibility paths:
 
 In practice today, this means Datus ingests existing metric YAML (MetricFlow-compatible), generates new semantic models alongside them, and scopes Subagents to specific domain contexts. Full cross-layer orchestration — unified governance across Cube, MetricFlow, and LookML from a single control plane — is the architectural direction, not the shipped feature set.
 
-For the full agent-side definition, read [what is a data engineering agent](/posts/what-is-data-engineering-agent-2026).
+For the full agent-side definition, read [what is a data engineering agent](/blog/what-is-data-engineering-agent-2026/).
 
 ## 7. When you need a semantic layer — signals, not dogma
 
@@ -232,4 +232,4 @@ Incrementally is the only way that sticks. Start with one team, one domain, and 
 
 ## Related articles
 
-- [What is a data engineering agent?](/posts/what-is-data-engineering-agent-2026) — how agents differ from copilots and where context fits
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent-2026/) — how agents differ from copilots and where context fits

--- a/blog/posts/what-is-semantic-model.md
+++ b/blog/posts/what-is-semantic-model.md
@@ -33,12 +33,12 @@ head:
 
 # What Is a Semantic Model? Definition, Examples & How It Differs From a Semantic View
 
-A data engineer inherits a 500-table Snowflake instance. Somewhere in `analytics_prod` is the data the marketing team needs for their Q3 campaign attribution analysis — but the schema is a landscape of cryptic column names (`attrib_windows_30d_v2`, `conv_type_id_fk`), undocumented join paths, and tribal knowledge that left with the previous engineer. A [semantic layer](/posts/what-is-semantic-layer) would give her the full business dictionary. But before you can build a dictionary, you need to write the entries. A **semantic model** is a single entry — one dataset, described in business terms: which columns are measures you can quantify, which are dimensions you can group by, how this dataset connects to others, and what business rules apply. This article defines what goes into a semantic model, walks through a MetricFlow example, and distinguishes it from the newer concept of warehouse-native semantic views — including when you would use one over the other.
+A data engineer inherits a 500-table Snowflake instance. Somewhere in `analytics_prod` is the data the marketing team needs for their Q3 campaign attribution analysis — but the schema is a landscape of cryptic column names (`attrib_windows_30d_v2`, `conv_type_id_fk`), undocumented join paths, and tribal knowledge that left with the previous engineer. A [semantic layer](/blog/what-is-semantic-layer/) would give her the full business dictionary. But before you can build a dictionary, you need to write the entries. A **semantic model** is a single entry — one dataset, described in business terms: which columns are measures you can quantify, which are dimensions you can group by, how this dataset connects to others, and what business rules apply. This article defines what goes into a semantic model, walks through a MetricFlow example, and distinguishes it from the newer concept of warehouse-native semantic views — including when you would use one over the other.
 
 ## TL;DR
 
 - A **semantic model** describes one data source in business language: measures, dimensions, joins, metadata, and business rules — turning `fact_orders.amount_usd` into "Net Revenue, filtered to completed orders."
-- It is the **building block** of a semantic layer. A semantic layer is composed of multiple semantic models connected by relationships. A [metric layer](/posts/what-is-metric-layer) is the subset that standardizes KPIs across those models.
+- It is the **building block** of a semantic layer. A semantic layer is composed of multiple semantic models connected by relationships. A [metric layer](/blog/what-is-metric-layer/) is the subset that standardizes KPIs across those models.
 - Common formats: MetricFlow `semantic_model` YAML (dbt), Cube data model JavaScript/YAML, LookML `view` files, GoodData LDM.
 - A **semantic view** (Snowflake, BigQuery) is a warehouse-native alternative — semantics defined in SQL inside the database rather than in an external modeling layer. See §5 for the tradeoffs.
 - Datus auto-generates semantic models from live schema (`/gen_semantic_model`), stores them in MetricFlow-compatible YAML, and refines them through agent feedback — turning model creation from a manual, sprint-gated process into a continuous one.
@@ -166,7 +166,7 @@ WITH SEMANTIC METADATA (
 | You want Git-managed, reviewed, CI/CD-validated semantics | You prioritize operational simplicity over governance workflow |
 | You are building for AI agent consumption | You are building for human SQL consumers |
 
-In practice, larger organizations often have both: semantic models for cross-platform, governed definitions, and semantic views for quick, warehouse-scoped use cases. The OSI standard (see [Open Semantic Interchange explained](/posts/open-semantic-interchange-osi)) aims to make both patterns interoperable — so a semantic view in Snowflake and a semantic model in MetricFlow can exchange definitions through a common format.
+In practice, larger organizations often have both: semantic models for cross-platform, governed definitions, and semantic views for quick, warehouse-scoped use cases. The OSI standard (see [Open Semantic Interchange explained](/blog/open-semantic-interchange-osi/)) aims to make both patterns interoperable — so a semantic view in Snowflake and a semantic model in MetricFlow can exchange definitions through a common format.
 
 ## 6. When you need more than ad-hoc semantic models
 
@@ -205,6 +205,6 @@ Partially — and that partial automation is the pragmatic sweet spot. A data en
 
 ## Related articles
 
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — the full business dictionary composed of semantic models
-- [What is a metric layer?](/posts/what-is-metric-layer) — the KPI catalog built from semantic model measures
-- [What is a data catalog?](/posts/what-is-data-catalog) — discovery metadata vs executable semantics
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the full business dictionary composed of semantic models
+- [What is a metric layer?](/blog/what-is-metric-layer/) — the KPI catalog built from semantic model measures
+- [What is a data catalog?](/blog/what-is-data-catalog/) — discovery metadata vs executable semantics

--- a/blog/posts/what-is-text-to-sql.md
+++ b/blog/posts/what-is-text-to-sql.md
@@ -70,7 +70,7 @@ The pipeline most teams implement — explicitly or inside a vendor product — 
 
 The four-stage decomposition matters because different failure modes demand different fixes. Intent parsing errors need better disambiguation prompts or user clarification loops. Schema linking errors — the dominant failure category in production — need richer metadata, aliases, and reference SQL, not a bigger language model. Synthesis errors need structural constraints like join authority graphs. Validation errors need execution loops and result inspection. A team that treats all four failure categories as "the model got it wrong" will spend cycles on model upgrades when the real bottleneck lives in stages 2 and 4.
 
-For a deep dive on the second stage, see [what is schema linking](/posts/what-is-schema-linking).
+For a deep dive on the second stage, see [what is schema linking](/blog/what-is-schema-linking/).
 
 ## 2. Text-to-SQL vs NL2SQL vs SQL copilot
 
@@ -83,11 +83,11 @@ These terms overlap in marketing but differ in scope:
 | **SQL copilot** | IDE or chat assist that **suggests** SQL; often **no persistent schema memory** or execution loop |
 | **Data engineering agent** | Broader system: text-to-SQL **plus** context persistence, workflows, feedback, and multi-step data work |
 
-A SQL copilot can produce excellent one-off queries. A [data engineering agent](/posts/what-is-data-engineering-agent) treats text-to-SQL as a **repeatable production capability** — the same question next month should benefit from corrections made last month.
+A SQL copilot can produce excellent one-off queries. A [data engineering agent](/blog/what-is-data-engineering-agent/) treats text-to-SQL as a **repeatable production capability** — the same question next month should benefit from corrections made last month.
 
 The distinction becomes operational quickly. If a VP of Sales asks "month-over-month pipeline growth by region" and gets the right answer in March, she expects the same question in April to produce a comparable answer — not a different SQL that happened to feel right to the model that day. Copilots optimized for assistive drafting don't carry corrections forward. Agents optimized for repeatable answers must persist every validated mapping, join path, and filter as state. This persistence requirement — not model quality — is what separates the two categories in production.
 
-For how agents differ from copilots at the product level, read [data engineering agent vs. SQL copilot](/posts/data-engineering-agent-vs-sql-copilot).
+For how agents differ from copilots at the product level, read [data engineering agent vs. SQL copilot](/blog/data-engineering-agent-vs-sql-copilot/).
 
 ## 3. What context text-to-SQL systems need
 
@@ -103,11 +103,11 @@ Minimum context for reliable text-to-SQL:
 | **Business rules** | Deprecations, PII boundaries, "never use table X" |
 | **Feedback history** | Corrections from prior runs |
 
-Without semantics, models guess from column names — `amt_usd_net_v2` is not self-explanatory. A [semantic layer](/posts/what-is-semantic-layer) supplies governed metrics; a **context engine** adds validated ad-hoc SQL and usage-based corrections on top.
+Without semantics, models guess from column names — `amt_usd_net_v2` is not self-explanatory. A [semantic layer](/blog/what-is-semantic-layer/) supplies governed metrics; a **context engine** adds validated ad-hoc SQL and usage-based corrections on top.
 
 The hierarchy matters here. A physical schema tells the model `fact_orders` has a column called `amount_usd`. A semantic definition tells the model that "net revenue" means `SUM(amount_usd) WHERE status != 'refunded' AND account_type != 'TEST'`. Reference SQL tells the model that last week's CFO asked a similar question and the answer used `fiscal_calendar_v2`, not `calendar_date`. Feedback history tells the model that three months ago, Marketing complained that "channel" mapped to `dim_sales_channel` instead of `dim_marketing_channel`, and the correction was recorded. Each layer of context addresses failure modes the layer below cannot catch.
 
-Retrieval-augmented generation (RAG) is how many systems inject that context at query time. See [RAG for data engineering](/posts/rag-data-engineering).
+Retrieval-augmented generation (RAG) is how many systems inject that context at query time. See [RAG for data engineering](/blog/rag-data-engineering/).
 
 ## 4. How accuracy is measured (and why benchmarks mislead)
 
@@ -154,7 +154,7 @@ Text-to-SQL alone does not make an agent. Agents add:
 - **Integration** — MCP clients, orchestrators, CI workflows. Text-to-SQL embedded in a dbt pull request can validate that a model change does not break downstream SQL.
 - **Governance** — scoped tables, rules, audit trails (especially in enterprise deployments). Every query leaves a trace from question to SQL to tables used to result.
 
-[Contextual data engineering](/posts/contextual-data-engineering) describes the operating model: every text-to-SQL run strengthens context for the next run. In practice, this means the system's accuracy graph slopes upward over time within a domain — not because the model was upgraded, but because every correction is stored and every validated query is indexed as a retrieval candidate for future questions. A stateless copilot's accuracy graph is flat forever.
+[Contextual data engineering](/blog/contextual-data-engineering/) describes the operating model: every text-to-SQL run strengthens context for the next run. In practice, this means the system's accuracy graph slopes upward over time within a domain — not because the model was upgraded, but because every correction is stored and every validated query is indexed as a retrieval candidate for future questions. A stateless copilot's accuracy graph is flat forever.
 
 ## 7. A text-to-SQL failure, step by step
 
@@ -219,9 +219,9 @@ ChatGPT generates SQL from its training data — it knows what `SELECT` syntax l
 
 ## Related articles
 
-- [What is schema linking?](/posts/what-is-schema-linking) — the bottleneck inside most text-to-SQL failures
-- [RAG for data engineering](/posts/rag-data-engineering) — how retrieval supplies context at query time
-- [What is a semantic layer?](/posts/what-is-semantic-layer) — governed metrics text-to-SQL should ground on
+- [What is schema linking?](/blog/what-is-schema-linking/) — the bottleneck inside most text-to-SQL failures
+- [RAG for data engineering](/blog/rag-data-engineering/) — how retrieval supplies context at query time
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — governed metrics text-to-SQL should ground on
 
 ---
 

--- a/blog/posts/why-ai-agents-need-semantic-context-to-work-reliably.md
+++ b/blog/posts/why-ai-agents-need-semantic-context-to-work-reliably.md
@@ -271,10 +271,10 @@ That is not extra infrastructure. It is the operating substrate for production-g
 
 ## Related Reading
 
-- [How MCP Changes Data Workflow Automation](/posts/how-mcp-changes-data-workflow-automation)
-- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs)
-- [Agentic Data Engineering vs Traditional Data Engineering](/posts/agentic-data-engineering-vs-traditional-data-engineering)
-- [What Is a Data Engineering Agent? A Practical Guide with Datus](/posts/what-is-data-engineering-agent)
+- [How MCP Changes Data Workflow Automation](/blog/how-mcp-changes-data-workflow-automation/)
+- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/blog/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs/)
+- [Agentic Data Engineering vs Traditional Data Engineering](/blog/agentic-data-engineering-vs-traditional-data-engineering/)
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](/blog/what-is-data-engineering-agent/)
 
 ## Start with Datus
 

--- a/blog/posts/why-reliable-data-agents-need-more-than-good-prompts.md
+++ b/blog/posts/why-reliable-data-agents-need-more-than-good-prompts.md
@@ -343,9 +343,9 @@ Prompting still has a role. It is just not the foundation.
 
 If you are building data agents for real workflows, start with the reliability layers first:
 
-- [Why AI Agents Need Semantic Context to Work Reliably](/posts/why-ai-agents-need-semantic-context-to-work-reliably)
-- [How MCP Changes Data Workflow Automation](/posts/how-mcp-changes-data-workflow-automation)
-- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/posts/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs)
+- [Why AI Agents Need Semantic Context to Work Reliably](/blog/why-ai-agents-need-semantic-context-to-work-reliably/)
+- [How MCP Changes Data Workflow Automation](/blog/how-mcp-changes-data-workflow-automation/)
+- [AI Data Pipeline Automation: Use Cases, Architecture, and Tradeoffs](/blog/ai-data-pipeline-automation-use-cases-architecture-and-tradeoffs/)
 - Explore the Datus docs to see how structured context, workflow-aware execution, and production guardrails fit together.
 
 ## FAQ

--- a/src/public/llms.txt
+++ b/src/public/llms.txt
@@ -1,0 +1,43 @@
+# Datus
+
+> Datus is a context-aware data engineering agent. It connects to your warehouse, learns your semantic layer, and turns natural language into trustworthy SQL and production data pipelines — so a one-person data team can move like ten.
+
+Datus pairs large language models with a persistent semantic context engine (metrics, schema links, lineage, and governance) so agents produce reliable, explainable results instead of plausible-but-wrong SQL. It ships as a CLI, a VS Code extension, a hosted Studio, and an Enterprise platform.
+
+## Products
+
+- [Datus CLI](https://datus.ai/products/cli/): Run the modern data stack from your terminal — agentic SQL, pipelines, and context.
+- [VS Code Extension](https://datus.ai/products/vscode/): Bring context and data agents into your editor.
+- [Datus Studio](https://datus.ai/products/studio/): The easiest way to start — free, hosted, no setup.
+- [Enterprise](https://datus.ai/products/enterprise/): Shared context, governance, and long-running agents for teams.
+
+## Resources
+
+- [Integrations](https://datus.ai/integrations/): Warehouses, catalogs, and tools Datus connects to.
+- [Pricing](https://datus.ai/pricing/): Plans for individuals, teams, and enterprise.
+- [Glossary](https://datus.ai/glossary/): Definitions for data engineering, semantic layer, and agent concepts.
+- [FAQ](https://datus.ai/faq/): Common questions about Datus.
+- [Documentation](https://docs.datus.ai): Product and API docs.
+
+## Blog
+
+- [Blog](https://datus.ai/blog/): All essays on agentic data engineering, semantic layers, and the agentic data stack.
+- [What Is a Data Engineering Agent? A Practical Guide with Datus](https://datus.ai/blog/what-is-data-engineering-agent/): Business and technical primer.
+- [Data Engineering Agent Architecture for Production](https://datus.ai/blog/data-engineering-agent-architecture/): Architecture and rollout path from prototype to production.
+- [Why Data Engineering Agents Need Layered Subagents](https://datus.ai/blog/data-engineering-agent/data-engineering-agent-layered-subagent/): The layered subagent pattern for domain-scoped agents.
+- [7 High-Impact Data Engineering Agent Use Cases (Powered by Datus)](https://datus.ai/blog/data-engineering-agent-use-cases/): Practical scenarios and ROI.
+- [From Human-First Data Systems to the Agentic Data Stack](https://datus.ai/blog/agentic-data-stack/): How the data stack changes when agents are first-class users.
+- [SQL Agents Are Broken Without Context. Meet Datus.](https://datus.ai/blog/meet_datus/): Why semantic context is the missing piece for reliable agents.
+- [What Is a Semantic Layer?](https://datus.ai/blog/what-is-semantic-layer/): Definition, examples, and how it differs from a metric layer.
+- [What Is Text-to-SQL?](https://datus.ai/blog/what-is-text-to-sql/): How it works and why context matters.
+- [MCP and Data Engineering](https://datus.ai/blog/mcp-data-engineering/): The protocol that connects your entire data stack.
+
+## Community
+
+- [GitHub](https://github.com/Datus-ai/Datus-agent): Open-source Datus agent.
+- [Slack](https://join.slack.com/t/datus-ai/shared_invite/zt-3g6h4fsdg-iOl5uNoz6A4GOc4xKKWUYg): Community and support.
+
+## Optional
+
+- [Sitemap](https://datus.ai/sitemap.xml): Full list of marketing pages.
+- [Blog sitemap](https://datus.ai/blog/sitemap.xml): Full list of blog posts.


### PR DESCRIPTION
## What

Fixes broken internal links across the blog (crawlability + UX) and adds a previously-404ing `/llms.txt`.

### Broken links repaired

Verified against the live site as ground truth:

| Pattern | Was | Now |
|---|---|---|
| `](/posts/<slug>)` — 286 links, 42 files | **404** | `](/blog/<slug>/)` ✅ 200 |
| `](/data-engineering-agent/data-engineering-agent-layered-subagent)` — 8 links | **404** | `](/blog/data-engineering-agent/.../)` ✅ 200 |

- `/posts/` was never a served prefix; canonical posts live at `/blog/<slug>/`. All 53 distinct targets resolve to real published posts.
- Pillar-root links (`/data-engineering-agent/`, returns 200) were **left untouched** — not broken.
- Trailing slashes added to match canonical URLs and avoid 301 redirect hops.

### llms.txt

Adds `src/public/llms.txt` → served at `/llms.txt` (was 404). Follows the [llmstxt.org](https://llmstxt.org) format: products, resources, cornerstone blog posts, community, and sitemaps. Hygiene for AI crawlers / GEO.

## Verification

- Live probes confirm old paths 404 and new paths 200.
- All rewritten `/posts/` slugs map to existing `blog/posts/<slug>.md`.
- `node scripts/build-blog.mjs` passes (53 posts + index + redirects + sitemap).
- No corruption (`/blog/blog/`, `//`, double-rewrites) — clean 1:1 substitutions.

## Scope notes

- Untracked `blog/blog/` duplicate dir and the untracked `DataEngineeringAgentLanding.tsx` scaffold were intentionally not modified (not part of the tracked/live build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)