### PR TITLE
fix(blog): copy blog/public into dist + dev middleware (follow-up to #42)

### DIFF
--- a/blog/posts/meet_datus.md
+++ b/blog/posts/meet_datus.md
@@ -46,7 +46,7 @@ The name Datus comes from the Latin word datum, meaning “something that has be
 
 ### Architecture
 
-![Architecture](../assets/architecture.png)
+![Architecture](/images/meet_datus/architecture.png)
 
 Datus turns context into a first-class, programmable asset for data teams. It has three layers:
 
@@ -74,7 +74,7 @@ Plugs into your existing stack: LLMs, data warehouses, catalog/lineage, semantic
 
 Engineers publish a subagent via CLI → analysts use it in Chat and submit feedback → feedback updates the Context Engine and regression sets → once stable, the subagent is exposed via API and orchestrated with schedulers → external systems keep supplying facts/semantics, and the loop repeats.
 
-![User Journey](../assets/user_journey.png)
+![User Journey](/images/meet_datus/user_journey.png)
 
 For example, data engineers start by seeding a small domain. They chat against the context, correct mistakes, capture “bad cases,” and publish a subagent for analysts to self-serve. Feedback flows back into the context; weekly regression keeps accuracy honest. As the subagent stabilizes, teams expose it as an API for other agents and services. (This mirrors how early users moved from “please fetch this” support to minutes-level self-service.)
 
@@ -82,7 +82,7 @@ For example, data engineers start by seeding a small domain. They chat against t
 
 ### The Context Engine
 
-![Context Engine](../assets/context_engine.png)
+![Context Engine](/images/meet_datus/context_engine.png)
 
 Datus organizes context along two axes:
 
@@ -94,7 +94,7 @@ With the Datus CLI, you browse/edit via @catalog and @subject, batch-bootstrap a
 
 - Subagents: domain-aware agents (or chatbots) that run with scoped context, minimizing hallucination and improving accuracy via feedback and continuous evaluation.
 
-![Subagent System](../assets/subagent.png)
+![Subagent System](/images/meet_datus/subagent.png)
 
 A subagent is a deployable unit: a curated scoped context + a vetted tool set + rules/policies for a specific business scenario. Think “Retention Analytics subagent” or “Store Operations subagent.” Typical contents might be ~10 key tables, ~20 metrics, ~30 reference SQLs and a few rules—most auto-extracted from history and success cases, then refined by engineers. Datus treats the feedback loop as part of the runtime: chat interactions create evaluations; evaluations refine context; refined context raises accuracy. Over time, subagents can be delivered as a chatbot to analysts and as stable APIs to other agents/microservices.
 
@@ -108,7 +108,7 @@ Open development also reflects how agents truly improve: by iterating context an
 
 Traditional data engineering pipelines end at delivery—tables built, dashboards published, next request starts. But questions evolve faster than pipelines, and context stays scattered across notebooks, dashboards, ad-hoc SQL, and tribal knowledge.
 
-![Contextual Data Engineering](../assets/contextual_data_engineering.png)
+![Contextual Data Engineering](/images/meet_datus/contextual_data_engineering.png)
 
 Contextual Data Engineering flips this model: the pipeline itself becomes a living map of your data system—continuously learning from historical SQL, feedback, and human corrections. Instead of just delivering data, you deliver an iterable context made of metadata, metrics, SQL history, and domain knowledge.
 

--- a/scripts/build-blog.mjs
+++ b/scripts/build-blog.mjs
@@ -5,7 +5,7 @@
 //
 // Output is written into dist/ (run after `vite build`).
 
-import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync, cpSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
@@ -15,6 +15,10 @@ import anchor from "markdown-it-anchor";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const POSTS_DIR = join(ROOT, "blog", "posts");
+// The blog's static assets (images, favicon, logo) — the old VitePress public
+// dir, referenced from posts at the site root (e.g. /images/...). vite's
+// publicDir is src/public, so nothing else copies these into dist/.
+const PUBLIC_DIR = join(ROOT, "blog", "public");
 const DIST = join(ROOT, "dist");
 const SITE = "https://datus.ai";
 const GA_ID = "G-EPVCH78EZP";
@@ -571,6 +575,15 @@ function main() {
     process.exit(1);
   }
   const posts = readPosts();
+
+  // Copy blog static assets (blog/public/* -> dist/*) so post images resolve at
+  // the site root. Without this, every /images/... reference 404s in production.
+  // Runs after `vite build` (which populates dist/ from src/public), so the only
+  // overlap is logo_dark.svg (byte-identical); favicon.svg + images are additive.
+  if (existsSync(PUBLIC_DIR)) {
+    cpSync(PUBLIC_DIR, DIST, { recursive: true });
+  }
+
   write(join(DIST, "blog", "blog.css"), blogCss());
 
   for (const post of posts.values()) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,7 +53,8 @@ const cleanUrls = () => {
 const MIME: Record<string, string> = {
   '.html': 'text/html; charset=utf-8', '.css': 'text/css', '.js': 'text/javascript',
   '.xml': 'application/xml', '.svg': 'image/svg+xml', '.png': 'image/png',
-  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.json': 'application/json', '.txt': 'text/plain',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.webp': 'image/webp',
+  '.json': 'application/json', '.txt': 'text/plain',
 };
 const serveBuiltBlog = () => {
   const DIST = path.resolve(__dirname, 'dist');
@@ -91,8 +92,31 @@ const serveBuiltBlog = () => {
   };
 };
 
+// Blog post images (and favicon/logo) live in blog/public/ and are referenced
+// at the site root (e.g. /images/...). In production scripts/build-blog.mjs
+// copies them into dist/, but vite's publicDir is src/public, so `vite dev`
+// has no route for them — requests fall through to the SPA fallback and render
+// as broken images. Serve any request that maps to a real file under
+// blog/public/ straight from source (no rebuild needed when an image changes).
+const serveBlogPublic = () => {
+  const PUBLIC = path.resolve(__dirname, 'blog/public');
+  const handler = (server: { middlewares: { use: (fn: (req: any, res: any, next: () => void) => void) => void } }) => {
+    server.middlewares.use((req, res, next) => {
+      const pathname = (req.url || '').split('?')[0].split('#')[0];
+      if (!pathname || pathname.endsWith('/')) return next();
+      const file = path.resolve(PUBLIC, decodeURIComponent(pathname).replace(/^\/+/, ''));
+      // Confine to blog/public so `..` segments can't escape the dir.
+      if (file !== PUBLIC && !file.startsWith(PUBLIC + path.sep)) return next();
+      if (!existsSync(file) || !statSync(file).isFile()) return next();
+      res.setHeader('Content-Type', MIME[path.extname(file)] || 'application/octet-stream');
+      res.end(readFileSync(file));
+    });
+  };
+  return { name: 'serve-blog-public', configureServer: handler, configurePreviewServer: handler };
+};
+
 export default defineConfig(() => ({
-  plugins: [react(), cleanUrls(), serveBuiltBlog()],
+  plugins: [react(), cleanUrls(), serveBuiltBlog(), serveBlogPublic()],
   base: '/',
   publicDir: 'src/public', 
   resolve: {


### PR DESCRIPTION
## Why

#42 was supposed to fix broken blog images but accidentally committed **only the 5 image renames** — a bad `git add` pathspec (referencing the already-moved `blog/assets/*.png`) aborted staging, so the code/content fixes never made it into the commit. Result: images still 404 in production and `meet_datus` still rendered `../assets/...`.

This PR adds the changes that were missing.

## Changes

- **`scripts/build-blog.mjs`** — copy `blog/public/* → dist/*` so `/images/...` and `/favicon.svg` resolve on GitHub Pages.
- **`vite.config.ts`** — `serveBlogPublic` dev/preview middleware (serves `blog/public/` files, path-confined) + `.gif`/`.webp` MIME types.
- **`blog/posts/meet_datus.md`** — switch the 5 image refs to `/images/meet_datus/...` (images already relocated in #42).

## Verification

Built locally (`npm run build:all`) and scanned all 118 built pages: **0 missing image references**. `vite preview` + `vite dev` serve all previously-404 images with correct content-types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)