### PR TITLE
docs(blog): add deeplinks across glossary articles and /glossary page

### DIFF
--- a/blog/posts/rag-data-engineering.md
+++ b/blog/posts/rag-data-engineering.md
@@ -40,7 +40,7 @@ head:
 ## TL;DR
 
 - **RAG** = **retrieve** relevant documents → **inject** into prompt → **generate** SQL or explanations.
-- In data engineering, retrieval targets **schemas, semantic models, reference SQL, and runbooks** — not generic web pages.
+- In data engineering, retrieval targets **schemas, [semantic models](/blog/what-is-semantic-model/), reference SQL, and runbooks** — not generic web pages.
 - Bad retrieval causes **confident wrong SQL** — worse than admitting "I don't know."
 - RAG in a **session** is not enough; production systems need **durable indexes** that update with feedback.
 - Production data RAG uses structured context navigation and vector search over institutional SQL to inject the right schema, metrics, and reference queries into each generation — not a one-size-fits-all retrieval dump.

--- a/blog/posts/what-is-data-agent.md
+++ b/blog/posts/what-is-data-agent.md
@@ -39,9 +39,9 @@ If you attended three data conferences in 2026, you heard at least a dozen tools
 
 - A **data agent** is any AI system that interacts with data — querying, analyzing, monitoring, or discovering — using natural language and data context.
 - The category spans a wide range: text-to-SQL chatbots, AI data analysts, pipeline agents, catalog agents, BI agents, and data engineering agents.
-- A **data engineering agent** is the **builder subclass** — it does not just answer questions from data; it builds and evolves the context (semantic models, metrics, reference SQL, validation rules) that makes all other data agents more accurate.
+- A **data engineering agent** is the **builder subclass** — it does not just answer questions from data; it builds and evolves the context ([semantic models](/blog/what-is-semantic-model/), metrics, reference SQL, validation rules) that makes all other data agents more accurate.
 - Most data agents are **consumers** of data context. Data engineering agents are **producers and maintainers** of data context. This is the fundamental architectural distinction.
-- Datus is a data engineering agent: it builds evolvable context for data systems, and exposes that context to other data agents (chatbots, BI tools, external agents) through Subagents, APIs, and MCP.
+- Datus is a data engineering agent: it builds evolvable context for data systems, and exposes that context to other data agents (chatbots, BI tools, external agents) through Subagents, APIs, and [MCP](/blog/what-is-mcp-data-engineering/).
 
 ## 1. Data agent: a working definition
 

--- a/blog/posts/what-is-data-catalog.md
+++ b/blog/posts/what-is-data-catalog.md
@@ -43,7 +43,7 @@ A **data catalog** inventories and describes data assets — tables, columns, ow
 - Popular platforms include <a href="https://datahubproject.io/" rel="nofollow noopener">DataHub</a>, <a href="https://atlan.com/" rel="nofollow noopener">Atlan</a>, and <a href="https://www.selectstar.com/" rel="nofollow noopener">Select Star</a> — plus native features in cloud warehouses.
 - **Data dictionary** = column-level definitions; **catalog** = searchable asset graph with governance metadata.
 - A **[semantic layer](/blog/what-is-semantic-layer/)** adds executable metric logic; catalogs rarely encode "net revenue" computation completely.
-- A catalog alone is not an AI grounding layer — agents need **executable context** (reference SQL, semantic models, feedback) layered on top of catalog metadata to generate correct queries reliably.
+- A catalog alone is not an AI grounding layer — agents need **executable context** (reference SQL, [semantic models](/blog/what-is-semantic-model/), feedback) layered on top of catalog metadata to generate correct queries reliably.
 
 ## 1. Data catalog: a working definition
 
@@ -84,7 +84,7 @@ The progression from catalog to context engine is a progression from descriptive
 Common drivers:
 
 - **Self-serve friction** — analysts cannot find trusted tables. The symptom is Slack messages to the data team that start with "where do I find..." — a catalog eliminates those messages by making table discovery self-service.
-- **Governance programs** — GDPR, SOX, internal data contracts need ownership tags. A catalog assignment of "PII: yes" on `dim_customer.email` enables automated policy enforcement at the metadata layer before any query touches the data.
+- **Governance programs** — GDPR, SOX, internal [data contracts](/blog/what-is-data-contract/) need ownership tags. A catalog assignment of "PII: yes" on `dim_customer.email` enables automated policy enforcement at the metadata layer before any query touches the data.
 - **Cloud migration** — new warehouse, lost oral history. A team migrating from Redshift to Snowflake discovers that 60% of their tables have no description and 40% have no known owner. The catalog becomes an archaeology tool before it becomes a governance tool.
 - **Cost control** — identify unused tables and duplicate pipelines. A catalog's popularity metrics reveal that `fact_orders_v1`, `fact_orders_v2`, and `fact_orders_v3` are all still queried weekly — by different teams, using different definitions, producing revenue numbers that differ by up to 5%.
 - **AI initiatives** — leadership assumes catalogs automatically fix NL2SQL (they do not, without more context). This is the fastest-growing driver in 2026 and also the most commonly misunderstood. A catalog populated with table descriptions does not upgrade to a text-to-SQL grounding layer by adding a chatbot on top. It needs executable context — reference SQL, join authority, grain definitions — that catalogs were not designed to store.

--- a/blog/posts/what-is-data-mesh.md
+++ b/blog/posts/what-is-data-mesh.md
@@ -68,7 +68,7 @@ Mesh is not "delete the data platform team." It shifts them from **authoring eve
 
 | Idea | Center of gravity | Typical slogan |
 | --- | --- | --- |
-| **Data warehouse / lakehouse** | Central storage and compute | "One copy of truth in the platform" |
+| **[Data warehouse](/blog/what-is-data-warehouse/) / [lakehouse](/blog/what-is-lakehouse/)** | Central storage and compute | "One copy of truth in the platform" |
 | **Data fabric** | Metadata-driven **integration layer** across silos | "Connect everything automatically" |
 | **Data mesh** | **Domain products** on shared infrastructure | "Domains own their data products" |
 
@@ -166,7 +166,7 @@ Yes, if the platform enables **per-domain context and delivery** (Subagents, ACL
 
 ### What's the relationship between data mesh and data contracts?
 
-Data contracts formalize the interface between data producers and consumers — schema structure, SLAs, semantics, and deprecation policies. They are a practical implementation mechanism for the "data as a product" principle in mesh. A data product without a contract is a table with good intentions. A data product with a contract says: here is the schema, here is the freshness SLA (updated by 9am ET daily), here are the semantics (this column means X, not Y), and here is the deprecation policy (backward-compatible for 90 days after a breaking change). Subagents consume data contracts as context — a Subagent configured with a domain's data contracts knows not just which tables to query but what guarantees those tables carry.
+[Data contracts](/blog/what-is-data-contract/) formalize the interface between data producers and consumers — schema structure, SLAs, semantics, and deprecation policies. They are a practical implementation mechanism for the "data as a product" principle in mesh. A data product without a contract is a table with good intentions. A data product with a contract says: here is the schema, here is the freshness SLA (updated by 9am ET daily), here are the semantics (this column means X, not Y), and here is the deprecation policy (backward-compatible for 90 days after a breaking change). Subagents consume data contracts as context — a Subagent configured with a domain's data contracts knows not just which tables to query but what guarantees those tables carry.
 
 ## Related articles
 

--- a/blog/posts/what-is-schema-linking.md
+++ b/blog/posts/what-is-schema-linking.md
@@ -86,7 +86,7 @@ Enterprise warehouses expose thousands of tables. Dumping full DDL into a prompt
 
 ### Ambiguous naming
 
-`value`, `status`, `type`, and `amount` appear on dozens of tables. Human engineers disambiguate with documentation and memory; models without aliases guess. In a typical SaaS data warehouse, `amount` appears on 40+ tables — `fact_invoices.amount`, `fact_payments.amount`, `fact_refunds.amount`, `dim_contract.amount`, and so on. A human engineer knows that "monthly revenue amount" means `fact_invoices.amount` with a date filter, not `dim_contract.amount`. A model without linking context sees five candidate `amount` columns and picks the one with the most semantic similarity to the prompt — which might be `fact_payments.amount` because "revenue" and "payments" are close in embedding space, even though payments includes one-time charges that are not revenue.
+`value`, `status`, `type`, and `amount` appear on dozens of tables. Human engineers disambiguate with documentation and memory; models without aliases guess. In a typical SaaS [data warehouse](/blog/what-is-data-warehouse/), `amount` appears on 40+ tables — `fact_invoices.amount`, `fact_payments.amount`, `fact_refunds.amount`, `dim_contract.amount`, and so on. A human engineer knows that "monthly revenue amount" means `fact_invoices.amount` with a date filter, not `dim_contract.amount`. A model without linking context sees five candidate `amount` columns and picks the one with the most semantic similarity to the prompt — which might be `fact_payments.amount` because "revenue" and "payments" are close in embedding space, even though payments includes one-time charges that are not revenue.
 
 ### Multiple valid join paths
 

--- a/blog/posts/what-is-text-to-sql.md
+++ b/blog/posts/what-is-text-to-sql.md
@@ -143,7 +143,7 @@ Retrieve relevant tables, metric docs, and past queries via embeddings or keywor
 
 The model plans, calls `list_tables`, `run_sql`, inspects errors, retries. Closer to how engineers work. Cost and latency rise; governance must constrain which tools and tables are in scope. The agent-loop architecture introduces a new failure mode that none of the simpler architectures face: cascading errors. If the first `run_sql` call uses a wrong join path and returns plausible-looking numbers, the model may treat those numbers as confirmation and deepen the wrong approach in subsequent iterations rather than backtracking. Mitigation requires execution guardrails — result shape checks, cardinality assertions, and diff comparisons against cached correct results — that add complexity to the agent loop but are necessary for production reliability.
 
-Datus combines catalog and subject trees, vector retrieval over reference SQL, semantic model generation commands, and scoped Subagents so text-to-SQL runs inside a bounded, evolvable context — not a global schema dump.
+Datus combines catalog and subject trees, vector retrieval over reference SQL, [semantic model](/blog/what-is-semantic-model/) generation commands, and scoped Subagents so text-to-SQL runs inside a bounded, evolvable context — not a global schema dump.
 
 ## 6. Text-to-SQL inside a data engineering agent
 
@@ -151,7 +151,7 @@ Text-to-SQL alone does not make an agent. Agents add:
 
 - **Persistence** — corrections survive the session. When an analyst corrects "revenue" from `gross_amount` to `net_revenue_usd`, that mapping is stored and applied to every future question in the domain.
 - **Delivery** — domain-scoped interfaces package context for analysts or APIs, rather than forcing every user through the same global prompt.
-- **Integration** — MCP clients, orchestrators, CI workflows. Text-to-SQL embedded in a dbt pull request can validate that a model change does not break downstream SQL.
+- **Integration** — [MCP](/blog/what-is-mcp-data-engineering/) clients, orchestrators, CI workflows. Text-to-SQL embedded in a dbt pull request can validate that a model change does not break downstream SQL.
 - **Governance** — scoped tables, rules, audit trails (especially in enterprise deployments). Every query leaves a trace from question to SQL to tables used to result.
 
 [Contextual data engineering](/blog/contextual-data-engineering/) describes the operating model: every text-to-SQL run strengthens context for the next run. In practice, this means the system's accuracy graph slopes upward over time within a domain — not because the model was upgraded, but because every correction is stored and every validated query is indexed as a retrieval candidate for future questions. A stateless copilot's accuracy graph is flat forever.

--- a/src/glossary/glossaryData.ts
+++ b/src/glossary/glossaryData.ts
@@ -226,12 +226,14 @@ export const glossary: GlossaryCategory[] = [
         slug: "data-catalog",
         definition:
           "A searchable inventory of tables, columns, owners, and documentation across the data platform. Answers “what data do we have and where does it live?”",
+        article: "/blog/what-is-data-catalog/",
       },
       {
         term: "Data Contract",
         slug: "data-contract",
         definition:
           "A machine-checked agreement between a data producer and its consumers, specifying schema, semantics, freshness, and ownership of a dataset.",
+        article: "/blog/what-is-data-contract/",
       },
       {
         term: "Data Lineage",
@@ -268,24 +270,28 @@ export const glossary: GlossaryCategory[] = [
         slug: "text-to-sql",
         definition:
           "Generating SQL from a natural-language question grounded in a real schema. Quality depends heavily on schema linking, business context, and feedback loops.",
+        article: "/blog/what-is-text-to-sql/",
       },
       {
         term: "Schema Linking",
         slug: "schema-linking",
         definition:
           "The step where the model figures out which tables and columns a question is actually about, before any SQL is written. Often the single biggest accuracy lever.",
+        article: "/blog/what-is-schema-linking/",
       },
       {
         term: "Retrieval-Augmented Generation (RAG)",
         slug: "retrieval-augmented-generation",
         definition:
           "Pulling relevant context — table docs, prior queries, glossary entries — into the model's prompt at query time, instead of relying on what it memorized during training.",
+        article: "/blog/rag-data-engineering/",
       },
       {
         term: "Model Context Protocol (MCP)",
         slug: "model-context-protocol",
         definition:
           "An open protocol for exposing tools, data, and context to LLM clients like Claude, Cursor, and IDEs. Lets one server power many AI front ends.",
+        article: "/blog/what-is-mcp-data-engineering/",
       },
       {
         term: "Embedding",
@@ -304,6 +310,7 @@ export const glossary: GlossaryCategory[] = [
         slug: "data-engineering-agent",
         definition:
           "An LLM-driven system that plans and executes data workflows end-to-end — schema discovery, SQL generation, validation, and iteration — instead of just autocompleting a single query.",
+        article: "/blog/what-is-data-engineering-agent/",
       },
     ],
   },


### PR DESCRIPTION
## Summary
Adds missing internal deeplinks so glossary terms point to the now-existing blog articles that explain them.

### Blog article cross-links (first natural mention)
- `what-is-data-mesh` → data contract, data warehouse, lakehouse
- `what-is-data-catalog` → data contract, semantic model
- `what-is-data-agent` → MCP, semantic model
- `what-is-text-to-sql` → MCP, semantic model
- `what-is-schema-linking` → data warehouse
- `rag-data-engineering` → semantic model

### /glossary aggregate page (`src/glossary/glossaryData.ts`)
Added 7 "Read the full guide →" deeplinks (Data Catalog, Data Contract, Text-to-SQL, Schema Linking, RAG, MCP, Data Engineering Agent), bringing linked terms from **7 → 14**.

All link targets verified against existing `blog/posts/*.md` — no dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added more internal links across several blog posts and glossary entries.
  * Linked related terms like semantic models, data contracts, data warehouse, MCP, and Text-to-SQL to their dedicated articles.
  * Improved cross-references in glossary categories so readers can navigate related topics more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->