### PR TITLE
docs(blog): add Apache Iceberg and Apache Hudi glossary articles

### DIFF
--- a/blog/posts/index.md
+++ b/blog/posts/index.md
@@ -67,6 +67,12 @@ Core data engineering terms — defined, with how they connect to agents and con
 - [What Is a Data Warehouse? Definition, Architecture & How It Differs From a Data Lake](/blog/what-is-data-warehouse/) — Jun 24, 2026
 - [What Is a Data Lake? Definition, Architecture & Data Lake vs Data Warehouse](/blog/what-is-data-lake/) — Jun 24, 2026
 - [What Is a Lakehouse Catalog? Hive, Glue, Unity, Polaris & Horizon](/blog/what-is-lakehouse-catalog/) — Jun 26, 2026
+- [What Is a Data Contract? Definition, Schema Enforcement & Examples](/blog/what-is-data-contract/) — Jun 29, 2026
+- [What Is MCP? Model Context Protocol for Data Engineering Explained](/blog/what-is-mcp-data-engineering/) — Jun 29, 2026
+- [What Is an Embedding? Definition, Vectors & Why AI Needs Them](/blog/what-is-embedding-ai/) — Jun 30, 2026
+- [What Is Medallion Architecture? Bronze, Silver & Gold Layers](/blog/what-is-medallion-architecture/) — Jun 30, 2026
+- [What Is Apache Iceberg? Table Format, Features & Iceberg vs Delta Lake](/blog/what-is-apache-iceberg/) — Jun 30, 2026
+- [What Is Apache Hudi? Upserts, Copy-on-Write vs Merge-on-Read & CDC](/blog/what-is-apache-hudi/) — Jun 30, 2026
 
 ## Why agents, not copilots
 

--- a/blog/posts/what-is-apache-hudi.md
+++ b/blog/posts/what-is-apache-hudi.md
@@ -1,0 +1,163 @@
+---
+title: "What Is Apache Hudi? Upserts, Copy-on-Write vs Merge-on-Read & CDC"
+description: "Apache Hudi definition, how copy-on-write and merge-on-read tables, record-level upserts and incremental queries work, Hudi vs Iceberg vs Delta, and agent context."
+author: "John Smith"
+date: 2026-06-30
+lastmod: 2026-06-30
+head:
+  - - meta
+    - name: keywords
+      content: "apache hudi, what is apache hudi, hudi upsert, copy on write vs merge on read, hudi incremental query, hudi vs iceberg, hudi vs delta lake"
+  - - meta
+    - property: og:title
+      content: "What Is Apache Hudi? Upserts, Copy-on-Write vs Merge-on-Read & CDC"
+  - - meta
+    - property: og:description
+      content: "Apache Hudi definition, how copy-on-write and merge-on-read tables, record-level upserts and incremental queries work, Hudi vs Iceberg vs Delta, and agent context."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-apache-hudi/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-apache-hudi/
+---
+
+# What Is Apache Hudi? Upserts, Copy-on-Write vs Merge-on-Read & CDC
+
+**Apache Hudi** is an open table format and ingestion framework that brings database-style **upserts, deletes, and incremental processing** to data lakes built on object storage. Where most lake tables were designed to be appended to, Hudi was designed from the start to be *mutated*: it can apply a stream of changed records to an existing table efficiently, track every change on a timeline, and let downstream jobs read only what changed since the last run. This glossary entry defines what Hudi is, how its two table types work, how record-level upserts and incremental queries differ from append-only formats, how it compares to Iceberg and Delta Lake, and why AI agents querying a Hudi lakehouse need format-aware context.
+
+*Disclosure: Datus is a data engineering agent platform. This article explains Apache Hudi as a general concept, referencing Datus alongside other tools and architectures in the category. See the end for more detail.*
+
+## TL;DR
+
+- **Apache Hudi** is an open table format and incremental data platform that adds **record-level upserts, deletes, change tracking, and incremental queries** to data lakes on object storage.
+- Its defining capability is **mutability**: applying a continuous stream of inserts and updates — for example from CDC — to lake tables without full rewrites, which append-only formats handle poorly.
+- Hudi offers two table types: **Copy-on-Write (CoW)** optimizes read performance, while **Merge-on-Read (MoR)** optimizes write/ingest latency by deferring compaction.
+- A **record-level index** lets Hudi locate and update individual records quickly, which is what makes high-frequency upsert workloads practical at lake scale.
+- Against **Iceberg** and **Delta Lake**, Hudi's sweet spot is **streaming ingest and CDC-heavy pipelines**; agents querying Hudi must understand table type and query type, or they will read stale or partial data.
+
+## 1. Apache Hudi: a working definition
+
+Hudi was created at Uber to solve a problem append-only lake formats handled badly: ingesting a high-volume stream of *updates*, not just new rows. Uber's data — trips, payments, driver and rider state — changed constantly after first landing, and rewriting entire partitions to apply a handful of updated records was prohibitively expensive. Hudi (the name comes from "Hadoop Upserts Deletes and Incrementals") was donated to the Apache Software Foundation and is now a top-level project. The original problem still defines its character: Hudi treats a lake table as something you continuously merge changes into, with a managed **timeline** recording every commit, so the table can be both mutated and audited.
+
+The mechanics follow from that goal. Every write is recorded on the Hudi **timeline** as an instant with a state, which gives the table a consistent, ordered history and enables rollback and time travel. To make updates cheap, Hudi maintains a **record-level index** that maps a record key to the file group holding it, so an upsert can rewrite or append to the right file instead of scanning everything. This index is the feature most responsible for Hudi's reputation in upsert-heavy workloads, and it is the thing most absent from formats that began as append-only and added updates later.
+
+Consider a concrete pipeline. A change-data-capture stream from an operational Postgres delivers `orders` events — new orders, status changes, cancellations — every few minutes. With an append-only table you would accumulate a log and reconstruct current state with expensive window functions at query time. With Hudi, you define `order_id` as the record key and continuously **upsert** the stream into an `orders` table; the table always reflects current state, late updates land in the right file group via the index, and a deletion propagates as a real delete rather than a tombstone you must remember to filter. The same table also supports an **incremental query** that returns only records changed since a given commit, so a downstream Silver-layer job processes deltas instead of rescanning the whole table.
+
+A useful working definition:
+
+> **Apache Hudi** is an open table format and incremental processing framework for data lakes that provides **record-level upserts and deletes, a managed commit timeline, time travel, and incremental queries** over open file formats on object storage. It is built for **mutable, continuously updated lake tables** — especially streaming and change-data-capture ingestion — exposing files as transactional tables that engines such as Spark, Flink, and Trino can read and write.
+
+That definition draws a few boundaries. Hudi is **not** only a file format — it ships ingestion tooling (the streaming ingest utility, formerly DeltaStreamer) and table services like compaction and clustering, making it more of an *incremental data platform* than a passive spec. It is **not** a query engine — Spark, Flink, Presto/Trino, and Hive execute the SQL. And it is **not** the right default for purely append-only, read-optimized analytics, where a simpler [lakehouse](/blog/what-is-lakehouse/) table format may carry less operational overhead.
+
+## 2. Copy-on-Write vs Merge-on-Read
+
+The single most important Hudi concept to understand before querying or designing a table is its **table type**, because it determines the trade-off between write latency and read latency. The choice is not cosmetic — it changes how fresh data appears and how much work each query does.
+
+| Aspect | Copy-on-Write (CoW) | Merge-on-Read (MoR) |
+| --- | --- | --- |
+| **On write** | Rewrites affected files with merged data | Writes lightweight delta logs; defers merge |
+| **On read** | Reads columnar files directly — fast | Merges base files + delta logs at read time |
+| **Write latency** | Higher | Lower |
+| **Read latency** | Lower | Higher (until compaction) |
+| **Best for** | Read-heavy, moderate update rate | High-frequency ingest, streaming |
+| **Freshness** | Visible after each commit | Near-real-time via delta logs |
+
+**Copy-on-Write** rewrites the data files touched by an update so that every read hits clean, columnar files with no merge cost — excellent for read-heavy tables where updates arrive at a moderate pace. The price is paid on write: applying many small updates means repeatedly rewriting files, which becomes expensive under high-frequency ingestion.
+
+**Merge-on-Read** inverts the trade-off. Updates are written as compact delta log files alongside the base files, so ingestion is fast and near-real-time, but readers must merge base and delta files on the fly until a background **compaction** folds the logs into new base files. MoR is the natural choice for streaming and CDC pipelines where ingest latency matters most, provided the team actually runs compaction on a schedule rather than letting delta logs pile up. Choosing CoW for a high-velocity CDC stream — or MoR without scheduled compaction — is a common, self-inflicted performance problem, which is exactly why the table type belongs in any documentation an analyst or agent consults.
+
+## 3. Record-level upserts and incremental queries
+
+Two capabilities distinguish Hudi from append-first formats in day-to-day use: record-level writes and incremental reads. Understanding them is the difference between using Hudi as intended and fighting it.
+
+On the write side, Hudi's **record-level index** is what makes upserts and deletes efficient. Each record has a key, and the index knows which file group holds that key, so applying an update touches only the relevant files rather than rewriting a whole partition. This is why Hudi handles late-arriving and mutating data — corrections, status transitions, GDPR-style deletes — without the partition-rewrite tax that append-only formats incur when forced to update. Deletes are first-class: a delete removes the record, which matters for compliance workflows where a tombstone you must remember to filter is not acceptable.
+
+On the read side, **incremental queries** let a consumer ask "give me only the records that changed since commit *X*." Instead of rescanning an entire table to find what is new, a downstream job pulls the delta and processes it — the lake-native equivalent of reading a change feed. This composes naturally with [medallion architecture](/blog/what-is-medallion-architecture/): a Bronze table ingests raw CDC, and a Silver job incrementally consumes only changed Bronze records to maintain conformed tables, cutting compute dramatically versus full reprocessing. The official <a href="https://hudi.apache.org/docs/overview" rel="nofollow noopener">Apache Hudi documentation</a> details the query types, and the distinction between a *snapshot* query (current state) and an *incremental* query (changes only) is one an agent must respect to avoid double-counting or missing rows.
+
+## 4. Hudi vs Iceberg vs Delta Lake
+
+Hudi sits alongside two other dominant open table formats — <a href="https://iceberg.apache.org/" rel="nofollow noopener">Apache Iceberg</a> and <a href="https://docs.delta.io/" rel="nofollow noopener">Delta Lake</a> — and the comparison is less about who has which feature — they have converged substantially — and more about which workload each was built around. The table below answers which format leans toward which problem.
+
+| Dimension | Apache Hudi | Apache Iceberg | Delta Lake |
+| --- | --- | --- | --- |
+| **Origin / steward** | Uber → Apache | Netflix → Apache | Databricks → Linux Foundation |
+| **Core design bet** | Upserts, CDC, incremental | Engine-neutral metadata | Spark/Databricks integration |
+| **Update model** | CoW **and** MoR, record-level index | CoW / MoR, hidden partitioning | CoW; deletion vectors |
+| **Incremental reads** | First-class incremental queries | Snapshot-based incremental | Change Data Feed |
+| **Sweet spot** | Streaming ingest, mutable tables | Multi-engine analytics, vendor exit | Databricks-centric lakehouse |
+| **Engine breadth** | Spark, Flink, Hive, Presto/Trino | Broadest | Strongest in Spark/Databricks |
+
+Read this by sweet spot, because feature-by-feature the three formats keep narrowing the gaps. Hudi's strongest argument is **mutable, high-frequency ingestion**: if your central problem is applying a relentless CDC stream to lake tables with low latency and reading only deltas downstream, Hudi's record-level index and MoR design target exactly that. [Apache Iceberg](/blog/what-is-apache-iceberg/) is the safer default when **engine neutrality and avoiding vendor lock-in** dominate, given its broad engine support. Delta Lake is hard to beat inside the **Spark and Databricks** ecosystem where its integration is deepest.
+
+The honest framing is that there is no universal winner, and a team optimizing purely for read-heavy, multi-engine analytics may find Iceberg simpler to operate than Hudi, whose richer ingest machinery carries more moving parts. The right move is to match the format to the dominant workload, write the decision down, and make it discoverable — because implicit format choices are where both humans and agents go wrong.
+
+## 5. Hudi and AI agents: format-aware context
+
+Hudi's mutability is powerful for pipelines but raises the bar for AI agents and text-to-SQL systems, because correct results depend on concepts a column list never reveals: table type, query type, and the meaning of "current." An agent that knows table and column names but nothing about MoR semantics will confidently return stale or partial data.
+
+| Context gap | Agent symptom | What it needs injected |
+| --- | --- | --- |
+| **Table type unknown** | Assumes CoW freshness on a MoR table | Table type (CoW/MoR) and compaction status |
+| **Query type confusion** | Uses snapshot read when an incremental delta was intended | Query-type policy (snapshot vs incremental) |
+| **Record key blindness** | Re-aggregates a log instead of reading current state | Record key and precombine field semantics |
+| **Partition + index** | Full scan, ignores record-level index | Partition spec and indexed key documentation |
+| **Engine divergence** | Spark-only SQL on a Trino/Hive reader | Engine-scoped dialect and supported operations |
+
+This is why [schema linking](/blog/what-is-schema-linking/) on a Hudi estate is harder than on a plain relational database: the same table answers differently depending on whether you read it as a snapshot or incrementally, and on whether compaction has run. A [data engineering agent](/blog/what-is-data-engineering-agent/) needs evolvable context that captures table type and query semantics, not a static DDL dump that says nothing about how the table is meant to be read.
+
+Open-source agents aimed at cross-stack work address this by reading lake tables through a catalog and carrying table-format metadata into the model's context. As of June 2026, Datus includes a Spark adapter (v0.2.6) that connects to Hudi and Delta Lake tables and builds a catalog-backed context tree, so generated SQL references governed tables and their semantics rather than guessing at raw files. That is one implementation pattern among several; the general requirement — context that reflects how a mutable table is actually read — holds regardless of tool, and acknowledging that a managed Databricks or warehouse path may suit some teams better is part of choosing honestly.
+
+## 6. Production-readiness checklist for Hudi + agents
+
+Before pointing analysts or an agent at Hudi tables, a short checklist predicts most failures, because Hudi's flexibility is also its sharpest edge.
+
+1. **Table type documented** — Is each table CoW or MoR, and is the choice justified by its workload?
+2. **Compaction scheduled** — For MoR tables, does compaction run on a schedule so reads do not degrade?
+3. **Record keys and precombine** — Are record keys and the precombine (ordering) field documented per table?
+4. **Query-type policy** — When should consumers use snapshot vs incremental queries?
+5. **Catalog registration** — Are tables registered with owners, partitions, and physical/logical mappings?
+6. **Reference SQL** — Are vetted queries tagged by engine and query type so agents imitate correct patterns?
+
+Missing items 1–2 produce the stale-read and slow-query failures most often blamed on "the lakehouse," while missing items 3–6 are where agents specifically generate wrong results. The list is engine-agnostic by design — it holds whether your compute is Spark, Flink, or Trino.
+
+## Conclusion
+
+**Apache Hudi** is best understood as the open table format that made data lakes *mutable*: record-level upserts and deletes, a managed timeline for audit and rollback, and incremental queries that turn a lake table into a change feed. Its defining bet against Iceberg and Delta Lake is **streaming and CDC ingestion**, anchored by a record-level index and the Copy-on-Write versus Merge-on-Read trade-off. For AI agents, Hudi moves the hard problems from syntax to **table-type, query-type, and freshness context** — the same shift that separates a demo from a production-grade [data engineering agent](/blog/what-is-data-engineering-agent/).
+
+## Frequently asked questions
+
+### What is Apache Hudi used for?
+
+Hudi is used to build **mutable, incrementally updated data lake tables**, most commonly for change-data-capture and streaming ingestion. It applies a continuous stream of inserts, updates, and deletes to lake tables efficiently using a record-level index, tracks every change on a timeline for audit and rollback, and lets downstream jobs read only what changed via incremental queries — workloads that append-only lake formats handle poorly.
+
+### What is the difference between Copy-on-Write and Merge-on-Read in Hudi?
+
+**Copy-on-Write (CoW)** rewrites data files on each update, so reads are fast but writes are heavier — ideal for read-heavy tables with moderate update rates. **Merge-on-Read (MoR)** writes lightweight delta logs and defers merging to a background compaction, so ingestion is fast and near-real-time but reads must merge base and delta files until compaction runs. CoW optimizes read latency; MoR optimizes write latency for streaming and CDC.
+
+### Hudi vs Iceberg — when should I pick Hudi?
+
+Pick **Hudi** when your dominant workload is **high-frequency upserts, CDC ingestion, or incremental processing**, where its record-level index and Merge-on-Read design were purpose-built to apply changes cheaply. Choose **Iceberg** when engine neutrality, broad multi-engine support, and avoiding vendor lock-in matter more than streaming-update performance. Many teams pick one primary format and document exceptions per domain rather than running both everywhere.
+
+### Can a text-to-SQL agent query Hudi tables reliably?
+
+Only with format-aware context. On a small POC, pasting DDL may work, but on production Hudi tables an agent must know each table's **type (CoW or MoR)**, the intended **query type (snapshot vs incremental)**, and the **record key**, or it will return stale or partial results that look valid. Supply table-type and query-type metadata through a catalog before relying on agent-generated SQL.
+
+## Related articles
+
+- [What is Apache Iceberg?](/blog/what-is-apache-iceberg/) — the engine-neutral table format Hudi is often compared to
+- [What is a lakehouse?](/blog/what-is-lakehouse/) — the architecture Hudi tables make possible
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — why table-format-aware context matters
+
+---
+
+*Disclosure: Datus is a data engineering agent platform. This glossary entry explains Apache Hudi as a general concept and how cross-stack agents approach lakehouse context — alongside other tools and architectures in the category.*

--- a/blog/posts/what-is-apache-iceberg.md
+++ b/blog/posts/what-is-apache-iceberg.md
@@ -1,0 +1,159 @@
+---
+title: "What Is Apache Iceberg? Table Format, Features & Iceberg vs Delta Lake"
+description: "Apache Iceberg definition, how its hidden partitioning, snapshots and schema evolution work, Iceberg vs Delta Lake vs Hudi, and why AI agents need table-aware context."
+author: "John Smith"
+date: 2026-06-30
+lastmod: 2026-06-30
+head:
+  - - meta
+    - name: keywords
+      content: "apache iceberg, what is apache iceberg, iceberg table format, iceberg vs delta lake, iceberg vs hudi, iceberg hidden partitioning, lakehouse table format"
+  - - meta
+    - property: og:title
+      content: "What Is Apache Iceberg? Table Format, Features & Iceberg vs Delta Lake"
+  - - meta
+    - property: og:description
+      content: "Apache Iceberg definition, how its hidden partitioning, snapshots and schema evolution work, Iceberg vs Delta Lake vs Hudi, and why AI agents need table-aware context."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-apache-iceberg/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-apache-iceberg/
+---
+
+# What Is Apache Iceberg? Table Format, Features & Iceberg vs Delta Lake
+
+A data engineer partitions a large events table in Hive by a string column, `dt='2026-06-15'`, and ships it. Six months later the business wants hourly granularity. A backfill rewrites the underlying folders, a few late files land in the wrong directory, and every downstream query that hard-coded `WHERE dt = '2026-06-15'` quietly returns partial results — no error, just wrong numbers in a board deck. **Apache Iceberg** is the open table format designed to make this entire class of failure structurally impossible: it tracks which files belong to a table, hides partition logic from the query, and commits changes atomically. This glossary entry defines what Iceberg is, how its core mechanics work, how it compares to Delta Lake and Hudi, and why AI agents querying a lakehouse need to understand it.
+
+*Disclosure: Datus is a data engineering agent platform. This article explains Apache Iceberg as a general concept, referencing Datus alongside other tools and architectures in the category. See the end for more detail.*
+
+## TL;DR
+
+- **Apache Iceberg** is an open table format that turns a directory of files on object storage into a database-style table with **ACID transactions, schema evolution, hidden partitioning, and time travel** — readable by many engines, owned by no single vendor.
+- It is **not** a query engine, **not** a catalog, and **not** a storage system — it is a **metadata specification** layered on top of Parquet, ORC, or Avro files that engines like Spark, Trino, and Flink read and write.
+- **Hidden partitioning** and **partition evolution** let you change how a table is physically laid out without rewriting queries — the failure mode in the opening story simply cannot occur.
+- Against **Delta Lake** and **Apache Hudi**, Iceberg's distinguishing bet is **engine neutrality**: it was designed from the start to avoid coupling table semantics to one compute vendor.
+- AI agents and text-to-SQL systems break on Iceberg estates when they reason about **file paths instead of table snapshots**, ignore **partition transforms**, or assume a `MERGE` works the same across engines — context must be table-format-aware.
+
+## 1. Apache Iceberg: a working definition
+
+Iceberg originated at Netflix to solve correctness and scale problems with Hive tables on petabyte-scale data lakes, and was donated to the Apache Software Foundation, where it is now a top-level project. The motivation was concrete: Hive tracked tables as directory listings, so concurrent writers, partial commits, and partition layout changes produced silent corruption and inconsistent reads. Iceberg replaced directory-as-table with an explicit metadata tree that records exactly which data files constitute each version of a table.
+
+The mechanics are worth stating plainly because they drive everything downstream. A write does not modify a folder in place; it produces a new **snapshot** that points to a manifest list, which points to manifest files, which point to the actual data files. Readers always resolve a table to one immutable snapshot, so a long-running analytics query never sees a half-finished backfill. Writers commit by atomically swapping a metadata pointer, which is how Iceberg delivers ACID semantics on storage that is itself only eventually consistent.
+
+Consider the opening scenario again, but on Iceberg. The events table is partitioned with a **transform** — say `days(event_ts)` — rather than a hand-maintained `dt` string. Analysts query `WHERE event_ts >= '2026-06-15'` against logical columns, and Iceberg prunes partitions internally. When the team later wants hourly buckets, they evolve the partition spec; old data keeps its old layout, new data uses the new one, and **no query is rewritten**. The string-partition trap that returned partial board numbers is gone because the query never referenced physical partitions at all.
+
+A useful working definition:
+
+> **Apache Iceberg** is an open, vendor-neutral table format that manages large analytic datasets on object storage by maintaining a metadata layer of snapshots, manifests, and partition specifications. It provides **ACID transactions, full schema and partition evolution, hidden partitioning, and time travel** over open file formats such as Parquet — exposing a directory of files as a single SQL-accessible table that multiple engines can read and write consistently.
+
+That definition deliberately excludes a few things. Iceberg is **not** a database engine — it executes no SQL itself; Spark, Trino, Flink, Dremio, Snowflake, or BigQuery do that. It is **not** a catalog, though it requires one to map table names to metadata locations. And it is **not** a replacement for a [data warehouse](/blog/what-is-data-warehouse/) — it is the table abstraction that lets a [lakehouse](/blog/what-is-lakehouse/) behave warehouse-like on open storage.
+
+## 2. Iceberg vs Delta Lake vs Hudi
+
+Iceberg is one of three dominant open table formats — alongside <a href="https://docs.delta.io/" rel="nofollow noopener">Delta Lake</a> and <a href="https://hudi.apache.org/" rel="nofollow noopener">Apache Hudi</a> — and the differences are real even though all three deliver ACID tables on object storage. The table below answers a single question teams actually ask: which format leans toward which workload and ecosystem?
+
+| Dimension | Apache Iceberg | Delta Lake | Apache Hudi |
+| --- | --- | --- | --- |
+| **Origin / steward** | Netflix → Apache | Databricks → Linux Foundation | Uber → Apache |
+| **Core design bet** | Engine-neutral metadata | Tight Spark/Databricks integration | Streaming upserts & incremental |
+| **Partition handling** | Hidden partitioning + evolution | Directory partitioning, generated columns | Partition + record-level index |
+| **Update model** | Copy-on-write / merge-on-read | Copy-on-write (deletion vectors for MOR-like) | Copy-on-write **and** merge-on-read |
+| **Engine breadth** | Broadest (Spark, Trino, Flink, Snowflake, BigQuery) | Strongest in Spark/Databricks; readers elsewhere | Spark, Flink, Hive, Presto/Trino |
+| **Sweet spot** | Multi-engine analytics, vendor exit | Databricks-centric lakehouse | High-frequency upserts, CDC ingest |
+
+Read the table by sweet spot rather than by feature count, because the formats have steadily copied each other's capabilities. Iceberg's strongest argument is **engine neutrality**: if your strategy depends on reading the same tables from several engines and avoiding lock-in to one compute vendor, Iceberg was built for that from day one. Delta Lake is hard to beat when your stack is already centered on Spark and Databricks, where its integration is deepest. [Apache Hudi](/blog/what-is-apache-hudi/) earns its place where **mutable, high-frequency upserts and change-data-capture ingestion** dominate, because record-level indexing is its native concern rather than a later addition.
+
+None of these is a universal winner, and treating the choice as a tribal allegiance is the common mistake. Many organizations standardize on one primary format per lake to limit operational sprawl, then document exceptions where a specific domain genuinely needs another. The decision should be written down and discoverable, because — as the next sections show — both humans and agents make wrong calls when the format and its capabilities are implicit.
+
+## 3. How Iceberg works: snapshots, schema evolution, and hidden partitioning
+
+The three Iceberg features teams rely on most in practice are snapshots, schema evolution, and hidden partitioning, and they are easiest to understand through what each one prevents.
+
+**Snapshots and time travel** turn every commit into an immutable, addressable version of the table. Because a read resolves to exactly one snapshot, a report generated at 9:00 a.m. is reproducible even after a noon backfill, and you can query `AS OF` a prior snapshot to audit what a dashboard saw last week. This is also the mechanism behind safe rollbacks: a bad write is undone by repointing metadata at the previous snapshot rather than by restoring files from backup.
+
+**Schema evolution** in Iceberg tracks columns by a stable internal ID rather than by name or position. That detail sounds academic until someone renames a column or reorders fields: in directory-listing formats this can silently re-map data, but in Iceberg the IDs keep historical data correct. You can add, drop, rename, and reorder columns without rewriting existing files, which is what makes long-lived analytic tables maintainable over years rather than quarters.
+
+**Hidden partitioning** is the feature most directly tied to the opening story. The user writes queries against logical columns, and Iceberg stores a partition *transform* — `days(ts)`, `bucket(16, user_id)`, `truncate(10, zip)` — separately from the query. Engines prune partitions automatically, so analysts cannot forget a partition predicate, and the layout can evolve without breaking a single query. For deeper detail, the format is specified publicly in the <a href="https://iceberg.apache.org/spec/" rel="nofollow noopener">Apache Iceberg table specification</a>, which is itself a useful signal of the project's openness.
+
+## 4. Why organizations adopt Iceberg
+
+The triggers for adopting Iceberg are usually painful enough to be specific, not aspirational. Teams move when the cost of *not* having table semantics becomes visible in incidents and bills.
+
+- **Correctness incidents** — silent partial reads, double-counted backfills, and "the dashboard changed overnight" mysteries traceable to non-atomic writes.
+- **Multi-engine reality** — data scientists on Spark, analysts on Trino, and a warehouse reading external tables, all needing one consistent view.
+- **Vendor-exit strategy** — a board-level requirement that analytical data not be trapped in one proprietary storage format.
+- **Schema churn** — fast-moving product schemas where columns are added monthly and rewriting history is not viable.
+
+Adoption fails, however, when Iceberg is treated as a checkbox rather than an operational commitment. A frequent failure mode is enabling Iceberg but never running **compaction**, so thousands of tiny files from streaming writes accumulate and query latency degrades until someone blames "the lakehouse." Another is leaving **snapshot expiration** unconfigured, which quietly grows storage and metadata until expensive cleanups become necessary. The maturity signal is not "we use Iceberg" but "we run compaction, expiration, and catalog governance as routine operations," which is the same discipline a serious [data catalog](/blog/what-is-data-catalog/) practice demands.
+
+## 5. Iceberg and AI agents: the context problem
+
+Iceberg solves correctness for human-written SQL, but it raises the bar for AI agents and text-to-SQL systems, because the format introduces concepts a column list alone does not capture. An agent that knows table and column names but nothing about snapshots, transforms, or engine differences will generate SQL that is syntactically valid and semantically wrong.
+
+| Context gap | Agent symptom | What it needs injected |
+| --- | --- | --- |
+| **Path vs table** | Targets `s3://.../*.parquet` instead of the registered table | Catalog entry mapping physical files to a logical table |
+| **Partition transforms** | Full table scan and timeout; no pruning | Partition spec (`days`, `bucket`, `truncate`) and required filters |
+| **Snapshot semantics** | Mixes snapshots across a multi-step report | Snapshot ID or an explicit "as of" policy |
+| **Engine divergence** | Spark-only SQL run against a Trino cluster | Engine-scoped dialect and supported operations |
+| **Update capability** | Assumes `MERGE` works on a read-only snapshot | Format + engine feature matrix |
+
+This is why [schema linking](/blog/what-is-schema-linking/) on an Iceberg estate is harder than on a small Postgres instance: there are more tables, more layers, and more engines, and therefore more ways to be correct in syntax but wrong in result. A [data engineering agent](/blog/what-is-data-engineering-agent/) needs evolvable, table-format-aware context — not a one-time dump of DDL that goes stale the moment a partition spec evolves.
+
+Open-source agents that target cross-stack work approach this by reading lakehouse tables through a catalog view rather than raw paths, and by carrying metadata about partitions and supported operations into the model's context. As of June 2026, Datus connects to lakehouse tables through native database and Spark adapters and builds a catalog-backed context tree so generated SQL references governed tables and their partitions rather than guessing at folder layouts. That is one implementation pattern among several; the general requirement — context that evolves with the table — holds regardless of tool.
+
+## 6. Production-readiness checklist for Iceberg + agents
+
+Before pointing analysts or an agent at Iceberg tables, teams can sanity-check a short list that predicts most downstream failures.
+
+1. **Catalog registration** — Is every table registered with an owner, description, and physical/logical mapping?
+2. **Partition documentation** — Are partition transforms recorded so queries and agents apply the right filters?
+3. **Compaction and expiration** — Are small-file compaction and snapshot expiration scheduled, not ad hoc?
+4. **Engine matrix** — Which engines read and write each table, and which support `MERGE`/`DELETE`?
+5. **Certified tables** — Which Iceberg tables are approved for executive metrics versus exploratory use?
+6. **Reference SQL** — Are vetted queries tagged by engine so agents have correct examples to imitate?
+
+Missing items 1–3 reliably reproduce the small-file and partial-read failures described earlier; missing items 4–6 are where agents specifically go wrong. The checklist is engine-agnostic on purpose — it works whether your compute is Spark, Trino, or a warehouse reading Iceberg externally.
+
+## Conclusion
+
+**Apache Iceberg** is best understood as a metadata contract that turns a pile of files into a trustworthy table: snapshots for atomic, reproducible reads; schema evolution for tables that survive years of change; and hidden partitioning that eliminates a whole category of silent wrong-number bugs. Its defining bet against Delta Lake and Hudi is engine neutrality, which matters most to teams that refuse to couple their data to one compute vendor. For AI agents, Iceberg moves the hard problems from syntax to **snapshot, partition, and engine context** — the same shift that separates a demo from a production-grade [data engineering agent](/blog/what-is-data-engineering-agent/).
+
+## Frequently asked questions
+
+### Is Apache Iceberg a database?
+
+No. Iceberg is a **table format** — a metadata specification — not a database or query engine. It defines how files, snapshots, and partitions are tracked so that engines like Spark, Trino, Flink, Snowflake, and BigQuery can read and write the same table consistently. The SQL execution, indexing, and caching all live in those engines, while Iceberg supplies the shared, open table contract underneath them.
+
+### Iceberg vs Delta Lake — which should I choose?
+
+Choose by ecosystem and goals rather than feature checklists, since the two have converged on most capabilities. **Delta Lake** is the natural fit when your stack is centered on Spark and Databricks, where its integration runs deepest. **Iceberg** wins when engine neutrality and avoiding vendor lock-in are strategic — its broad engine support and open governance were design goals from the start. Many teams standardize on one and document the exceptions.
+
+### What is hidden partitioning in Iceberg?
+
+Hidden partitioning means the table's physical partition layout is defined by a transform (such as `days(event_ts)` or `bucket(16, user_id)`) that is stored in metadata, not written into every query. Engines prune partitions automatically from filters on logical columns, so analysts cannot forget a partition predicate, and the partition scheme can evolve without rewriting any existing queries — the single biggest source of Hive-era partition bugs.
+
+### Can a text-to-SQL agent query Iceberg without extra context?
+
+For a tiny POC schema, paste DDL and it may work. For a production Iceberg estate with many tables, evolving partition specs, and multiple engines, an agent needs **catalog mappings, partition specifications, and an engine feature matrix** in its context, or it will produce valid SQL with wrong results. Invest in catalog and certified-table context before blaming the model for inaccuracy.
+
+## Related articles
+
+- [What is a lakehouse?](/blog/what-is-lakehouse/) — the architecture Iceberg tables make possible
+- [What is Apache Hudi?](/blog/what-is-apache-hudi/) — the upsert-first table format Iceberg is often compared to
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — why table-format-aware context matters
+
+---
+
+*Disclosure: Datus is a data engineering agent platform. This glossary entry explains Apache Iceberg as a general concept and how cross-stack agents approach lakehouse context — alongside other tools and architectures in the category.*

--- a/src/glossary/glossaryData.ts
+++ b/src/glossary/glossaryData.ts
@@ -141,6 +141,7 @@ export const glossary: GlossaryCategory[] = [
         slug: "apache-iceberg",
         definition:
           "An open table format that adds schema evolution, hidden partitioning, and snapshot isolation on top of Parquet files in object storage.",
+        article: "/blog/what-is-apache-iceberg/",
       },
       {
         term: "Delta Lake",
@@ -153,6 +154,7 @@ export const glossary: GlossaryCategory[] = [
         slug: "apache-hudi",
         definition:
           "An open table format focused on upserts and incremental processing — designed for use cases where records change frequently after they land.",
+        article: "/blog/what-is-apache-hudi/",
       },
       {
         term: "Lakehouse Catalog",


### PR DESCRIPTION
## Summary

Adds two new `category: Glossary` articles to datus.ai/blog and wires them into navigation, following the `datus-glossary-article` skill.

- **What Is Apache Iceberg?** (`/blog/what-is-apache-iceberg/`, ~2.6k words) — hidden partitioning, snapshots & schema evolution, Iceberg vs Delta vs Hudi decision table, agent context-gap table, production-readiness checklist.
- **What Is Apache Hudi?** (`/blog/what-is-apache-hudi/`, ~2.7k words) — Copy-on-Write vs Merge-on-Read, record-level upserts, incremental queries / CDC, Hudi vs Iceberg vs Delta.

Both are GlossaryTerm articles (Category C — Storage & Formats), author John Smith.

## Changes

- `blog/posts/what-is-apache-iceberg.md` (new)
- `blog/posts/what-is-apache-hudi.md` (new)
- `blog/posts/index.md` — register both under the Glossary section
- `src/glossary/glossaryData.ts` — link the Apache Iceberg / Apache Hudi glossary entries to the new articles

## Quality checks

- Hard Gates G1–G7 + D1–D4: Pass (facts verified vs product-facts; Datus mentions ≤15% with disclosure ×2; link budget OK)
- Each article: 2200–3200 words, 3 external authoritative citations, ≥4 FAQ, snippet-ready definition
- Cross-article audit: distinct hooks/narratives (Iceberg = partition-failure scenario; Hudi = definition-first streaming/CDC)
- Built locally via `npm run build && npm run blog:build`; both render at `/blog/<slug>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new glossary entries and links for several topics, including Data Contract, MCP, Embedding, Medallion Architecture, Apache Iceberg, and Apache Hudi.
  * Published new articles explaining Apache Iceberg and Apache Hudi, with comparisons to other table formats and practical guidance for using them.

* **Documentation**
  * Expanded the blog index to surface the latest glossary and storage-format content.
  * Added FAQ, checklist, and related-reading sections to the new posts for easier discovery and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->