### PR TITLE
nav: surface Web Chatbot & MCP Server interface pages in the Products menu

### DIFF
--- a/src/components/InterfaceView.tsx
+++ b/src/components/InterfaceView.tsx
@@ -45,10 +45,9 @@ export type InterfaceData = {
 /** Rewrite datus-design marker classes + inline code to site.css styling. */
 function styleHtml(html: string): string {
   return html
-    .replace(/class="marker-cyan"/g, 'style="color:var(--term-cyan)"')
-    .replace(/class="marker-amber"/g, 'style="color:var(--term-amber)"')
-    .replace(/class="marker-sage"/g, 'style="color:var(--term-green)"')
-    .replace(/class="marker-pink"/g, 'style="color:var(--term-pink)"')
+    // Datus-website keeps headings neutral: drop the datus-design marker accent
+    // colors so highlighted phrases match the main ink color (no rainbow text).
+    .replace(/\s*class="marker-(?:cyan|amber|sage|pink)"/g, "")
     .replace(/<code[^>]*>/g, '<code class="rich-code">');
 }
 
@@ -296,7 +295,7 @@ function InterfaceMatrix({ current, title, description }: { current: string | nu
             <Marked as="h2" className="h2" html={title} style={{ fontSize: "clamp(24px,3vw,34px)" }} />
           ) : (
             <h2 className="h2" style={{ fontSize: "clamp(24px,3vw,34px)" }}>
-              Pick the <span style={{ color: "var(--term-cyan)" }}>Interface</span> That Fits Your Team
+              Pick the Interface That Fits Your Team
             </h2>
           )}
           <p className="lead" style={{ marginTop: 10 }}>

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -42,6 +42,16 @@ export const PRODUCTS: NavLink[] = [
     description: "The easiest way to start — free, no setup.",
   },
   {
+    label: "Web Chatbot",
+    href: "/chatbot/",
+    description: "Slack / web chat for analysts.",
+  },
+  {
+    label: "MCP Server",
+    href: "/mcp/",
+    description: "Connect Claude, Cursor, IDEs.",
+  },
+  {
     label: "Enterprise",
     href: "/products/enterprise/",
     description: "Shared context, governance, long-running agents.",


### PR DESCRIPTION
## Context

Task: implement the `/mcp` and `/chatbot` subpages from the datus-design materials.

**Finding:** both pages are already fully built and current — no page work was needed:
- `src/pages/mcp/` and `src/pages/chatbot/` render via `<InterfaceView>` (dark site.css design system, `catalog` primitives), covering every design section (Why, Use Cases, Deploy/Config split, Primitives/Loop, Toolbox, How-to, Interface Matrix, FAQ, CTA).
- Content was diffed field-by-field against the live datus-design Supabase `interfaces` source — **identical** except for YAML code-block newline encoding, which the local port already handles correctly (real newlines vs. escaped `\n`).
- Already wired into `prerender.tsx` ROUTES, `vite.config.ts` MPA routes, `src/public/sitemap.xml`, `scripts/build-og.mjs` (OG cards), and cross-linked from every on-site `InterfaceMatrix`.

**The only gap:** neither page was linked from the top navigation, so both were orphan pages — live and crawlable via sitemap, but not discoverable from the menu.

## Change

Add **Web Chatbot** (`/chatbot/`) and **MCP Server** (`/mcp/`) to the **Products** dropdown (`src/config/nav.ts`), placed between Datus Studio and Enterprise — mirroring the datus-design "Interfaces" grouping.

- Labels/descriptions follow datus-design copy (Web Chatbot — "Slack / web chat for analysts"; MCP Server — "Connect Claude, Cursor, IDEs").
- Python API from the design's Interfaces menu is intentionally omitted (no `/api` page exists in this repo → avoids a dead link).

## Verification
- `npx vite build && npm run prerender` → passes; both `/chatbot/` and `/mcp/` links render as `role="menuitem"` in every prerendered page header.
- Puppeteer crawl of `/mcp/` and `/chatbot/`: **0 page errors**, full section outline present, hero + card grids render correctly in the dark theme.
- Screenshotted the open Products dropdown — both new entries appear with correct labels/descriptions and ordering.

## Note
The design's `why_carousel` (image carousel) is deliberately rendered as a dark card grid in `InterfaceView` per the datus-website-design skill (reuse site.css, don't port the light "sticker" style). The `mcp-why-*.jpg` / `chatbot-why-*.jpg` design assets are therefore intentionally not used. Happy to port them in if you'd prefer the image treatment.

---

## Follow-up: neutral headings on /mcp & /chatbot

Per request, removed the datus-design marker accent colors (cyan/amber/sage/pink) from the hero + section heading phrases on both interface pages, so highlighted words render in the main ink color — matching the neutral-heading treatment already shipped for the catalog pages and homepage.

- `InterfaceView.styleHtml()` now strips `class="marker-*"` instead of mapping it to `--term-*` colors.
- Removed the hardcoded `--term-cyan` on the InterfaceMatrix "Interface" word.
- Kept the small accent elements (card tone bars, eyebrow pills, endpoint/SYM badge backgrounds) — only interspersed heading text is neutralized.
- Re-verified: `vite build` + `prerender` pass; puppeteer crawl shows 0 errors and neutral headings; no `color:var(--term-*)` on text remains in the prerendered HTML.