### PR TITLE
feat: OSI Field Mapping reference + OSI Playground tool pages

### DIFF
--- a/osi-field-mapping/index.html
+++ b/osi-field-mapping/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>OSI Field Mapping — 8 Semantic Layers Mapped to Open Semantic Interchange</title>
+    <meta
+      name="description"
+      content="See how MetricFlow, Cube, LookML, AtScale, Snowflake Semantic Views, GoodData, Power BI and Databricks Metric Views map onto the OSI spec — field by field across datasets, dimensions, metrics, relationships, time and AI context."
+    />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="author" content="Datus" />
+
+    <link rel="canonical" href="https://datus.ai/osi-field-mapping/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <meta property="og:type" content="article" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Datus" />
+    <meta property="og:title" content="OSI Field Mapping — 8 Semantic Layers Mapped to Open Semantic Interchange" />
+    <meta property="og:description" content="See how MetricFlow, Cube, LookML, AtScale, Snowflake Semantic Views, GoodData, Power BI and Databricks Metric Views map onto the OSI spec — field by field across datasets, dimensions, metrics, relationships, time and AI context." />
+    <meta property="og:url" content="https://datus.ai/osi-field-mapping/" />
+    <meta property="og:image" content="https://datus.ai/og/osi-field-mapping-1200x630.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="OSI Field Mapping — 8 Semantic Layers Mapped to Open Semantic Interchange" />
+    <meta name="twitter:description" content="Field-by-field mapping of MetricFlow, Cube, LookML, AtScale, Snowflake, GoodData, Power BI and Databricks onto the Open Semantic Interchange schema." />
+    <meta name="twitter:image" content="https://datus.ai/og/osi-field-mapping-1200x630.png" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Article","headline":"OSI Field Mapping — 8 Semantic Layers Mapped to Open Semantic Interchange","description":"See how MetricFlow, Cube, LookML, AtScale, Snowflake Semantic Views, GoodData, Power BI and Databricks Metric Views map onto the OSI spec — field by field across datasets, dimensions, metrics, relationships, time and AI context.","about":"Open Semantic Interchange","author":{"@type":"Organization","name":"Datus"},"publisher":{"@type":"Organization","name":"Datus","url":"https://datus.ai/"},"mainEntityOfPage":"https://datus.ai/osi-field-mapping/"}
+    </script>
+    <!-- BreadcrumbList + FAQPage JSON-LD are emitted by the shared React components (single source of truth). -->
+
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag("consent", "default", {
+        ad_storage: "denied", analytics_storage: "denied",
+        ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
+      });
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EPVCH78EZP"></script>
+    <script>
+      gtag("js", new Date());
+      gtag("config", "G-EPVCH78EZP");
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pages/osi-field-mapping/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vitejs/plugin-react-swc": "^3.10.2",
     "concurrently": "^9.2.1",
     "gray-matter": "^4.0.3",
+    "js-yaml": "^3.14.1",
     "markdown-it": "^14.2.0",
     "markdown-it-anchor": "^9.2.0",
     "puppeteer": "^24.10.0",

--- a/scripts/build-og.mjs
+++ b/scripts/build-og.mjs
@@ -45,6 +45,10 @@ const CARDS = [
     subtitle: "Essays and guides on data agents, semantic layers, and evolvable context." },
   { slug: "blog-post", eyebrow: "Blog", title: "Datus Blog",
     subtitle: "Essays and guides from the team building the data engineering agent." },
+  { slug: "osi-field-mapping", eyebrow: "OSI Field Mapping", title: "Eight semantic layers, one OSI spec",
+    subtitle: "MetricFlow, Cube, LookML, AtScale, Snowflake, GoodData, Power BI and Databricks — mapped field by field." },
+  { slug: "tools-osi-playground", eyebrow: "OSI Playground", title: "MetricFlow to OSI, in your browser",
+    subtitle: "Validate, convert and diff MetricFlow YAML against the Open Semantic Interchange spec." },
 ];
 
 const qs = (c) =>

--- a/src/components/tools/OsiPlayground.tsx
+++ b/src/components/tools/OsiPlayground.tsx
@@ -1,0 +1,393 @@
+import { useMemo, useState } from "react";
+import { Copy, Download, RotateCcw, Sparkles } from "lucide-react";
+
+import { OSI_SCHEMA_VERSION } from "../../lib/osi/schema";
+import { convertMetricflowYaml } from "../../lib/osi/metricflow-to-osi";
+import { validateAsOsi } from "../../lib/osi/validate";
+import { diffLines } from "../../lib/osi/diff";
+import { SAMPLE_METRICFLOW, SAMPLE_METRICFLOW_INVALID } from "../../lib/osi/samples";
+
+const MAX_INPUT_BYTES = 200 * 1024; // 200KB — protect the main thread
+
+type Tab = "validator" | "converter" | "diff";
+
+/** macOS-style window frame reusing the site.css `.term` chrome. */
+function WindowFrame({
+  title,
+  meta,
+  traffic = true,
+  children,
+}: {
+  title?: React.ReactNode;
+  meta?: React.ReactNode;
+  traffic?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="term" style={{ fontFamily: "var(--font-sans)" }}>
+      <div className="term__bar">
+        {traffic && (
+          <>
+            <span className="term__dot term__dot--r" />
+            <span className="term__dot term__dot--y" />
+            <span className="term__dot term__dot--g" />
+          </>
+        )}
+        {title !== undefined && <span className="term__title">{title}</span>}
+        {meta !== undefined && (
+          <span className="term__title" style={{ marginLeft: "auto" }}>
+            {meta}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const TONE: Record<"sage" | "amber" | "pink", string> = {
+  sage: "var(--term-green)",
+  amber: "var(--term-amber)",
+  pink: "var(--term-pink)",
+};
+
+function StatusBadge({ tone, children }: { tone: keyof typeof TONE; children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        borderRadius: 6,
+        border: `1px solid ${TONE[tone]}`,
+        padding: "3px 9px",
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        color: TONE[tone],
+        background: `color-mix(in oklab, ${TONE[tone]} 14%, transparent)`,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function DroppedList({ items }: { items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      style={{
+        marginBottom: 12,
+        borderRadius: 8,
+        border: "1px solid var(--line)",
+        background: "color-mix(in oklab, var(--term-amber) 10%, transparent)",
+        padding: "8px 12px",
+        fontSize: 12,
+        color: "var(--ink-dim)",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.14em",
+          color: "var(--ink-faint)",
+        }}
+      >
+        Dropped fields:
+      </span>{" "}
+      {items.join(", ")}
+    </div>
+  );
+}
+
+function download(name: string, contents: string) {
+  const blob = new Blob([contents], { type: "text/yaml" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function OsiPlayground() {
+  const [input, setInput] = useState(SAMPLE_METRICFLOW);
+  const [tab, setTab] = useState<Tab>("converter");
+  const [copied, setCopied] = useState(false);
+
+  const oversize = input.length > MAX_INPUT_BYTES;
+
+  const conversion = useMemo(
+    () => (oversize ? null : convertMetricflowYaml(input)),
+    [input, oversize],
+  );
+
+  const validation = useMemo(
+    () => (oversize ? null : validateAsOsi(input)),
+    [input, oversize],
+  );
+
+  const diffParts = useMemo(() => {
+    if (!conversion || !conversion.osiYaml) return [];
+    return diffLines(input, conversion.osiYaml);
+  }, [conversion, input]);
+
+  const diffSummary = useMemo(() => {
+    let added = 0;
+    let removed = 0;
+    for (const p of diffParts) {
+      const lines = p.value.split("\n").filter(Boolean).length;
+      if (p.added) added += lines;
+      if (p.removed) removed += lines;
+    }
+    return { added, removed };
+  }, [diffParts]);
+
+  const copyOsi = async () => {
+    if (!conversion) return;
+    await navigator.clipboard.writeText(conversion.osiYaml);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const tabBtn = (value: Tab, label: string) => (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={tab === value}
+      className="osi-tab"
+      onClick={() => setTab(value)}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="osi-pg">
+      {/* INPUT COLUMN */}
+      <WindowFrame title="metricflow.yml" meta={`${(input.length / 1024).toFixed(1)} KB`}>
+        <div className="osi-bar">
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button type="button" className="osi-btn" onClick={() => setInput(SAMPLE_METRICFLOW)}>
+              <Sparkles size={12} /> Load example
+            </button>
+            <button
+              type="button"
+              className="osi-btn"
+              onClick={() => setInput(SAMPLE_METRICFLOW_INVALID)}
+            >
+              Load invalid
+            </button>
+          </div>
+          <button type="button" className="osi-btn" onClick={() => setInput("")}>
+            <RotateCcw size={12} /> Clear
+          </button>
+        </div>
+        <textarea
+          className="osi-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          spellCheck={false}
+          placeholder="Paste your MetricFlow YAML here…"
+          aria-label="MetricFlow YAML input"
+        />
+        {oversize && (
+          <div
+            style={{
+              borderTop: "1px solid var(--line)",
+              background: "color-mix(in oklab, var(--term-pink) 13%, transparent)",
+              padding: "8px 12px",
+              fontSize: 12,
+              color: "var(--ink-dim)",
+            }}
+          >
+            Input is over 200 KB — trimmed for browser-side processing.
+          </div>
+        )}
+      </WindowFrame>
+
+      {/* OUTPUT COLUMN */}
+      <div>
+        <div className="osi-tabs" role="tablist" aria-label="OSI Playground tools">
+          {tabBtn("validator", "Validator")}
+          {tabBtn("converter", "Converter")}
+          {tabBtn("diff", "Diff")}
+        </div>
+
+        {/* VALIDATOR */}
+        {tab === "validator" && (
+          <WindowFrame title="validator" meta={`OSI v${OSI_SCHEMA_VERSION}`} traffic={false}>
+            <div style={{ padding: 18, minHeight: 420, display: "grid", gap: 12, alignContent: "start" }}>
+              {!validation ? null : validation.kind === "yaml-error" ? (
+                <>
+                  <StatusBadge tone="pink">✗ YAML error</StatusBadge>
+                  <pre className="osi-pre" style={{ color: "var(--ink-dim)" }}>
+                    {validation.message}
+                  </pre>
+                </>
+              ) : validation.kind === "not-object" ? (
+                <>
+                  <StatusBadge tone="pink">✗ Invalid root</StatusBadge>
+                  <p style={{ fontSize: 13, color: "var(--ink-dim)", margin: 0 }}>
+                    {validation.message}
+                  </p>
+                </>
+              ) : validation.kind === "valid" ? (
+                <>
+                  <StatusBadge tone="sage">✓ Valid OSI</StatusBadge>
+                  <p style={{ fontSize: 13, color: "var(--ink-muted)", margin: 0 }}>
+                    This document conforms to the OSI v{OSI_SCHEMA_VERSION} core schema (subset).{" "}
+                    {validation.warnings[0] ?? ""}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <StatusBadge tone="amber">
+                    ⚠ {validation.errors.length} issue{validation.errors.length === 1 ? "" : "s"}
+                  </StatusBadge>
+                  {validation.warnings.map((w, i) => (
+                    <p key={i} style={{ fontSize: 12, color: "var(--ink-faint)", margin: 0 }}>
+                      {w}
+                    </p>
+                  ))}
+                  <ul style={{ margin: "6px 0 0", padding: 0, listStyle: "none", display: "grid", gap: 8 }}>
+                    {validation.errors.slice(0, 20).map((err, i) => (
+                      <li
+                        key={i}
+                        style={{
+                          borderRadius: 8,
+                          border: "1px solid var(--line)",
+                          background: "rgba(11,18,48,0.4)",
+                          padding: "8px 12px",
+                          fontFamily: "var(--font-mono)",
+                          fontSize: 12,
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: 10,
+                            textTransform: "uppercase",
+                            letterSpacing: "0.14em",
+                            color: "var(--ink-faint)",
+                          }}
+                        >
+                          {err.instancePath || "/"}
+                        </div>
+                        <div style={{ color: "var(--ink-dim)" }}>{err.message}</div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          </WindowFrame>
+        )}
+
+        {/* CONVERTER */}
+        {tab === "converter" && (
+          <WindowFrame
+            title="osi.yml"
+            meta={
+              conversion && conversion.errors.length === 0
+                ? `${conversion.mappedCount} mapped · ${conversion.renamedCount} renamed`
+                : "—"
+            }
+            traffic={false}
+          >
+            <div className="osi-bar">
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.14em",
+                  color: "var(--ink-faint)",
+                }}
+              >
+                OSI v{OSI_SCHEMA_VERSION}
+              </span>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  type="button"
+                  className="osi-btn"
+                  onClick={copyOsi}
+                  disabled={!conversion?.osiYaml}
+                >
+                  <Copy size={12} /> {copied ? "Copied" : "Copy"}
+                </button>
+                <button
+                  type="button"
+                  className="osi-btn"
+                  onClick={() => conversion && download("osi.yml", conversion.osiYaml)}
+                  disabled={!conversion?.osiYaml}
+                >
+                  <Download size={12} /> Download
+                </button>
+              </div>
+            </div>
+            <div style={{ padding: 18, minHeight: 380 }}>
+              {conversion && <DroppedList items={conversion.droppedFields} />}
+              {conversion?.errors.length ? (
+                <>
+                  <StatusBadge tone="pink">✗ Conversion failed</StatusBadge>
+                  <pre className="osi-pre" style={{ marginTop: 8 }}>
+                    {conversion.errors.join("\n")}
+                  </pre>
+                </>
+              ) : (
+                <pre className="osi-pre">
+                  <code>{conversion?.osiYaml ?? ""}</code>
+                </pre>
+              )}
+            </div>
+          </WindowFrame>
+        )}
+
+        {/* DIFF */}
+        {tab === "diff" && (
+          <WindowFrame
+            title="diff · metricflow ↔ osi"
+            meta={`+${diffSummary.added} · −${diffSummary.removed} lines`}
+            traffic={false}
+          >
+            <div style={{ padding: 18, minHeight: 420, overflowX: "auto" }}>
+              {diffParts.length === 0 ? (
+                <p style={{ fontSize: 13, color: "var(--ink-faint)", margin: 0 }}>
+                  Paste a MetricFlow YAML on the left to see the line-by-line diff.
+                </p>
+              ) : (
+                <pre className="osi-pre" style={{ whiteSpace: "pre" }}>
+                  {diffParts.map((p, i) => {
+                    const bg = p.added
+                      ? "color-mix(in oklab, var(--term-green) 20%, transparent)"
+                      : p.removed
+                        ? "color-mix(in oklab, var(--term-pink) 20%, transparent)"
+                        : "transparent";
+                    const prefix = p.added ? "+ " : p.removed ? "− " : "  ";
+                    return (
+                      <span key={i} style={{ background: bg, display: "block", whiteSpace: "pre-wrap" }}>
+                        {p.value
+                          .split("\n")
+                          .filter((_, idx, arr) => !(idx === arr.length - 1 && arr[idx] === ""))
+                          .map((line, li) => (
+                            <span key={li} style={{ display: "block" }}>
+                              <span style={{ color: "var(--ink-faint)", userSelect: "none" }}>{prefix}</span>
+                              {line}
+                            </span>
+                          ))}
+                      </span>
+                    );
+                  })}
+                </pre>
+              )}
+            </div>
+          </WindowFrame>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/tools/OsiPlayground.tsx
+++ b/src/components/tools/OsiPlayground.tsx
@@ -11,37 +11,13 @@ const MAX_INPUT_BYTES = 200 * 1024; // 200KB — protect the main thread
 
 type Tab = "validator" | "converter" | "diff";
 
-/** macOS-style window frame reusing the site.css `.term` chrome. */
-function WindowFrame({
-  title,
-  meta,
-  traffic = true,
-  children,
-}: {
-  title?: React.ReactNode;
-  meta?: React.ReactNode;
-  traffic?: boolean;
-  children: React.ReactNode;
-}) {
+function TrafficDots() {
   return (
-    <div className="term" style={{ fontFamily: "var(--font-sans)" }}>
-      <div className="term__bar">
-        {traffic && (
-          <>
-            <span className="term__dot term__dot--r" />
-            <span className="term__dot term__dot--y" />
-            <span className="term__dot term__dot--g" />
-          </>
-        )}
-        {title !== undefined && <span className="term__title">{title}</span>}
-        {meta !== undefined && (
-          <span className="term__title" style={{ marginLeft: "auto" }}>
-            {meta}
-          </span>
-        )}
-      </div>
-      {children}
-    </div>
+    <>
+      <span className="term__dot term__dot--r" />
+      <span className="term__dot term__dot--y" />
+      <span className="term__dot term__dot--g" />
+    </>
   );
 }
 
@@ -114,6 +90,12 @@ function download(name: string, contents: string) {
   URL.revokeObjectURL(url);
 }
 
+const barTitleStyle: React.CSSProperties = {
+  marginLeft: "auto",
+  fontSize: 12.5,
+  color: "var(--ink-faint)",
+};
+
 export function OsiPlayground() {
   const [input, setInput] = useState(SAMPLE_METRICFLOW);
   const [tab, setTab] = useState<Tab>("converter");
@@ -154,12 +136,21 @@ export function OsiPlayground() {
     setTimeout(() => setCopied(false), 1500);
   };
 
-  const tabBtn = (value: Tab, label: string) => (
+  const outMeta =
+    tab === "validator"
+      ? `OSI v${OSI_SCHEMA_VERSION}`
+      : tab === "converter"
+        ? conversion && conversion.errors.length === 0
+          ? `${conversion.mappedCount} mapped · ${conversion.renamedCount} renamed`
+          : "—"
+        : `+${diffSummary.added} · −${diffSummary.removed} lines`;
+
+  const miniTab = (value: Tab, label: string) => (
     <button
       type="button"
       role="tab"
       aria-selected={tab === value}
-      className="osi-tab"
+      className="osi-tab-mini"
       onClick={() => setTab(value)}
     >
       {label}
@@ -168,8 +159,15 @@ export function OsiPlayground() {
 
   return (
     <div className="osi-pg">
-      {/* INPUT COLUMN */}
-      <WindowFrame title="metricflow.yml" meta={`${(input.length / 1024).toFixed(1)} KB`}>
+      {/* INPUT WINDOW */}
+      <div className="term osi-win" style={{ fontFamily: "var(--font-sans)" }}>
+        <div className="term__bar">
+          <TrafficDots />
+          <span className="term__title">metricflow.yml</span>
+          <span className="term__title" style={{ marginLeft: "auto" }}>
+            {(input.length / 1024).toFixed(1)} KB
+          </span>
+        </div>
         <div className="osi-bar">
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <button type="button" className="osi-btn" onClick={() => setInput(SAMPLE_METRICFLOW)}>
@@ -208,128 +206,114 @@ export function OsiPlayground() {
             Input is over 200 KB — trimmed for browser-side processing.
           </div>
         )}
-      </WindowFrame>
+      </div>
 
-      {/* OUTPUT COLUMN */}
-      <div>
-        <div className="osi-tabs" role="tablist" aria-label="OSI Playground tools">
-          {tabBtn("validator", "Validator")}
-          {tabBtn("converter", "Converter")}
-          {tabBtn("diff", "Diff")}
+      {/* OUTPUT WINDOW — tab switcher lives in the title bar, meta on the right */}
+      <div className="term osi-win" style={{ fontFamily: "var(--font-sans)" }}>
+        <div className="term__bar">
+          <div className="osi-seg" role="tablist" aria-label="OSI Playground tools">
+            {miniTab("validator", "Validator")}
+            {miniTab("converter", "Converter")}
+            {miniTab("diff", "Diff")}
+          </div>
+          <span style={barTitleStyle}>{outMeta}</span>
         </div>
 
-        {/* VALIDATOR */}
-        {tab === "validator" && (
-          <WindowFrame title="validator" meta={`OSI v${OSI_SCHEMA_VERSION}`} traffic={false}>
-            <div style={{ padding: 18, minHeight: 420, display: "grid", gap: 12, alignContent: "start" }}>
-              {!validation ? null : validation.kind === "yaml-error" ? (
-                <>
-                  <StatusBadge tone="pink">✗ YAML error</StatusBadge>
-                  <pre className="osi-pre" style={{ color: "var(--ink-dim)" }}>
-                    {validation.message}
-                  </pre>
-                </>
-              ) : validation.kind === "not-object" ? (
-                <>
-                  <StatusBadge tone="pink">✗ Invalid root</StatusBadge>
-                  <p style={{ fontSize: 13, color: "var(--ink-dim)", margin: 0 }}>
-                    {validation.message}
-                  </p>
-                </>
-              ) : validation.kind === "valid" ? (
-                <>
-                  <StatusBadge tone="sage">✓ Valid OSI</StatusBadge>
-                  <p style={{ fontSize: 13, color: "var(--ink-muted)", margin: 0 }}>
-                    This document conforms to the OSI v{OSI_SCHEMA_VERSION} core schema (subset).{" "}
-                    {validation.warnings[0] ?? ""}
-                  </p>
-                </>
-              ) : (
-                <>
-                  <StatusBadge tone="amber">
-                    ⚠ {validation.errors.length} issue{validation.errors.length === 1 ? "" : "s"}
-                  </StatusBadge>
-                  {validation.warnings.map((w, i) => (
-                    <p key={i} style={{ fontSize: 12, color: "var(--ink-faint)", margin: 0 }}>
-                      {w}
-                    </p>
-                  ))}
-                  <ul style={{ margin: "6px 0 0", padding: 0, listStyle: "none", display: "grid", gap: 8 }}>
-                    {validation.errors.slice(0, 20).map((err, i) => (
-                      <li
-                        key={i}
-                        style={{
-                          borderRadius: 8,
-                          border: "1px solid var(--line)",
-                          background: "rgba(11,18,48,0.4)",
-                          padding: "8px 12px",
-                          fontFamily: "var(--font-mono)",
-                          fontSize: 12,
-                        }}
-                      >
-                        <div
-                          style={{
-                            fontSize: 10,
-                            textTransform: "uppercase",
-                            letterSpacing: "0.14em",
-                            color: "var(--ink-faint)",
-                          }}
-                        >
-                          {err.instancePath || "/"}
-                        </div>
-                        <div style={{ color: "var(--ink-dim)" }}>{err.message}</div>
-                      </li>
-                    ))}
-                  </ul>
-                </>
-              )}
+        {tab === "converter" && (
+          <div className="osi-bar">
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 10,
+                textTransform: "uppercase",
+                letterSpacing: "0.14em",
+                color: "var(--ink-faint)",
+              }}
+            >
+              OSI v{OSI_SCHEMA_VERSION}
+            </span>
+            <div style={{ display: "flex", gap: 8 }}>
+              <button type="button" className="osi-btn" onClick={copyOsi} disabled={!conversion?.osiYaml}>
+                <Copy size={12} /> {copied ? "Copied" : "Copy"}
+              </button>
+              <button
+                type="button"
+                className="osi-btn"
+                onClick={() => conversion && download("osi.yml", conversion.osiYaml)}
+                disabled={!conversion?.osiYaml}
+              >
+                <Download size={12} /> Download
+              </button>
             </div>
-          </WindowFrame>
+          </div>
         )}
 
-        {/* CONVERTER */}
-        {tab === "converter" && (
-          <WindowFrame
-            title="osi.yml"
-            meta={
-              conversion && conversion.errors.length === 0
-                ? `${conversion.mappedCount} mapped · ${conversion.renamedCount} renamed`
-                : "—"
-            }
-            traffic={false}
-          >
-            <div className="osi-bar">
-              <span
-                style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 10,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.14em",
-                  color: "var(--ink-faint)",
-                }}
-              >
-                OSI v{OSI_SCHEMA_VERSION}
-              </span>
-              <div style={{ display: "flex", gap: 8 }}>
-                <button
-                  type="button"
-                  className="osi-btn"
-                  onClick={copyOsi}
-                  disabled={!conversion?.osiYaml}
-                >
-                  <Copy size={12} /> {copied ? "Copied" : "Copy"}
-                </button>
-                <button
-                  type="button"
-                  className="osi-btn"
-                  onClick={() => conversion && download("osi.yml", conversion.osiYaml)}
-                  disabled={!conversion?.osiYaml}
-                >
-                  <Download size={12} /> Download
-                </button>
+        <div className="osi-body">
+          {/* VALIDATOR */}
+          {tab === "validator" &&
+            (!validation ? null : validation.kind === "yaml-error" ? (
+              <div style={{ display: "grid", gap: 12, alignContent: "start" }}>
+                <StatusBadge tone="pink">✗ YAML error</StatusBadge>
+                <pre className="osi-pre" style={{ color: "var(--ink-dim)" }}>
+                  {validation.message}
+                </pre>
               </div>
-            </div>
-            <div style={{ padding: 18, minHeight: 380 }}>
+            ) : validation.kind === "not-object" ? (
+              <div style={{ display: "grid", gap: 12, alignContent: "start" }}>
+                <StatusBadge tone="pink">✗ Invalid root</StatusBadge>
+                <p style={{ fontSize: 13, color: "var(--ink-dim)", margin: 0 }}>{validation.message}</p>
+              </div>
+            ) : validation.kind === "valid" ? (
+              <div style={{ display: "grid", gap: 12, alignContent: "start" }}>
+                <StatusBadge tone="sage">✓ Valid OSI</StatusBadge>
+                <p style={{ fontSize: 13, color: "var(--ink-muted)", margin: 0 }}>
+                  This document conforms to the OSI v{OSI_SCHEMA_VERSION} core schema (subset).{" "}
+                  {validation.warnings[0] ?? ""}
+                </p>
+              </div>
+            ) : (
+              <div style={{ display: "grid", gap: 12, alignContent: "start" }}>
+                <StatusBadge tone="amber">
+                  ⚠ {validation.errors.length} issue{validation.errors.length === 1 ? "" : "s"}
+                </StatusBadge>
+                {validation.warnings.map((w, i) => (
+                  <p key={i} style={{ fontSize: 12, color: "var(--ink-faint)", margin: 0 }}>
+                    {w}
+                  </p>
+                ))}
+                <ul style={{ margin: "6px 0 0", padding: 0, listStyle: "none", display: "grid", gap: 8 }}>
+                  {validation.errors.slice(0, 20).map((err, i) => (
+                    <li
+                      key={i}
+                      style={{
+                        borderRadius: 8,
+                        border: "1px solid var(--line)",
+                        background: "rgba(11,18,48,0.4)",
+                        padding: "8px 12px",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 12,
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: 10,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.14em",
+                          color: "var(--ink-faint)",
+                        }}
+                      >
+                        {err.instancePath || "/"}
+                      </div>
+                      <div style={{ color: "var(--ink-dim)" }}>{err.message}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+
+          {/* CONVERTER */}
+          {tab === "converter" && (
+            <>
               {conversion && <DroppedList items={conversion.droppedFields} />}
               {conversion?.errors.length ? (
                 <>
@@ -343,50 +327,41 @@ export function OsiPlayground() {
                   <code>{conversion?.osiYaml ?? ""}</code>
                 </pre>
               )}
-            </div>
-          </WindowFrame>
-        )}
+            </>
+          )}
 
-        {/* DIFF */}
-        {tab === "diff" && (
-          <WindowFrame
-            title="diff · metricflow ↔ osi"
-            meta={`+${diffSummary.added} · −${diffSummary.removed} lines`}
-            traffic={false}
-          >
-            <div style={{ padding: 18, minHeight: 420, overflowX: "auto" }}>
-              {diffParts.length === 0 ? (
-                <p style={{ fontSize: 13, color: "var(--ink-faint)", margin: 0 }}>
-                  Paste a MetricFlow YAML on the left to see the line-by-line diff.
-                </p>
-              ) : (
-                <pre className="osi-pre" style={{ whiteSpace: "pre" }}>
-                  {diffParts.map((p, i) => {
-                    const bg = p.added
-                      ? "color-mix(in oklab, var(--term-green) 20%, transparent)"
-                      : p.removed
-                        ? "color-mix(in oklab, var(--term-pink) 20%, transparent)"
-                        : "transparent";
-                    const prefix = p.added ? "+ " : p.removed ? "− " : "  ";
-                    return (
-                      <span key={i} style={{ background: bg, display: "block", whiteSpace: "pre-wrap" }}>
-                        {p.value
-                          .split("\n")
-                          .filter((_, idx, arr) => !(idx === arr.length - 1 && arr[idx] === ""))
-                          .map((line, li) => (
-                            <span key={li} style={{ display: "block" }}>
-                              <span style={{ color: "var(--ink-faint)", userSelect: "none" }}>{prefix}</span>
-                              {line}
-                            </span>
-                          ))}
-                      </span>
-                    );
-                  })}
-                </pre>
-              )}
-            </div>
-          </WindowFrame>
-        )}
+          {/* DIFF */}
+          {tab === "diff" &&
+            (diffParts.length === 0 ? (
+              <p style={{ fontSize: 13, color: "var(--ink-faint)", margin: 0 }}>
+                Paste a MetricFlow YAML on the left to see the line-by-line diff.
+              </p>
+            ) : (
+              <pre className="osi-pre" style={{ whiteSpace: "pre" }}>
+                {diffParts.map((p, i) => {
+                  const bg = p.added
+                    ? "color-mix(in oklab, var(--term-green) 20%, transparent)"
+                    : p.removed
+                      ? "color-mix(in oklab, var(--term-pink) 20%, transparent)"
+                      : "transparent";
+                  const prefix = p.added ? "+ " : p.removed ? "− " : "  ";
+                  return (
+                    <span key={i} style={{ background: bg, display: "block", whiteSpace: "pre-wrap" }}>
+                      {p.value
+                        .split("\n")
+                        .filter((_, idx, arr) => !(idx === arr.length - 1 && arr[idx] === ""))
+                        .map((line, li) => (
+                          <span key={li} style={{ display: "block" }}>
+                            <span style={{ color: "var(--ink-faint)", userSelect: "none" }}>{prefix}</span>
+                            {line}
+                          </span>
+                        ))}
+                    </span>
+                  );
+                })}
+              </pre>
+            ))}
+        </div>
       </div>
     </div>
   );

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -74,6 +74,16 @@ export const INTEGRATIONS: NavLink[] = [
     href: "/models/",
     description: "OpenAI, Claude, Gemini, DeepSeek…",
   },
+  {
+    label: "OSI Field Mapping",
+    href: "/osi-field-mapping/",
+    description: "Semantic layers mapped to the OSI spec.",
+  },
+  {
+    label: "OSI Playground",
+    href: "/tools/osi-playground/",
+    description: "MetricFlow → OSI: validate, convert, diff.",
+  },
 ];
 
 export const NAV: NavItem[] = [

--- a/src/lib/osi/diff.ts
+++ b/src/lib/osi/diff.ts
@@ -2,60 +2,105 @@
 // `diff` npm package. Returns parts compatible with what the UI renders:
 // `{ value, added?, removed? }`, where `value` is a chunk of one-or-more lines
 // joined by "\n". Contiguous lines of the same kind are grouped into one part.
+//
+// The full LCS table is O(n·m) memory, which is dangerous for large inputs
+// (a ~150KB YAML can be ~5k lines → ~25M cells → ~200MB, on the main thread).
+// We keep it bounded two ways: trim the common prefix/suffix first (cheap and
+// usually huge), then only run the DP when the remaining middle is small
+// enough; past that cap we degrade to a plain removed-block/added-block diff so
+// memory and time stay flat.
 
 export type DiffPart = { value: string; added?: boolean; removed?: boolean };
+
+// Max DP cells we are willing to allocate (~1.5M ≈ 12MB of doubles, <30ms).
+const MAX_CELLS = 1_500_000;
 
 /** Diff two strings line by line. */
 export function diffLines(a: string, b: string): DiffPart[] {
   const aLines = splitLines(a);
   const bLines = splitLines(b);
 
-  // Longest common subsequence table over lines.
-  const n = aLines.length;
-  const m = bLines.length;
+  const builder = new PartBuilder();
+
+  // 1. Common prefix — identical leading lines pass through untouched.
+  let lo = 0;
+  const minLen = Math.min(aLines.length, bLines.length);
+  while (lo < minLen && aLines[lo] === bLines[lo]) {
+    builder.push(aLines[lo], "same");
+    lo++;
+  }
+
+  // 2. Common suffix — identical trailing lines (not overlapping the prefix).
+  let aHi = aLines.length;
+  let bHi = bLines.length;
+  while (aHi > lo && bHi > lo && aLines[aHi - 1] === bLines[bHi - 1]) {
+    aHi--;
+    bHi--;
+  }
+
+  // 3. Diff the differing middle.
+  const aMid = aLines.slice(lo, aHi);
+  const bMid = bLines.slice(lo, bHi);
+  if (aMid.length * bMid.length > MAX_CELLS) {
+    // Degrade: emit removals then additions. Bounded memory, still readable.
+    for (const l of aMid) builder.push(l, "rm");
+    for (const l of bMid) builder.push(l, "add");
+  } else {
+    lcsWalk(aMid, bMid, builder);
+  }
+
+  // 4. Common suffix.
+  for (let i = aHi; i < aLines.length; i++) builder.push(aLines[i], "same");
+
+  return builder.parts;
+}
+
+/** LCS walk over two (already prefix/suffix-trimmed) line arrays. */
+function lcsWalk(a: string[], b: string[], builder: PartBuilder): void {
+  const n = a.length;
+  const m = b.length;
   const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
   for (let i = n - 1; i >= 0; i--) {
     for (let j = m - 1; j >= 0; j--) {
-      dp[i][j] = aLines[i] === bLines[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
     }
   }
-
-  const parts: DiffPart[] = [];
-  const push = (line: string, kind: "same" | "add" | "rm") => {
-    const last = parts[parts.length - 1];
-    const added = kind === "add" || undefined;
-    const removed = kind === "rm" || undefined;
-    if (last && !!last.added === !!added && !!last.removed === !!removed) {
-      last.value += line;
-    } else {
-      parts.push({ value: line, added, removed });
-    }
-  };
-
   let i = 0;
   let j = 0;
   while (i < n && j < m) {
-    if (aLines[i] === bLines[j]) {
-      push(aLines[i], "same");
+    if (a[i] === b[j]) {
+      builder.push(a[i], "same");
       i++;
       j++;
     } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      push(aLines[i], "rm");
+      builder.push(a[i], "rm");
       i++;
     } else {
-      push(bLines[j], "add");
+      builder.push(b[j], "add");
       j++;
     }
   }
-  while (i < n) push(aLines[i++], "rm");
-  while (j < m) push(bLines[j++], "add");
+  while (i < n) builder.push(a[i++], "rm");
+  while (j < m) builder.push(b[j++], "add");
+}
 
-  return parts;
+/** Accumulates lines into grouped {value, added?, removed?} parts. */
+class PartBuilder {
+  parts: DiffPart[] = [];
+  push(line: string, kind: "same" | "add" | "rm"): void {
+    const added = kind === "add" || undefined;
+    const removed = kind === "rm" || undefined;
+    const last = this.parts[this.parts.length - 1];
+    if (last && !!last.added === !!added && !!last.removed === !!removed) {
+      last.value += line;
+    } else {
+      this.parts.push({ value: line, added, removed });
+    }
+  }
 }
 
 /** Split into lines while keeping the trailing "\n" on each line. */
 function splitLines(s: string): string[] {
   if (s === "") return [];
-  const out = s.match(/[^\n]*\n|[^\n]+/g) ?? [];
-  return out;
+  return s.match(/[^\n]*\n|[^\n]+/g) ?? [];
 }

--- a/src/lib/osi/diff.ts
+++ b/src/lib/osi/diff.ts
@@ -1,0 +1,61 @@
+// A tiny line-based diff (LCS) so the Playground's Diff tab works without the
+// `diff` npm package. Returns parts compatible with what the UI renders:
+// `{ value, added?, removed? }`, where `value` is a chunk of one-or-more lines
+// joined by "\n". Contiguous lines of the same kind are grouped into one part.
+
+export type DiffPart = { value: string; added?: boolean; removed?: boolean };
+
+/** Diff two strings line by line. */
+export function diffLines(a: string, b: string): DiffPart[] {
+  const aLines = splitLines(a);
+  const bLines = splitLines(b);
+
+  // Longest common subsequence table over lines.
+  const n = aLines.length;
+  const m = bLines.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = aLines[i] === bLines[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const parts: DiffPart[] = [];
+  const push = (line: string, kind: "same" | "add" | "rm") => {
+    const last = parts[parts.length - 1];
+    const added = kind === "add" || undefined;
+    const removed = kind === "rm" || undefined;
+    if (last && !!last.added === !!added && !!last.removed === !!removed) {
+      last.value += line;
+    } else {
+      parts.push({ value: line, added, removed });
+    }
+  };
+
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (aLines[i] === bLines[j]) {
+      push(aLines[i], "same");
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      push(aLines[i], "rm");
+      i++;
+    } else {
+      push(bLines[j], "add");
+      j++;
+    }
+  }
+  while (i < n) push(aLines[i++], "rm");
+  while (j < m) push(bLines[j++], "add");
+
+  return parts;
+}
+
+/** Split into lines while keeping the trailing "\n" on each line. */
+function splitLines(s: string): string[] {
+  if (s === "") return [];
+  const out = s.match(/[^\n]*\n|[^\n]+/g) ?? [];
+  return out;
+}

--- a/src/lib/osi/metricflow-to-osi.ts
+++ b/src/lib/osi/metricflow-to-osi.ts
@@ -1,0 +1,232 @@
+import yaml from "js-yaml";
+import { OSI_SCHEMA_VERSION } from "./schema";
+
+// Fields on a MetricFlow semantic_model that we intentionally drop when
+// mapping into OSI. Surfaced back in the UI as "Dropped fields".
+const KNOWN_DROPPED_MODEL_FIELDS = new Set([
+  "model", // dbt ref
+  "primary_entity",
+  "defaults",
+  "config",
+]);
+
+type AnyRec = Record<string, unknown>;
+
+export type ConversionResult = {
+  ok: boolean;
+  osiYaml: string;
+  osi: AnyRec | null;
+  mappedCount: number;
+  renamedCount: number;
+  droppedFields: string[];
+  warnings: string[];
+  errors: string[];
+};
+
+const AGG_TO_TYPE: Record<string, string> = {
+  sum: "sum",
+  count: "count",
+  count_distinct: "count_distinct",
+  average: "average",
+  avg: "average",
+  min: "min",
+  max: "max",
+};
+
+function isRec(x: unknown): x is AnyRec {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+function asArray<T = unknown>(x: unknown): T[] {
+  return Array.isArray(x) ? (x as T[]) : [];
+}
+
+/**
+ * Convert a MetricFlow YAML document (as parsed JS object) to an OSI
+ * document. Pure function — no I/O, no globals — so it can be unit tested
+ * and reused server-side later.
+ */
+export function metricflowObjectToOsi(input: AnyRec): {
+  osi: AnyRec;
+  mappedCount: number;
+  renamedCount: number;
+  droppedFields: string[];
+  warnings: string[];
+} {
+  const droppedFields = new Set<string>();
+  const warnings: string[] = [];
+  let mappedCount = 0;
+  let renamedCount = 0;
+
+  const semanticModels = asArray<AnyRec>(input.semantic_models);
+  const topLevelMetrics = asArray<AnyRec>(input.metrics);
+
+  if (semanticModels.length === 0 && topLevelMetrics.length === 0) {
+    warnings.push(
+      "No `semantic_models` or top-level `metrics` found — is this really a MetricFlow file?",
+    );
+  }
+
+  // Group top-level metrics onto the first entity that references them
+  // (MetricFlow lets metrics reference any measure by name).
+  const entities = semanticModels.map((sm) => {
+    const entity: AnyRec = { name: String(sm.name ?? "unnamed") };
+    mappedCount++;
+
+    if (typeof sm.description === "string") entity.description = sm.description;
+    if (isRec(sm.node_relation) && typeof sm.node_relation.alias === "string") {
+      entity.table = sm.node_relation.alias;
+      renamedCount++;
+    } else if (typeof sm.model === "string") {
+      // dbt `model:` ref → strip ref() wrapper for OSI `table`
+      const m = sm.model.match(/ref\(['"]?([^'")]+)['"]?\)/);
+      entity.table = m ? m[1] : sm.model;
+      renamedCount++;
+    }
+
+    // entities → join_keys
+    const mfEntities = asArray<AnyRec>(sm.entities);
+    if (mfEntities.length > 0) {
+      entity.join_keys = mfEntities.map((e) => {
+        mappedCount++;
+        renamedCount++;
+        const jk: AnyRec = { name: String(e.name ?? "id") };
+        if (typeof e.type === "string" && ["primary", "foreign", "natural"].includes(e.type))
+          jk.type = e.type;
+        if (typeof e.expr === "string") jk.expr = e.expr;
+        return jk;
+      });
+    }
+
+    // dimensions → dimensions
+    const mfDims = asArray<AnyRec>(sm.dimensions);
+    if (mfDims.length > 0) {
+      entity.dimensions = mfDims.map((d) => {
+        mappedCount++;
+        const dim: AnyRec = { name: String(d.name ?? "unnamed") };
+        const t = typeof d.type === "string" ? d.type.toLowerCase() : "categorical";
+        dim.type = ["categorical", "time", "numeric"].includes(t) ? t : "categorical";
+        if (typeof d.expr === "string") dim.expr = d.expr;
+        if (isRec(d.type_params) && typeof d.type_params.time_granularity === "string") {
+          dim.granularity = d.type_params.time_granularity;
+          renamedCount++;
+        }
+        if (typeof d.description === "string") dim.description = d.description;
+        return dim;
+      });
+    }
+
+    // measures + top-level metrics → metrics
+    const mfMeasures = asArray<AnyRec>(sm.measures);
+    const measureNames = new Set(mfMeasures.map((m) => String(m.name ?? "")));
+    const metrics: AnyRec[] = [];
+
+    for (const m of mfMeasures) {
+      mappedCount++;
+      const metric: AnyRec = { name: String(m.name ?? "unnamed") };
+      const agg = typeof m.agg === "string" ? m.agg.toLowerCase() : "sum";
+      metric.type = AGG_TO_TYPE[agg] ?? "simple";
+      if (typeof m.expr === "string") metric.expr = m.expr;
+      if (typeof m.description === "string") metric.description = m.description;
+      metrics.push(metric);
+    }
+    // Attach top-level metrics whose type_params.measure lives in this model
+    for (const tm of topLevelMetrics) {
+      const measureRef =
+        isRec(tm.type_params) && typeof tm.type_params.measure === "string"
+          ? tm.type_params.measure
+          : isRec(tm.type_params) &&
+              isRec(tm.type_params.measure) &&
+              typeof (tm.type_params.measure as AnyRec).name === "string"
+            ? String((tm.type_params.measure as AnyRec).name)
+            : null;
+      if (measureRef && measureNames.has(measureRef)) {
+        mappedCount++;
+        renamedCount++;
+        const metric: AnyRec = { name: String(tm.name ?? measureRef) };
+        const t = typeof tm.type === "string" ? tm.type.toLowerCase() : "simple";
+        metric.type = ["simple", "ratio", "cumulative", "derived"].includes(t) ? t : "simple";
+        if (typeof tm.description === "string") metric.description = tm.description;
+        metrics.push(metric);
+      }
+    }
+    if (metrics.length > 0) entity.metrics = metrics;
+
+    // Track dropped fields
+    for (const k of Object.keys(sm)) {
+      if (
+        ["name", "description", "entities", "dimensions", "measures", "node_relation"].includes(k)
+      )
+        continue;
+      if (KNOWN_DROPPED_MODEL_FIELDS.has(k)) droppedFields.add(k);
+      else droppedFields.add(k);
+    }
+
+    return entity;
+  });
+
+  const osi: AnyRec = {
+    osi_version: OSI_SCHEMA_VERSION,
+    ...(typeof input.name === "string" ? { name: input.name } : {}),
+    entities,
+  };
+
+  return {
+    osi,
+    mappedCount,
+    renamedCount,
+    droppedFields: Array.from(droppedFields).sort(),
+    warnings,
+  };
+}
+
+/**
+ * Top-level entry point used by the UI: parse YAML, convert, and re-serialize.
+ */
+export function convertMetricflowYaml(yamlSource: string): ConversionResult {
+  const errors: string[] = [];
+  let parsed: unknown = null;
+  try {
+    parsed = yaml.load(yamlSource);
+  } catch (e) {
+    return {
+      ok: false,
+      osiYaml: "",
+      osi: null,
+      mappedCount: 0,
+      renamedCount: 0,
+      droppedFields: [],
+      warnings: [],
+      errors: [`YAML parse error: ${(e as Error).message}`],
+    };
+  }
+
+  if (!isRec(parsed)) {
+    return {
+      ok: false,
+      osiYaml: "",
+      osi: null,
+      mappedCount: 0,
+      renamedCount: 0,
+      droppedFields: [],
+      warnings: [],
+      errors: ["Root of the YAML must be a mapping (a key/value document)."],
+    };
+  }
+
+  const { osi, mappedCount, renamedCount, droppedFields, warnings } =
+    metricflowObjectToOsi(parsed);
+
+  const osiYaml = yaml.dump(osi, { lineWidth: 100, noRefs: true, sortKeys: false });
+
+  return {
+    ok: errors.length === 0,
+    osiYaml,
+    osi,
+    mappedCount,
+    renamedCount,
+    droppedFields,
+    warnings,
+    errors,
+  };
+}

--- a/src/lib/osi/samples.ts
+++ b/src/lib/osi/samples.ts
@@ -1,0 +1,41 @@
+export const SAMPLE_METRICFLOW = `# MetricFlow semantic model — paste your own or edit this one.
+semantic_models:
+  - name: orders
+    description: Fact table of customer orders
+    model: ref('fct_orders')
+    entities:
+      - name: order_id
+        type: primary
+      - name: customer_id
+        type: foreign
+    dimensions:
+      - name: order_date
+        type: time
+        type_params:
+          time_granularity: day
+      - name: status
+        type: categorical
+    measures:
+      - name: order_total
+        agg: sum
+        expr: amount_usd
+        description: Gross order value in USD
+      - name: order_count
+        agg: count
+        expr: order_id
+
+metrics:
+  - name: revenue
+    type: simple
+    description: Total revenue across all orders
+    type_params:
+      measure: order_total
+`;
+
+export const SAMPLE_METRICFLOW_INVALID = `# Missing required 'name' on the semantic_model — Validator should flag this.
+semantic_models:
+  - description: broken model
+    measures:
+      - name: order_total
+        agg: sum
+`;

--- a/src/lib/osi/schema.ts
+++ b/src/lib/osi/schema.ts
@@ -1,0 +1,78 @@
+// Minimal, hand-authored subset of the OSI (Open Semantic Interchange) 0.2.0.dev0
+// core spec — enough to validate the shape of a converted document in the
+// browser without shipping the full upstream schema. Kept intentionally lax
+// (additionalProperties: true) because the upstream spec is still a draft.
+//
+// Ref: https://github.com/open-semantic-interchange/OSI/blob/main/core-spec/spec.md
+export const OSI_SCHEMA_VERSION = "0.2.0.dev0";
+
+export const osiSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://datus.ai/tools/osi-playground/osi.schema.json",
+  title: "OSI Core Metadata (subset)",
+  type: "object",
+  additionalProperties: true,
+  required: ["osi_version", "entities"],
+  properties: {
+    osi_version: { type: "string", pattern: "^0\\.[0-9]+" },
+    name: { type: "string" },
+    description: { type: "string" },
+    entities: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: true,
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1 },
+          description: { type: "string" },
+          table: { type: "string" },
+          join_keys: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["name"],
+              properties: {
+                name: { type: "string" },
+                type: { type: "string", enum: ["primary", "foreign", "natural"] },
+                expr: { type: "string" },
+              },
+            },
+          },
+          dimensions: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["name", "type"],
+              properties: {
+                name: { type: "string", minLength: 1 },
+                type: { type: "string", enum: ["categorical", "time", "numeric"] },
+                expr: { type: "string" },
+                granularity: { type: "string" },
+                description: { type: "string" },
+              },
+            },
+          },
+          metrics: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["name", "type"],
+              properties: {
+                name: { type: "string", minLength: 1 },
+                type: {
+                  type: "string",
+                  enum: ["simple", "ratio", "cumulative", "derived", "sum", "count", "count_distinct", "average", "min", "max"],
+                },
+                expr: { type: "string" },
+                description: { type: "string" },
+                agg: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/osi/validate.ts
+++ b/src/lib/osi/validate.ts
@@ -1,0 +1,161 @@
+import yaml from "js-yaml";
+import { OSI_SCHEMA_VERSION } from "./schema";
+import { convertMetricflowYaml } from "./metricflow-to-osi";
+
+// A tiny, dependency-free validator for the OSI core-schema subset defined in
+// ./schema.ts. It intentionally re-implements only the handful of constraints
+// that schema declares (required keys, string / array shapes, enum values) so
+// the Playground can run in the browser and during SSR prerender without
+// pulling a full JSON-Schema engine into the build. Error objects mirror the
+// `{ instancePath, message }` shape the UI renders.
+
+export type OsiError = { instancePath: string; message: string };
+
+type AnyRec = Record<string, unknown>;
+
+const isRec = (x: unknown): x is AnyRec =>
+  typeof x === "object" && x !== null && !Array.isArray(x);
+
+const DIM_TYPES = ["categorical", "time", "numeric"];
+const JOIN_TYPES = ["primary", "foreign", "natural"];
+const METRIC_TYPES = [
+  "simple",
+  "ratio",
+  "cumulative",
+  "derived",
+  "sum",
+  "count",
+  "count_distinct",
+  "average",
+  "min",
+  "max",
+];
+
+const MISSING = (prop: string): string => `must have required property '${prop}'`;
+const ENUM = "must be equal to one of the allowed values";
+
+/** Validate a parsed OSI document against the core-schema subset. */
+export function validateOsiObject(doc: unknown): OsiError[] {
+  const errors: OsiError[] = [];
+  if (!isRec(doc)) {
+    errors.push({ instancePath: "", message: "must be object" });
+    return errors;
+  }
+
+  if (!("osi_version" in doc)) {
+    errors.push({ instancePath: "", message: MISSING("osi_version") });
+  } else if (typeof doc.osi_version !== "string" || !/^0\.[0-9]+/.test(doc.osi_version)) {
+    errors.push({ instancePath: "/osi_version", message: 'must match pattern "^0\\.[0-9]+"' });
+  }
+
+  if (!("entities" in doc)) {
+    errors.push({ instancePath: "", message: MISSING("entities") });
+  } else if (!Array.isArray(doc.entities)) {
+    errors.push({ instancePath: "/entities", message: "must be array" });
+  } else {
+    if (doc.entities.length < 1) {
+      errors.push({ instancePath: "/entities", message: "must NOT have fewer than 1 items" });
+    }
+    doc.entities.forEach((ent, ei) => {
+      const base = `/entities/${ei}`;
+      if (!isRec(ent)) {
+        errors.push({ instancePath: base, message: "must be object" });
+        return;
+      }
+      if (!("name" in ent)) {
+        errors.push({ instancePath: base, message: MISSING("name") });
+      } else if (typeof ent.name !== "string" || ent.name.length < 1) {
+        errors.push({ instancePath: `${base}/name`, message: "must NOT have fewer than 1 characters" });
+      }
+
+      if ("join_keys" in ent) validateJoinKeys(ent.join_keys, `${base}/join_keys`, errors);
+      if ("dimensions" in ent) validateDimensions(ent.dimensions, `${base}/dimensions`, errors);
+      if ("metrics" in ent) validateMetrics(ent.metrics, `${base}/metrics`, errors);
+    });
+  }
+
+  return errors;
+}
+
+function validateJoinKeys(v: unknown, base: string, errors: OsiError[]): void {
+  if (!Array.isArray(v)) {
+    errors.push({ instancePath: base, message: "must be array" });
+    return;
+  }
+  v.forEach((jk, i) => {
+    const p = `${base}/${i}`;
+    if (!isRec(jk)) return;
+    if (!("name" in jk)) errors.push({ instancePath: p, message: MISSING("name") });
+    if ("type" in jk && !JOIN_TYPES.includes(String(jk.type)))
+      errors.push({ instancePath: `${p}/type`, message: ENUM });
+  });
+}
+
+function validateDimensions(v: unknown, base: string, errors: OsiError[]): void {
+  if (!Array.isArray(v)) {
+    errors.push({ instancePath: base, message: "must be array" });
+    return;
+  }
+  v.forEach((d, i) => {
+    const p = `${base}/${i}`;
+    if (!isRec(d)) return;
+    if (!("name" in d)) errors.push({ instancePath: p, message: MISSING("name") });
+    if (!("type" in d)) errors.push({ instancePath: p, message: MISSING("type") });
+    else if (!DIM_TYPES.includes(String(d.type)))
+      errors.push({ instancePath: `${p}/type`, message: ENUM });
+  });
+}
+
+function validateMetrics(v: unknown, base: string, errors: OsiError[]): void {
+  if (!Array.isArray(v)) {
+    errors.push({ instancePath: base, message: "must be array" });
+    return;
+  }
+  v.forEach((m, i) => {
+    const p = `${base}/${i}`;
+    if (!isRec(m)) return;
+    if (!("name" in m)) errors.push({ instancePath: p, message: MISSING("name") });
+    if (!("type" in m)) errors.push({ instancePath: p, message: MISSING("type") });
+    else if (!METRIC_TYPES.includes(String(m.type)))
+      errors.push({ instancePath: `${p}/type`, message: ENUM });
+  });
+}
+
+export type ValidationResult =
+  | { kind: "yaml-error"; message: string }
+  | { kind: "not-object"; message: string }
+  | { kind: "valid"; warnings: string[] }
+  | { kind: "invalid"; errors: OsiError[]; warnings: string[] };
+
+/**
+ * Validate a raw YAML string as OSI. If the source looks like a MetricFlow
+ * document, it is converted to OSI first and the converted result validated
+ * (matching the Playground's behavior).
+ */
+export function validateAsOsi(source: string): ValidationResult {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(source);
+  } catch (e) {
+    return { kind: "yaml-error", message: (e as Error).message };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { kind: "not-object", message: "Root must be a YAML mapping." };
+  }
+
+  const isMetricflow = "semantic_models" in (parsed as AnyRec);
+  const warnings: string[] = [];
+  let target: unknown = parsed;
+  if (isMetricflow) {
+    warnings.push(
+      "Detected MetricFlow input — validated the converted OSI document, not the source.",
+    );
+    target = convertMetricflowYaml(source).osi;
+  }
+
+  const errors = validateOsiObject(target);
+  if (errors.length === 0) return { kind: "valid", warnings };
+  return { kind: "invalid", errors, warnings };
+}
+
+export { OSI_SCHEMA_VERSION };

--- a/src/pages/osi-field-mapping/Page.tsx
+++ b/src/pages/osi-field-mapping/Page.tsx
@@ -1,0 +1,414 @@
+import type { ReactNode } from "react";
+import { ArrowRight } from "lucide-react";
+import SiteLayout from "../../components/SiteLayout";
+import Breadcrumb from "../../components/Breadcrumb";
+import FAQ from "../../components/FAQ";
+import { DOCS_URL } from "../../config/nav";
+import {
+  CatalogSection,
+  InlineCode,
+  SectionHead,
+  toneAt,
+} from "../../components/catalog";
+import {
+  OSI_MAPPING_COLUMNS,
+  OSI_DATASET_ROWS,
+  OSI_DIMENSIONS_ROWS,
+  OSI_METRICS_ROWS,
+  OSI_RELATIONSHIPS_ROWS,
+  OSI_TIME_ROWS,
+  OSI_AI_CONTEXT_ROWS,
+  type MappingRow,
+} from "./data";
+import { osiFieldMappingFaq } from "./faq";
+
+/* -------------------------------------------------------------------------- */
+/*  Presentation helpers                                                       */
+/* -------------------------------------------------------------------------- */
+
+const [OSI_COL, ...PRODUCT_COLS] = OSI_MAPPING_COLUMNS;
+
+/** Dotted-underline internal link (design's use-case link style). */
+function L({ href, children, external }: { href: string; children: ReactNode; external?: boolean }) {
+  return (
+    <a
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      style={{
+        color: "var(--brand-bright)",
+        textDecoration: "underline",
+        textDecorationStyle: "dotted",
+        textUnderlineOffset: 2,
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * Vertical field-card variant of the spec table. Each row renders as a card:
+ * an OSI-field header + a grid of the eight per-product mappings. Avoids a
+ * 9-wide horizontal-scroll table (ports datus-design SpecFieldCards).
+ */
+function LayerFieldCards({ filename, rows }: { filename: string; rows: MappingRow[] }) {
+  return (
+    <div className="term">
+      <div className="term__bar">
+        <span className="term__dot term__dot--r" />
+        <span className="term__dot term__dot--y" />
+        <span className="term__dot term__dot--g" />
+        <span className="term__title">{filename}</span>
+        <span className="term__title" style={{ marginLeft: "auto" }}>yaml</span>
+      </div>
+      <div className="osi-fields">
+        {rows.map((r) => {
+          const [osiCell, ...productCells] = r.cells;
+          return (
+            <div key={r.key} className="osi-field-row">
+              <div style={labelStyle}>{OSI_COL.label}</div>
+              <div style={{ marginTop: 4, fontSize: 14, color: "var(--ink)", lineHeight: 1.55 }}>
+                {osiCell}
+              </div>
+              <div className="osi-field-products">
+                {PRODUCT_COLS.map((col, i) => (
+                  <div key={col.label} style={{ minWidth: 0 }}>
+                    <div style={labelStyle}>{col.label}</div>
+                    <div
+                      style={{
+                        marginTop: 4,
+                        fontSize: 13,
+                        color: "var(--ink-muted)",
+                        lineHeight: 1.55,
+                        overflowWrap: "anywhere",
+                      }}
+                    >
+                      {productCells[i]}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10.5,
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  color: "var(--ink-faint)",
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Layer sections                                                             */
+/* -------------------------------------------------------------------------- */
+
+type Layer = {
+  id: string;
+  filename: string;
+  title: string;
+  description: string;
+  rows: MappingRow[];
+  commentary: ReactNode;
+};
+
+const LAYERS: Layer[] = [
+  {
+    id: "dataset",
+    filename: "osi-dataset-mapping.yaml",
+    title: "1 · Dataset Layer (tables & sources)",
+    description:
+      "How each product names the physical table that backs a semantic object, and how OSI unifies those names under dataset.name + dataset.source.",
+    rows: OSI_DATASET_ROWS,
+    commentary: (
+      <>
+        The name of a semantic object varies wildly across tools — <strong>cube</strong>,{" "}
+        <strong>view</strong>, <strong>semantic_model</strong>, a raw SQL alias — but every product
+        ultimately points at one physical table. OSI collapses that into two fields:{" "}
+        <strong>dataset.name</strong> for the logical identifier your metrics reference, and{" "}
+        <strong>dataset.source</strong> for the exact table binding downstream consumers hit.
+      </>
+    ),
+  },
+  {
+    id: "dimensions",
+    filename: "osi-dimensions-mapping.yaml",
+    title: "2 · Dimensions Layer (fields & attributes)",
+    description:
+      "Field-level metadata: names, expressions, labels, descriptions, and the two pieces most products lack — a time flag and an AI-context slot.",
+    rows: OSI_DIMENSIONS_ROWS,
+    commentary: (
+      <>
+        OSI's <strong>fields[].expression.dialects[]</strong> is the one place multi-dialect SQL can
+        live natively — MetricFlow, Cube and LookML each assume a single dialect. And{" "}
+        <strong>fields[].dimension.is_time</strong> is the only cross-product flag any consumer can
+        rely on for time dimensions: no more sniffing LookML's <em>dimension_group</em>,
+        MetricFlow's <em>type: time</em>, and Snowflake's raw SQL to guess the same thing three
+        different ways.
+      </>
+    ),
+  },
+  {
+    id: "metrics",
+    filename: "osi-metrics-mapping.yaml",
+    title: "3 · Metrics Layer (measures & aggregations)",
+    description:
+      "How each product describes aggregations, filters, and derived metrics — and how OSI pulls the aggregation out of the SQL string into a first-class field.",
+    rows: OSI_METRICS_ROWS,
+    commentary: (
+      <>
+        Snowflake Semantic Views and GoodData embed the aggregation inside the expression string (
+        <InlineCode>AS SUM(...)</InlineCode>, <InlineCode>SELECT SUM({"{fact}"})</InlineCode>). OSI
+        moves it out to <strong>metrics[].aggregation</strong> so agents and BI tools can reason
+        about the operation without parsing SQL. Derived metrics that reference other metrics are
+        preserved verbatim through <strong>metrics[].expression</strong>.
+      </>
+    ),
+  },
+  {
+    id: "relationships",
+    filename: "osi-relationships-mapping.yaml",
+    title: "4 · Relationships Layer (joins)",
+    description:
+      "Where joins are declared and where they must be inferred. OSI hoists them into a first-class relationships[] block.",
+    rows: OSI_RELATIONSHIPS_ROWS,
+    commentary: (
+      <>
+        This is the most inconsistent layer across the six products. MetricFlow and AtScale derive
+        joins from <em>entities</em> / <em>level bindings</em>; Cube and LookML declare them inline;
+        Snowflake and GoodData sit in between. OSI's <strong>relationships[]</strong> block gives
+        every consumer the same four fields — name, from_dataset, to_dataset, foreign_key — plus
+        explicit <strong>cardinality</strong>, which only Cube and LookML currently declare.
+      </>
+    ),
+  },
+  {
+    id: "time",
+    filename: "osi-time-mapping.yaml",
+    title: "5 · Time Semantics Layer (granularity)",
+    description:
+      "How each product marks a time dimension and expresses granularity. OSI's is_time + granularity is the smallest common denominator.",
+    rows: OSI_TIME_ROWS,
+    commentary: (
+      <>
+        LookML's <strong>dimension_group</strong> with <em>timeframes</em> is the most complete;
+        Snowflake leaves time entirely to SQL. OSI collapses this into a single time field with{" "}
+        <strong>is_time: true</strong> and a <strong>granularity</strong> value — downstream tools
+        that want day / week / month / quarter / year can generate them from the base field plus
+        granularity metadata, so nothing is lost and every consumer can test one flag.
+      </>
+    ),
+  },
+  {
+    id: "ai-context",
+    filename: "osi-ai-context-mapping.yaml",
+    title: "6 · AI Context Layer (OSI's differentiator)",
+    description:
+      "The one layer where OSI leads the ecosystem. Only Snowflake Semantic Views has native equivalents today.",
+    rows: OSI_AI_CONTEXT_ROWS,
+    commentary: (
+      <>
+        This is the layer OSI was built for. Snowflake shipped <strong>WITH SYNONYMS</strong>,{" "}
+        <strong>AI_SQL_GENERATION</strong> and <strong>AI_VERIFIED_QUERIES</strong> in 2026 — and no
+        other mainstream semantic layer has an equivalent yet. OSI standardizes those hints into{" "}
+        <strong>ai_context</strong> on every field and metric, so an agent reading OSI can find
+        synonyms, natural-language names and verified sample queries the same way whether the source
+        stack is Snowflake, Cube or a home-grown YAML store. When downstream tools adopt OSI, the
+        AI-grounding metadata travels with the metric — instead of being locked inside one vendor's
+        SQL dialect.
+      </>
+    ),
+  },
+];
+
+const USE_CASES: { id: string; title: string; description: ReactNode }[] = [
+  {
+    id: "one-metric-every-tool",
+    title: "One metric definition across every BI tool",
+    description: (
+      <>
+        OSI turns <InlineCode>metrics[].aggregation</InlineCode>, <InlineCode>fields[]</InlineCode>{" "}
+        and <InlineCode>relationships[]</InlineCode> into a vendor-neutral contract. The same revenue
+        or retention definition ships to Cube, Looker, Metabase and a Python notebook without silent
+        drift. Validate conversions in the <L href="/tools/osi-playground/">OSI Playground</L>.
+      </>
+    ),
+  },
+  {
+    id: "ground-ai-agents",
+    title: "Ground AI agents in business semantics",
+    description: (
+      <>
+        Synonyms, natural-language labels and verified sample queries live in{" "}
+        <InlineCode>ai_context</InlineCode> on every field and metric.{" "}
+        <L href="/chatbot/">Datus-Chat</L> and the <L href="/models/">model layer</L> read the same
+        grounding, so "ARR" resolves to annual recurring revenue — not an airport code.
+      </>
+    ),
+  },
+  {
+    id: "move-between-layers",
+    title: "Move between semantic layers without rewriting",
+    description: (
+      <>
+        Author in MetricFlow, Cube or LookML, then export to OSI as the shared interchange.{" "}
+        <L href={DOCS_URL} external>Data engineers</L> keep their source-of-truth tool while
+        downstream consumers read one consistent schema — generated and reviewed from the{" "}
+        <L href="/products/cli/">CLI</L>.
+      </>
+    ),
+  },
+  {
+    id: "catch-drift-early",
+    title: "Catch schema drift before dashboards break",
+    description: (
+      <>
+        Diff two OSI files to see exactly which <InlineCode>dataset.source</InlineCode>,{" "}
+        <InlineCode>relationships[]</InlineCode> or <InlineCode>metrics[].filter</InlineCode> changed.
+        Governance checks run against the spec from the <L href="/products/cli/">CLI</L>, not against
+        vendor-specific YAML. See how this fits into <L href={DOCS_URL} external>Datus features</L>.
+      </>
+    ),
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  Page                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export default function OsiFieldMappingPage() {
+  return (
+    <SiteLayout>
+      <Breadcrumb
+        currentUrl="/osi-field-mapping/"
+        items={[
+          { label: "Home", href: "/" },
+          { label: "OSI Field Mapping" },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 72, paddingBottom: 40 }}>
+        <div className="container" style={{ maxWidth: 900 }}>
+          <span className="eyebrow">OSI Field Mapping</span>
+          <h1
+            style={{
+              fontSize: "clamp(32px,4.6vw,52px)",
+              lineHeight: 1.06,
+              letterSpacing: "-0.03em",
+              fontWeight: 750,
+              margin: "20px 0 0",
+            }}
+          >
+            OSI Field Mapping: every semantic layer, one spec
+          </h1>
+          <p className="lead" style={{ maxWidth: 720 }}>
+            A field-by-field reference of how MetricFlow, Cube, LookML, AtScale, Snowflake Semantic
+            Views, GoodData, Power BI and Databricks Metric Views translate onto the Open Semantic
+            Interchange schema — the vendor-neutral wire format for the modern semantic layer.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "8px 20px",
+              marginTop: 22,
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--ink-faint)",
+            }}
+          >
+            <span>OSI v0.2.0.dev0</span>
+            <span>·</span>
+            <span>8 products</span>
+            <span>·</span>
+            <span>Apache 2.0</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Layer sections */}
+      {LAYERS.map((layer, i) => (
+        <CatalogSection key={layer.id} alt={i % 2 === 0}>
+          <div id={layer.id} style={{ scrollMarginTop: 90 }}>
+            <SectionHead eyebrow={`Layer ${i + 1}`} title={layer.title} lead={layer.description} />
+            <LayerFieldCards filename={layer.filename} rows={layer.rows} />
+            <p
+              style={{
+                marginTop: 20,
+                maxWidth: 760,
+                fontSize: 14,
+                lineHeight: 1.7,
+                color: "var(--ink-muted)",
+              }}
+            >
+              {layer.commentary}
+            </p>
+          </div>
+        </CatalogSection>
+      ))}
+
+      {/* Use cases */}
+      <CatalogSection alt={LAYERS.length % 2 === 0}>
+        <SectionHead
+          eyebrow="Use cases"
+          title="What OSI enables for data teams"
+          lead="Four patterns teams unlock once their semantic layer speaks one vendor-neutral format — from the terminal to the chat interface."
+        />
+        <div className="grid grid-2">
+          {USE_CASES.map((u, i) => (
+            <div key={u.id} id={u.id} className="card" style={{ display: "flex", flexDirection: "column", scrollMarginTop: 90 }}>
+              <div style={{ height: 6, width: 40, borderRadius: 3, background: toneAt(i), marginBottom: 16 }} />
+              <h3 className="card__title">{u.title}</h3>
+              <div className="card__body">{u.description}</div>
+            </div>
+          ))}
+        </div>
+      </CatalogSection>
+
+      {/* FAQ */}
+      <FAQ
+        items={osiFieldMappingFaq}
+        currentUrl="/osi-field-mapping/"
+        lead="LookML, Snowflake AI context, Cube joins, dimension_group timeframes, round-tripping and MAQL — how OSI handles each."
+      />
+
+      {/* Closing CTA */}
+      <section className="section" style={{ paddingTop: 0 }}>
+        <div className="container">
+          <div
+            className="card"
+            style={{
+              textAlign: "center",
+              padding: "48px 32px",
+              background:
+                "radial-gradient(700px 300px at 50% -20%, var(--brand-soft), transparent 70%), var(--panel)",
+              borderColor: "var(--line-strong)",
+            }}
+          >
+            <h2 className="h2" style={{ fontSize: "clamp(24px,3vw,34px)" }}>
+              Try the OSI Playground.
+            </h2>
+            <p className="lead" style={{ marginInline: "auto", maxWidth: 620 }}>
+              Paste your MetricFlow YAML, get OSI back — validation, conversion and diff all run in
+              your browser.
+            </p>
+            <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap", marginTop: 26 }}>
+              <a className="btn btn-lg btn-primary" href="/tools/osi-playground/">
+                Open OSI Playground <ArrowRight size={17} />
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </SiteLayout>
+  );
+}

--- a/src/pages/osi-field-mapping/data.tsx
+++ b/src/pages/osi-field-mapping/data.tsx
@@ -1,0 +1,354 @@
+import type { ReactNode } from "react";
+import { InlineCode } from "../../components/catalog";
+
+// Field-by-field mapping content ported verbatim from the datus-design
+// /osi-field-mapping template (osi-mapping-full.tsx). One column for the OSI
+// field + eight products. Rendered as vertical field cards (see Page.tsx) to
+// avoid a 9-wide horizontal-scroll table.
+
+export type MappingColumn = { label: string };
+export type MappingRow = { key: string; cells: ReactNode[] };
+
+export const OSI_MAPPING_COLUMNS: MappingColumn[] = [
+  { label: "OSI Field" },
+  { label: "MetricFlow" },
+  { label: "Cube" },
+  { label: "AtScale (SML)" },
+  { label: "LookML" },
+  { label: "Snowflake Sem. View" },
+  { label: "GoodData" },
+  { label: "Power BI (TMDL)" },
+  { label: "Databricks Metric View" },
+];
+
+const row = (key: string, cells: ReactNode[]): MappingRow => ({ key, cells });
+const c = (s: string) => <InlineCode>{s}</InlineCode>;
+const na = <span style={{ color: "var(--ink-faint)" }}>—</span>;
+
+// ─── 1. Dataset layer ───
+export const OSI_DATASET_ROWS: MappingRow[] = [
+  row("dataset.name", [
+    c("dataset.name"),
+    c("semantic_model.name"),
+    c("cubes[].name"),
+    "dimension / dataset file name",
+    c("view: view_name"),
+    c("TABLES (alias AS …)"),
+    c("dataset.id"),
+    c("table 'Name'"),
+    c("CREATE METRIC VIEW name"),
+  ]),
+  row("dataset.source", [
+    c("dataset.source"),
+    <>model's <InlineCode>ref()</InlineCode> or source YAML</>,
+    c("cubes[].sql_table"),
+    c("dataset.source"),
+    <><InlineCode>sql_table_name</InlineCode> / <InlineCode>derived_table</InlineCode></>,
+    c("TABLES (alias AS db.schema.table)"),
+    <>connection + <InlineCode>dataset</InlineCode> mapping</>,
+    <><InlineCode>partition.source</InlineCode> (M / SQL)</>,
+    <><InlineCode>source: catalog.schema.table</InlineCode></>,
+  ]),
+  row("dataset.primary_key", [
+    c("dataset.primary_key"),
+    <><InlineCode>entities[]</InlineCode> with <InlineCode>type: primary</InlineCode></>,
+    <><InlineCode>dimensions[]</InlineCode> with <InlineCode>primary_key: true</InlineCode></>,
+    c("level_attributes[].key_columns"),
+    <><InlineCode>dimension:</InlineCode> + <InlineCode>primary_key: yes</InlineCode></>,
+    c("PRIMARY KEY (col)"),
+    <>implicit via <InlineCode>attribute</InlineCode> labels</>,
+    <><InlineCode>column.isKey: true</InlineCode></>,
+    "declared on source table (not in metric view)",
+  ]),
+  row("dataset.description", [
+    c("dataset.description"),
+    c("semantic_model.description"),
+    "in-code comment (no standard field)",
+    "dataset description",
+    "view-level comment",
+    c("COMMENT = '…'"),
+    c("dataset.description"),
+    c("table.description"),
+    c("COMMENT '…'"),
+  ]),
+];
+
+// ─── 2. Dimensions layer ───
+export const OSI_DIMENSIONS_ROWS: MappingRow[] = [
+  row("fields[].name", [
+    c("fields[].name"),
+    c("dimensions[].name"),
+    c("dimensions[].name"),
+    c("dimension.unique_name"),
+    c("dimension: field_name"),
+    c("DIMENSIONS (table.dim AS …)"),
+    <><InlineCode>attribute.id</InlineCode> + <InlineCode>label.id</InlineCode></>,
+    c("column.name"),
+    c("dimensions[].name"),
+  ]),
+  row("fields[].expression", [
+    c("fields[].expression.dialects[]"),
+    <><InlineCode>dimensions[].expr</InlineCode> (single dialect)</>,
+    <><InlineCode>dimensions[].sql</InlineCode> (single dialect)</>,
+    c("level_attribute.column"),
+    c("dimension: { sql: ${TABLE}.col }"),
+    c("DIMENSIONS (… AS sql_expr)"),
+    c("label.source_column"),
+    <><InlineCode>column.sourceColumn</InlineCode> or DAX calc column</>,
+    <><InlineCode>dimensions[].expr</InlineCode> (SQL)</>,
+  ]),
+  row("fields[].dimension.is_time", [
+    c("fields[].dimension.is_time"),
+    <><InlineCode>type: time</InlineCode> + <InlineCode>time_granularity</InlineCode></>,
+    c("type: time"),
+    c("type: TIME"),
+    <><InlineCode>dimension_group</InlineCode> + timeframes</>,
+    "no flag — SQL expression only",
+    <>no flag — <InlineCode>attribute</InlineCode> only</>,
+    <><InlineCode>dataType: dateTime</InlineCode> + mark-as-date-table</>,
+    "no flag — inferred from column type",
+  ]),
+  row("fields[].label", [
+    c("fields[].label"),
+    c("dimensions[].label"),
+    c("dimensions[].title"),
+    c("level_attribute.label"),
+    c("dimension.label"),
+    "no dedicated field (use COMMENT)",
+    c("label.title"),
+    "column name doubles as label",
+    c("dimensions[].label"),
+  ]),
+  row("fields[].description", [
+    c("fields[].description"),
+    c("dimensions[].description"),
+    c("dimensions[].description"),
+    c("level_attribute.description"),
+    c("dimension.description"),
+    c("COMMENT = '…'"),
+    c("attribute.description"),
+    c("column.description"),
+    c("dimensions[].comment"),
+  ]),
+  row("fields[].ai_context", [
+    c("fields[].ai_context"),
+    na, na, na, na,
+    c("WITH SYNONYMS = ('…')"),
+    na,
+    <><InlineCode>column.synonyms</InlineCode> (Q&amp;A)</>,
+    "Genie-space instructions (external)",
+  ]),
+  row("fields[].custom_extensions", [
+    c("fields[].custom_extensions"),
+    c("dimensions[].type_params"),
+    c("dimensions[].meta"),
+    <><InlineCode>dimension.type</InlineCode> / <InlineCode>format</InlineCode></>,
+    <><InlineCode>tags</InlineCode> / <InlineCode>group_label</InlineCode></>,
+    c("WITH TAG (…)"),
+    c("label.value_type"),
+    c("annotations[]"),
+    "column tags on source table",
+  ]),
+];
+
+// ─── 3. Metrics layer ───
+export const OSI_METRICS_ROWS: MappingRow[] = [
+  row("metrics[].name", [
+    c("metrics[].name"),
+    c("measures[].name"),
+    c("measures[].name"),
+    c("metric.unique_name"),
+    c("measure: field_name"),
+    c("METRICS (table.metric AS …)"),
+    c("metric.id"),
+    c("measure.name"),
+    c("measures[].name"),
+  ]),
+  row("metrics[].aggregation", [
+    c("metrics[].aggregation"),
+    <><InlineCode>measures[].agg</InlineCode> (sum, count_distinct…)</>,
+    <><InlineCode>measures[].type</InlineCode> (sum, avg…)</>,
+    c("metric.aggregation_type"),
+    c("measure: { type: sum }"),
+    <>inline in SQL (<InlineCode>SUM(...)</InlineCode>)</>,
+    "inline in MAQL",
+    <>inline in DAX (<InlineCode>SUM(...)</InlineCode>)</>,
+    <>inline in SQL (<InlineCode>SUM(...)</InlineCode>)</>,
+  ]),
+  row("metrics[].expression", [
+    c("metrics[].expression"),
+    c("measures[].expr"),
+    c("measures[].sql"),
+    c("metric.expression"),
+    c("measure: { sql: ${TABLE}.col }"),
+    c("METRICS (… AS sql_expr)"),
+    c("metric.maql"),
+    <><InlineCode>measure.expression</InlineCode> (DAX)</>,
+    <><InlineCode>measures[].expr</InlineCode> (SQL)</>,
+  ]),
+  row("metrics[].description", [
+    c("metrics[].description"),
+    c("measures[].description"),
+    c("measures[].description"),
+    c("metric.description"),
+    c("measure.description"),
+    c("COMMENT = '…'"),
+    c("metric.description"),
+    c("measure.description"),
+    c("measures[].comment"),
+  ]),
+  row("metrics[].filter", [
+    c("metrics[].filter"),
+    c("measures[].filter"),
+    c("measures[].filters[]"),
+    c("metric.filter"),
+    c("measure: { filters: [...] }"),
+    "inline in SQL WHERE",
+    "MAQL WHERE clause",
+    <>DAX <InlineCode>CALCULATE(..., filter)</InlineCode></>,
+    <>inline SQL <InlineCode>WHERE</InlineCode> in measure expr</>,
+  ]),
+  row("metrics[].label", [
+    c("metrics[].label"),
+    c("measures[].label"),
+    c("measures[].title"),
+    c("metric.label"),
+    c("measure.label"),
+    na,
+    c("metric.title"),
+    "measure name doubles as label",
+    c("measures[].label"),
+  ]),
+  row("derived-metrics", [
+    "composite / derived",
+    <><InlineCode>metrics:</InlineCode> block (ratio, derived)</>,
+    <><InlineCode>measures[].sql</InlineCode> referencing other measures</>,
+    "metric referencing metric",
+    c("type: number, sql: ${m1}/${m2}"),
+    "nested SQL only",
+    <><InlineCode>metric.maql</InlineCode> referencing other metrics</>,
+    "DAX measure referencing other measures",
+    <><InlineCode>MEASURE(name)</InlineCode> reference in metric view</>,
+  ]),
+  row("metrics[].ai_context", [
+    c("metrics[].ai_context"),
+    na, na, na, na,
+    c("WITH SYNONYMS = ('…')"),
+    na,
+    <><InlineCode>measure.synonyms</InlineCode> (Q&amp;A)</>,
+    "Genie certified instructions (external)",
+  ]),
+];
+
+// ─── 4. Relationships layer ───
+export const OSI_RELATIONSHIPS_ROWS: MappingRow[] = [
+  row("relationships[].name", [
+    c("relationships[].name"),
+    <>derived from <InlineCode>entity.name</InlineCode></>,
+    c("joins[].name"),
+    "dimension-to-fact binding (implicit)",
+    "join's view name",
+    c("RELATIONSHIPS (name AS …)"),
+    <>dataset <InlineCode>reference</InlineCode> declaration</>,
+    c("relationship.name"),
+    c("joins[].name"),
+  ]),
+  row("from-to-dataset", [
+    <><InlineCode>from_dataset</InlineCode> / <InlineCode>to_dataset</InlineCode></>,
+    <>model + <InlineCode>entity.type: foreign</InlineCode></>,
+    <>cube + <InlineCode>joins[].name</InlineCode></>,
+    "fact → dimension binding",
+    "current view + joined view",
+    c("table_a (col) REFERENCES table_b"),
+    "current + referenced dataset",
+    <><InlineCode>fromTable</InlineCode> / <InlineCode>toTable</InlineCode></>,
+    <>metric view + <InlineCode>joins[].source</InlineCode></>,
+  ]),
+  row("relationships[].foreign_key", [
+    c("relationships[].foreign_key"),
+    c("entities[].expr"),
+    c("joins[].sql"),
+    "FK column on fact dataset",
+    c("join: { sql_on: ${a}.fk = ${b}.pk }"),
+    "FK column in REFERENCES",
+    "reference key in dataset fields",
+    <><InlineCode>fromColumn</InlineCode> / <InlineCode>toColumn</InlineCode></>,
+    c("joins[].on (SQL predicate)"),
+  ]),
+  row("relationships[].cardinality", [
+    c("relationships[].cardinality"),
+    "inferred from entity type",
+    <><InlineCode>joins[].relationship</InlineCode></>,
+    "not declared",
+    c("relationship: many_to_one"),
+    "not declared",
+    "not declared",
+    <><InlineCode>cardinality: manyToOne</InlineCode></>,
+    "not declared",
+  ]),
+];
+
+// ─── 5. Time semantics layer ───
+export const OSI_TIME_ROWS: MappingRow[] = [
+  row("is_time flag", [
+    c("fields[].dimension.is_time"),
+    c("type: time"),
+    c("type: time"),
+    c("type: TIME"),
+    c("dimension_group: { type: time }"),
+    "no flag",
+    "no flag",
+    <><InlineCode>dataType: dateTime</InlineCode> + date table</>,
+    "no flag (TIMESTAMP column type)",
+  ]),
+  row("granularity", [
+    c("fields[].dimension.granularity"),
+    c("time_granularity: day"),
+    c("dimensions[].granularity"),
+    "hierarchy levels[]",
+    c("timeframes: [date, week, month]"),
+    <>SQL only (<InlineCode>DATE_TRUNC(...)</InlineCode>)</>,
+    "MAQL date semantics only",
+    "date-table hierarchy (Year / Qtr / Month / Day)",
+    <>SQL only (<InlineCode>DATE_TRUNC(...)</InlineCode>)</>,
+  ]),
+];
+
+// ─── 6. AI Context layer ───
+export const OSI_AI_CONTEXT_ROWS: MappingRow[] = [
+  row("field-synonyms", [
+    c("fields[].ai_context"),
+    na, na, na, na,
+    c("WITH SYNONYMS = ('…')"),
+    na,
+    c("column.synonyms (Q&A)"),
+    na,
+  ]),
+  row("metric-synonyms", [
+    c("metrics[].ai_context"),
+    na, na, na, na,
+    c("WITH SYNONYMS = ('…')"),
+    na,
+    c("measure.synonyms (Q&A)"),
+    na,
+  ]),
+  row("ai-instructions", [
+    "AI instruction block",
+    na,
+    "external Cube AI API",
+    na,
+    na,
+    c("AI_SQL_GENERATION '<instr>'"),
+    na,
+    "linguistic schema (.lsdl)",
+    "Genie-space instructions",
+  ]),
+  row("verified-queries", [
+    "verified sample block",
+    na, na, na, na,
+    c("AI_VERIFIED_QUERIES (…)"),
+    na,
+    "Q&A featured questions",
+    "Genie certified example queries",
+  ]),
+];

--- a/src/pages/osi-field-mapping/faq.ts
+++ b/src/pages/osi-field-mapping/faq.ts
@@ -1,0 +1,39 @@
+import type { FaqItem } from "../../components/FAQ";
+
+// Page-specific FAQ for /osi-field-mapping/. Content ported verbatim from the
+// datus-design template (osi-mapping-full.tsx OSI_MAPPING_FAQS). Owned by this
+// URL only; see datus-faq-spec.md.
+export const osiFieldMappingFaq: FaqItem[] = [
+  {
+    q: "Can LookML metrics be represented in OSI?",
+    a: "Yes. Every LookML measure translates to an OSI metric: the type becomes aggregation, sql becomes expression, filters becomes filter. LookML's derived measures (type: number with references) map to OSI derived metrics that reference other metric names in the same file.",
+  },
+  {
+    q: "Does OSI support Snowflake Semantic Views' WITH SYNONYMS and AI_SQL_GENERATION?",
+    a: "Yes — this is the layer OSI standardizes most aggressively. WITH SYNONYMS on a dimension or metric maps directly to OSI's ai_context.synonyms; AI_SQL_GENERATION and AI_VERIFIED_QUERIES have first-class slots so agents from any vendor can read the same grounding hints.",
+  },
+  {
+    q: "How does OSI represent Cube's joins[] block?",
+    a: "Cube's joins[] entries become OSI relationships[] entries. joins[].sql becomes foreign_key, joins[].relationship (many_to_one / one_to_many) becomes cardinality, and the target cube becomes to_dataset. No inference required — the mapping is 1:1.",
+  },
+  {
+    q: "Is there anything in MetricFlow that OSI can't express today?",
+    a: "OSI v0.2 covers all core MetricFlow constructs — semantic_models, measures, dimensions, entities, top-level metrics — but a few advanced surfaces (saved queries, cumulative metrics with grain-to-date, some conversion metric options) are still evolving. The Datus Playground surfaces any dropped fields explicitly so nothing is lost silently.",
+  },
+  {
+    q: "Does OSI have an equivalent to LookML's dimension_group timeframes?",
+    a: "OSI collapses the LookML dimension_group into a single time field with is_time: true and a granularity value. Downstream tools that want all timeframes (date, week, month, quarter, year) generate them from the base field plus the granularity metadata, which keeps OSI vendor-neutral without losing information.",
+  },
+  {
+    q: "Can I round-trip: MetricFlow → OSI → LookML?",
+    a: "OSI is primarily an interchange and consumption format today. Forward conversion from MetricFlow or Cube into OSI is well supported (see the Datus Playground); back-conversion into LookML or MetricFlow-native YAML is on the community roadmap. In practice most teams treat OSI as the shared read layer and keep authoring in their source-of-truth tool.",
+  },
+  {
+    q: "Will OSI ever support GoodData MAQL expressions?",
+    a: "MAQL survives via metrics[].expression.dialects[]: the raw MAQL string is preserved under its own dialect, so a GoodData-aware consumer can still execute it while non-GoodData consumers fall back to the SQL dialect. This is the same mechanism OSI uses for any vendor-specific expression language.",
+  },
+  {
+    q: "When will the Datus Playground support conversion beyond MetricFlow?",
+    a: "MetricFlow → OSI shipped first because dbt semantic-layer YAML is the most common starting point. Cube and LookML converters are next on the roadmap; contributions are welcome — the Playground is Apache 2.0 and every converter is a pure browser-side function.",
+  },
+];

--- a/src/pages/osi-field-mapping/main.tsx
+++ b/src/pages/osi-field-mapping/main.tsx
@@ -1,0 +1,4 @@
+import { mount } from "../../lib/mount";
+import OsiFieldMappingPage from "./Page";
+
+mount(<OsiFieldMappingPage />);

--- a/src/pages/tools/osi-playground/Page.tsx
+++ b/src/pages/tools/osi-playground/Page.tsx
@@ -1,0 +1,305 @@
+import type { ReactNode } from "react";
+import { ArrowRight } from "lucide-react";
+import SiteLayout from "../../../components/SiteLayout";
+import Breadcrumb from "../../../components/Breadcrumb";
+import FAQ from "../../../components/FAQ";
+import { DOCS_URL } from "../../../config/nav";
+import {
+  CatalogSection,
+  FeatureCard,
+  InlineCode,
+  SectionHead,
+  SpecTable,
+  toneAt,
+} from "../../../components/catalog";
+import { OsiPlayground } from "../../../components/tools/OsiPlayground";
+import { OSI_MAPPING_ROWS, OSI_VS_ROWS } from "./data";
+import { osiPlaygroundFaq } from "./faq";
+
+/* -------------------------------------------------------------------------- */
+/*  Content                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const HOW_TO_STEPS = [
+  {
+    title: "Paste your MetricFlow YAML",
+    description:
+      "Drop your semantic_models file into the input on the left. The Playground parses locally — nothing leaves your browser.",
+  },
+  {
+    title: "Convert to OSI",
+    description:
+      "Open the Converter tab, click Download, and you have an OSI-compatible .yml file ready to hand to any OSI-aware tool.",
+  },
+  {
+    title: "Diff and validate",
+    description:
+      "Use the Diff tab to see exactly what changed, then the Validator to confirm the output matches OSI v0.2 before you commit it.",
+  },
+];
+
+const WHY_MATTERS: { title: string; description: string }[] = [
+  {
+    title: "One definition, every tool",
+    description:
+      "Define 'weekly active users' once. Snowflake Cortex, Cube, Looker and the Datus agent all read the same OSI file — no more three answers for the same question.",
+  },
+  {
+    title: "AI agents that don't hallucinate metrics",
+    description:
+      "OSI is the missing grounding layer for LLM copilots. When your agent reads OSI, it stops inventing join keys and starts quoting the semantic layer verbatim.",
+  },
+  {
+    title: "Zero-lock migration path",
+    description:
+      "Author metrics in dbt MetricFlow today, export to OSI, and consume them from any downstream tool tomorrow. The interchange format decouples authoring from consumption.",
+  },
+  {
+    title: "Governance stays where it belongs",
+    description:
+      "Reviewed pull requests, lineage and ownership live in the source YAML. OSI carries the same names into every consumer, so downstream tools show the same governance metadata.",
+  },
+];
+
+const howToJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  name: "Convert MetricFlow YAML to Open Semantic Interchange",
+  description:
+    "Free browser-based workflow to validate, convert and diff a MetricFlow semantic layer into OSI YAML using the Datus Playground.",
+  step: HOW_TO_STEPS.map((s, i) => ({
+    "@type": "HowToStep",
+    position: i + 1,
+    name: s.title,
+    text: s.description,
+  })),
+};
+
+const ldJson = (obj: unknown) => JSON.stringify(obj).replace(/</g, "\\u003c");
+
+function Prose({ children }: { children: ReactNode }) {
+  return (
+    <p style={{ fontSize: 15, lineHeight: 1.75, color: "var(--ink-muted)", margin: 0 }}>{children}</p>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Page                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export default function OsiPlaygroundPage() {
+  return (
+    <SiteLayout>
+      <Breadcrumb
+        currentUrl="/tools/osi-playground/"
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Tools", noSchema: true },
+          { label: "OSI Playground" },
+        ]}
+      />
+
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 72, paddingBottom: 32 }}>
+        <div className="container" style={{ maxWidth: 900 }}>
+          <span className="eyebrow">OSI Playground</span>
+          <h1
+            style={{
+              fontSize: "clamp(32px,4.6vw,52px)",
+              lineHeight: 1.06,
+              letterSpacing: "-0.03em",
+              fontWeight: 750,
+              margin: "20px 0 0",
+            }}
+          >
+            The Open-Source OSI Playground for MetricFlow
+          </h1>
+          <p className="lead" style={{ maxWidth: 720 }}>
+            Validate MetricFlow YAML against the Open Semantic Interchange spec, convert it to OSI in
+            one click, and diff the two formats side-by-side. Runs entirely in your browser — no
+            upload, no signup.
+          </p>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "8px 20px",
+              marginTop: 22,
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--ink-faint)",
+            }}
+          >
+            <span>OSI v0.2.0.dev0</span>
+            <span>·</span>
+            <span>Browser-only</span>
+            <span>·</span>
+            <span>Apache 2.0</span>
+          </div>
+        </div>
+      </section>
+
+      {/* TOOL */}
+      <section className="section" style={{ paddingTop: 8, paddingBottom: 8 }}>
+        <div className="container">
+          <OsiPlayground />
+        </div>
+      </section>
+
+      {/* WHAT IS OSI */}
+      <CatalogSection alt>
+        <div style={{ maxWidth: 820 }}>
+          <SectionHead
+            eyebrow="Overview"
+            title="What Is the Open Semantic Interchange?"
+            lead="OSI is a vendor-neutral YAML specification for semantic-layer metadata — a shared way for warehouses, BI tools and AI agents to talk about the same metric without redefining it in every product."
+          />
+          <div style={{ display: "grid", gap: 16 }}>
+            <Prose>
+              Launched in 2025 by Snowflake, dbt Labs, Salesforce, ThoughtSpot and other members of
+              the modern data stack, OSI standardizes how <strong>entities</strong>,{" "}
+              <strong>dimensions</strong>, <strong>metrics</strong> and <strong>join keys</strong>{" "}
+              are described. Once a metric like <em>revenue</em> is defined in OSI, Cortex, Cube,
+              Looker, AtScale and Datus can all read the same source of truth.
+            </Prose>
+            <Prose>
+              The current draft is <strong>v0.2.0.dev0</strong>. It targets an eventual 1.0 alongside
+              production adoption in Snowflake Cortex and dbt semantic-layer exports.
+            </Prose>
+          </div>
+        </div>
+      </CatalogSection>
+
+      {/* FIELD MAPPING */}
+      <CatalogSection>
+        <SectionHead
+          eyebrow="Mapping"
+          title="MetricFlow → OSI Field Mapping"
+          lead="How every MetricFlow construct is translated into the OSI core schema. The Converter above uses exactly this table — nothing hidden. See the full 8-product mapping in the OSI Field Mapping reference."
+        />
+        <SpecTable
+          filename="metricflow-to-osi.yaml"
+          columns={[{ label: "MetricFlow" }, { label: "OSI" }, { label: "Notes" }]}
+          rows={OSI_MAPPING_ROWS}
+        />
+        <p style={{ marginTop: 16, fontSize: 14, color: "var(--ink-muted)" }}>
+          Want every product side-by-side?{" "}
+          <a
+            href="/osi-field-mapping/"
+            style={{
+              color: "var(--brand-bright)",
+              textDecoration: "underline",
+              textDecorationStyle: "dotted",
+              textUnderlineOffset: 2,
+            }}
+          >
+            Read the OSI Field Mapping reference
+          </a>{" "}
+          — MetricFlow, Cube, LookML, AtScale, Snowflake, GoodData, Power BI and Databricks across
+          six layers.
+        </p>
+      </CatalogSection>
+
+      {/* HOW-TO */}
+      <CatalogSection alt>
+        <SectionHead
+          eyebrow="How to"
+          title="How to Convert MetricFlow to OSI"
+          lead="Three steps, browser only — no CLI to install, no key to paste."
+        />
+        <div className="grid grid-3">
+          {HOW_TO_STEPS.map((step, i) => (
+            <div key={step.title} className="card" style={{ display: "flex", flexDirection: "column" }}>
+              <span
+                aria-hidden="true"
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 34,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  color: "var(--ink-faint)",
+                }}
+              >
+                {String(i + 1).padStart(2, "0")}
+              </span>
+              <h3 className="card__title" style={{ marginTop: 14 }}>
+                {step.title}
+              </h3>
+              <p className="card__body">{step.description}</p>
+            </div>
+          ))}
+        </div>
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: ldJson(howToJsonLd) }} />
+      </CatalogSection>
+
+      {/* WHY IT MATTERS */}
+      <CatalogSection>
+        <SectionHead
+          eyebrow="Why it matters"
+          title="Why an Open Semantic Standard Matters"
+          lead="Four concrete wins your data team gets the day a metric definition stops living inside a single vendor's YAML."
+        />
+        <div className="grid grid-2">
+          {WHY_MATTERS.map((w, i) => (
+            <FeatureCard key={w.title} tone={toneAt(i)} title={w.title} body={w.description} />
+          ))}
+        </div>
+      </CatalogSection>
+
+      {/* COMPARISON TABLE */}
+      <CatalogSection alt>
+        <SectionHead
+          eyebrow="Comparison"
+          title="OSI vs MetricFlow vs Cube"
+          lead="Interchange formats, engines and platforms solve different problems. Here is where each one fits."
+        />
+        <SpecTable
+          filename="osi-vs-metricflow-vs-cube.yaml"
+          columns={[{ label: "Dimension" }, { label: "OSI" }, { label: "MetricFlow" }, { label: "Cube" }]}
+          rows={OSI_VS_ROWS}
+        />
+      </CatalogSection>
+
+      {/* FAQ */}
+      <FAQ
+        items={osiPlaygroundFaq}
+        currentUrl="/tools/osi-playground/"
+        lead="What OSI is, how the converter works, whether your YAML stays local, and how Datus uses OSI internally."
+      />
+
+      {/* CTA */}
+      <section className="section" style={{ paddingTop: 0 }}>
+        <div className="container">
+          <div
+            className="card"
+            style={{
+              textAlign: "center",
+              padding: "48px 32px",
+              background:
+                "radial-gradient(700px 300px at 50% -20%, var(--brand-soft), transparent 70%), var(--panel)",
+              borderColor: "var(--line-strong)",
+            }}
+          >
+            <h2 className="h2" style={{ fontSize: "clamp(24px,3vw,34px)" }}>
+              Let a data engineering agent read your OSI.
+            </h2>
+            <p className="lead" style={{ marginInline: "auto", maxWidth: 640 }}>
+              Datus grounds every SQL query, pipeline and dashboard answer in your semantic layer —
+              OSI, MetricFlow, Cube or LookML, take your pick.
+            </p>
+            <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap", marginTop: 26 }}>
+              <a className="btn btn-lg btn-primary" href={DOCS_URL} target="_blank" rel="noopener noreferrer">
+                See Datus features <ArrowRight size={17} />
+              </a>
+              <a className="btn btn-lg btn-ghost" href="/osi-field-mapping/">
+                OSI field mapping <ArrowRight size={17} />
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </SiteLayout>
+  );
+}

--- a/src/pages/tools/osi-playground/data.tsx
+++ b/src/pages/tools/osi-playground/data.tsx
@@ -1,0 +1,88 @@
+import type { SpecTableRow } from "../../../components/catalog";
+import { InlineCode } from "../../../components/catalog";
+
+// Tables ported verbatim from the datus-design /tools/osi-playground template
+// (osi-mapping.tsx). Rendered with catalog.SpecTable.
+
+export const OSI_MAPPING_ROWS: SpecTableRow[] = [
+  {
+    key: "semantic_models",
+    cells: [
+      <InlineCode key="l">semantic_models[]</InlineCode>,
+      <InlineCode key="r">entities[]</InlineCode>,
+      "One MetricFlow semantic_model becomes one OSI entity — same name, same description.",
+    ],
+  },
+  {
+    key: "model_ref",
+    cells: [
+      <InlineCode key="l">model: ref('fct_orders')</InlineCode>,
+      <InlineCode key="r">table: fct_orders</InlineCode>,
+      "The dbt ref() wrapper is stripped; the raw table name is used as the OSI table binding.",
+    ],
+  },
+  {
+    key: "entities",
+    cells: [
+      <InlineCode key="l">entities[]</InlineCode>,
+      <InlineCode key="r">join_keys[]</InlineCode>,
+      "primary / foreign / natural key semantics are preserved verbatim.",
+    ],
+  },
+  {
+    key: "dimensions",
+    cells: [
+      <InlineCode key="l">dimensions[]</InlineCode>,
+      <InlineCode key="r">dimensions[]</InlineCode>,
+      "type is normalized to categorical / time / numeric; time_granularity moves to granularity.",
+    ],
+  },
+  {
+    key: "measures",
+    cells: [
+      <InlineCode key="l">measures[]</InlineCode>,
+      <InlineCode key="r">metrics[] (type = agg)</InlineCode>,
+      "MetricFlow measures become OSI metrics; agg becomes the metric type (sum, count, average…).",
+    ],
+  },
+  {
+    key: "top_metrics",
+    cells: [
+      <InlineCode key="l">metrics[] (top-level)</InlineCode>,
+      <InlineCode key="r">metrics[] (on entity)</InlineCode>,
+      "simple / ratio / cumulative / derived types survive; the referenced measure resolves onto its owning entity.",
+    ],
+  },
+];
+
+export const OSI_VS_ROWS: SpecTableRow[] = [
+  {
+    key: "scope",
+    cells: ["Scope", "Interchange format", "Semantic layer + engine", "Semantic layer + engine + API"],
+  },
+  {
+    key: "runs_queries",
+    cells: ["Runs queries", "No — spec only", "Yes (via dbt SQL)", "Yes (via Cube API)"],
+  },
+  {
+    key: "vendor",
+    cells: ["Vendor", "Neutral (Snowflake · dbt · Salesforce · …)", "dbt Labs", "Cube Dev"],
+  },
+  {
+    key: "consumers",
+    cells: [
+      "Primary consumers",
+      "BI + AI tools that share a definition",
+      "dbt projects + MetricFlow-aware tools",
+      "BI dashboards, embedded analytics, LLM apps",
+    ],
+  },
+  {
+    key: "license",
+    cells: ["License", "Apache 2.0", "Apache 2.0", "Apache 2.0"],
+  },
+  {
+    key: "maturity",
+    cells: ["Maturity", "Draft v0.2 (2026)", "GA", "GA"],
+  },
+];

--- a/src/pages/tools/osi-playground/faq.ts
+++ b/src/pages/tools/osi-playground/faq.ts
@@ -1,0 +1,39 @@
+import type { FaqItem } from "../../../components/FAQ";
+
+// Page-specific FAQ for /tools/osi-playground/. Content ported verbatim from the
+// datus-design template (osi-faqs.ts OSI_FAQS). Owned by this URL only; see
+// datus-faq-spec.md.
+export const osiPlaygroundFaq: FaqItem[] = [
+  {
+    q: "What is the Open Semantic Interchange (OSI)?",
+    a: "The Open Semantic Interchange is a vendor-neutral YAML specification for describing metrics, dimensions, and entities in a semantic layer. Backed by Snowflake, dbt Labs, Salesforce and others, OSI lets you define a metric once and query it from Snowflake Cortex, Cube, Looker, AtScale, ThoughtSpot and more without redefining 'Revenue' in every tool.",
+  },
+  {
+    q: "How do I convert MetricFlow YAML to OSI?",
+    a: "Paste your MetricFlow YAML into the Converter tab above. The Datus OSI Playground runs entirely in your browser: it parses your semantic_models, measures and dimensions, maps them to OSI entities, metrics and dimensions, and gives you a downloadable .yaml file plus a list of any fields that were dropped in translation.",
+  },
+  {
+    q: "Is my YAML sent to a server?",
+    a: "No. The Validator, Converter and Diff all run 100% in your browser using js-yaml. Your semantic definitions never leave your machine — there is no upload, no sign-up, and no logging. You can verify this in your browser's DevTools Network tab.",
+  },
+  {
+    q: "Which OSI version does the Playground validate against?",
+    a: "The Playground currently validates against OSI v0.2.0.dev0, the working draft of the core metadata specification. The OSI spec is still evolving toward a stable 1.0, so we track the upstream schema and re-publish the Playground when the spec moves. The active version is stamped at the top of every Validator result.",
+  },
+  {
+    q: "What is the difference between OSI and MetricFlow?",
+    a: "MetricFlow is dbt Labs' semantic layer YAML format — it's tightly integrated with the dbt project and generates SQL through the MetricFlow engine. OSI is a vendor-neutral interchange format: it doesn't run queries itself, it standardizes how metric and dimension definitions are shared across tools. In practice, teams author metrics in MetricFlow or Cube and export to OSI so downstream BI and AI tools can consume them without vendor lock-in.",
+  },
+  {
+    q: "Does the Converter support every MetricFlow feature?",
+    a: "The MVP covers the most common surface: semantic_models to entities, measures to metrics, dimensions to dimensions, entities to join_keys, and top-level metrics whose type_params.measure lives on a converted model. Advanced features (saved queries, cumulative metrics with grain-to-date, complex ratio metrics) are on the roadmap; any fields dropped in conversion are surfaced explicitly in the result panel so you never lose them silently.",
+  },
+  {
+    q: "How does Datus use OSI internally?",
+    a: "Datus is a data engineering agent that grounds every SQL query, pipeline and dashboard answer in your semantic layer. We treat OSI as the neutral wire format between Datus and whichever semantic layer you already run — dbt MetricFlow, Cube, Looker LookML or a home-grown YAML store — so the agent stays accurate as your stack changes. See our Features page for how the context engine reads OSI.",
+  },
+  {
+    q: "Is the OSI Playground open source?",
+    a: "The upstream OSI specification is Apache 2.0 (github.com/open-semantic-interchange/OSI). The Datus Playground is a free hosted tool built by the Datus team — the Datus data engineering agent itself is also Apache 2.0 and you can self-host the whole stack, semantic-layer support included.",
+  },
+];

--- a/src/pages/tools/osi-playground/main.tsx
+++ b/src/pages/tools/osi-playground/main.tsx
@@ -1,0 +1,4 @@
+import { mount } from "../../../lib/mount";
+import OsiPlaygroundPage from "./Page";
+
+mount(<OsiPlaygroundPage />);

--- a/src/prerender.tsx
+++ b/src/prerender.tsx
@@ -12,6 +12,8 @@ import McpPage from "./pages/mcp/Page";
 import ChatbotPage from "./pages/chatbot/Page";
 import PricingPage from "./pages/pricing/Page";
 import FaqPage from "./pages/faq/Page";
+import OsiFieldMappingPage from "./pages/osi-field-mapping/Page";
+import OsiPlaygroundPage from "./pages/tools/osi-playground/Page";
 
 /**
  * SSR entry for build-time prerendering. Loaded via Vite's ssrLoadModule in
@@ -37,6 +39,8 @@ export const ROUTES: { out: string; node: JSX.Element }[] = [
   { out: "chatbot/index.html", node: <ChatbotPage /> },
   { out: "pricing/index.html", node: <PricingPage /> },
   { out: "faq/index.html", node: <FaqPage /> },
+  { out: "osi-field-mapping/index.html", node: <OsiFieldMappingPage /> },
+  { out: "tools/osi-playground/index.html", node: <OsiPlaygroundPage /> },
 ];
 
 export function render(node: JSX.Element): string {

--- a/src/public/sitemap.xml
+++ b/src/public/sitemap.xml
@@ -76,4 +76,14 @@
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://datus.ai/osi-field-mapping/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://datus.ai/tools/osi-playground/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -620,6 +620,9 @@ body {
 }
 /* Both windows fill the (stretched) grid row so they stay equal height. */
 .osi-win { display: flex; flex-direction: column; min-height: 560px; }
+/* Fixed title-bar height so the left (plain text) and right (segmented tab
+   control) bars line up despite different content heights. */
+.osi-win > .term__bar { min-height: 54px; }
 .osi-body { flex: 1; min-height: 0; overflow: auto; padding: 18px; }
 /* Segmented tab switcher that lives inside the output window title bar. */
 .osi-seg {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -607,3 +607,104 @@ body {
   .cap-orbit-rotate { animation: none !important; }
   * { scroll-behavior: auto !important; }
 }
+
+/* ---------------- OSI Playground (/tools/osi-playground) ---------------- */
+.osi-pg {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 900px) {
+  .osi-pg { grid-template-columns: 1fr; }
+}
+.osi-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+}
+.osi-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 5px 9px;
+  border-radius: 6px;
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--ink-dim);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.osi-btn:hover:not(:disabled) { background: var(--brand-soft); color: var(--ink); }
+.osi-btn:disabled { opacity: 0.4; cursor: default; }
+.osi-input {
+  display: block;
+  width: 100%;
+  min-height: 420px;
+  resize: vertical;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--ink-dim);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  padding: 16px;
+}
+.osi-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+  margin-bottom: 12px;
+}
+.osi-tab {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 8px 0;
+  border-radius: 7px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.osi-tab[aria-selected="true"] { background: var(--brand-soft); color: var(--ink); }
+.osi-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--ink-dim);
+}
+
+/* ---------------- OSI field-mapping cards (/osi-field-mapping) ---------------- */
+.osi-fields { display: flex; flex-direction: column; }
+.osi-field-row { padding: 22px; border-bottom: 1px solid var(--line); }
+.osi-field-row:last-child { border-bottom: 0; }
+.osi-field-products {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px 24px;
+  margin-top: 16px;
+}
+@media (max-width: 900px) {
+  .osi-field-products { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 560px) {
+  .osi-field-products { grid-template-columns: 1fr; }
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -613,11 +613,36 @@ body {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-  align-items: start;
+  align-items: stretch;
 }
 @media (max-width: 900px) {
   .osi-pg { grid-template-columns: 1fr; }
 }
+/* Both windows fill the (stretched) grid row so they stay equal height. */
+.osi-win { display: flex; flex-direction: column; min-height: 560px; }
+.osi-body { flex: 1; min-height: 0; overflow: auto; padding: 18px; }
+/* Segmented tab switcher that lives inside the output window title bar. */
+.osi-seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(11, 18, 48, 0.5);
+}
+.osi-tab-mini {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  padding: 3px 11px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.osi-tab-mini[aria-selected="true"] { background: var(--brand-soft); color: var(--ink); }
 .osi-bar {
   display: flex;
   align-items: center;
@@ -649,8 +674,9 @@ body {
 .osi-input {
   display: block;
   width: 100%;
-  min-height: 420px;
-  resize: vertical;
+  flex: 1;
+  min-height: 0;
+  resize: none;
   border: 0;
   outline: none;
   background: transparent;
@@ -660,28 +686,6 @@ body {
   line-height: 1.7;
   padding: 16px;
 }
-.osi-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  padding: 4px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--panel);
-  margin-bottom: 12px;
-}
-.osi-tab {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 8px 0;
-  border-radius: 7px;
-  border: 0;
-  background: transparent;
-  color: var(--ink-muted);
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.osi-tab[aria-selected="true"] { background: var(--brand-soft); color: var(--ink); }
 .osi-pre {
   margin: 0;
   white-space: pre-wrap;

--- a/tools/osi-playground/index.html
+++ b/tools/osi-playground/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>MetricFlow to OSI Converter, Validator & Diff — Datus Playground</title>
+    <meta
+      name="description"
+      content="Free browser-based OSI Playground: validate MetricFlow YAML, convert it to Open Semantic Interchange, and diff both formats side-by-side. No signup, no upload."
+    />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="author" content="Datus" />
+
+    <link rel="canonical" href="https://datus.ai/tools/osi-playground/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="Datus" />
+    <meta property="og:title" content="MetricFlow to OSI Converter, Validator & Diff — Datus Playground" />
+    <meta property="og:description" content="Free browser-based OSI Playground: validate MetricFlow YAML, convert it to Open Semantic Interchange, and diff both formats side-by-side. No signup, no upload." />
+    <meta property="og:url" content="https://datus.ai/tools/osi-playground/" />
+    <meta property="og:image" content="https://datus.ai/og/tools-osi-playground-1200x630.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="MetricFlow to OSI Converter, Validator & Diff — Datus Playground" />
+    <meta name="twitter:description" content="Validate MetricFlow YAML, convert it to Open Semantic Interchange, and diff both side-by-side — in your browser." />
+    <meta name="twitter:image" content="https://datus.ai/og/tools-osi-playground-1200x630.png" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Datus OSI Playground","applicationCategory":"DeveloperApplication","operatingSystem":"Web","url":"https://datus.ai/tools/osi-playground/","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"description":"Free browser-based OSI Playground: validate MetricFlow YAML, convert it to Open Semantic Interchange, and diff both formats side-by-side. No signup, no upload."}
+    </script>
+    <!-- HowTo + FAQPage + BreadcrumbList JSON-LD are emitted by the React components (single source of truth). -->
+
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag("consent", "default", {
+        ad_storage: "denied", analytics_storage: "denied",
+        ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
+      });
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EPVCH78EZP"></script>
+    <script>
+      gtag("js", new Date());
+      gtag("config", "G-EPVCH78EZP");
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/pages/tools/osi-playground/main.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,8 @@ const MPA_ROUTES = [
   'chatbot',
   'pricing',
   'faq',
+  'osi-field-mapping',
+  'tools/osi-playground',
 ];
 
 // Locally mirror GitHub Pages behavior: redirect a clean URL like `/products/cli`


### PR DESCRIPTION
## What

Two new SEO pages ported from the datus-design template, built on the production dark-navy `site.css` / `catalog` design system (no light Tailwind sticker styling, no second component library).

### `/osi-field-mapping/` — reference
Field-by-field mapping of **8 products** (MetricFlow, Cube, AtScale, LookML, Snowflake Semantic Views, GoodData, Power BI, Databricks Metric Views) onto the OSI spec, across **6 layers** (Dataset, Dimensions, Metrics, Relationships, Time, AI Context). Each layer renders as a terminal-framed vertical field-card grid — one OSI field header + an 8-product grid — to avoid a 9-column horizontal-scroll table. Plus a "What OSI enables" use-case grid, 8-question FAQ, and closing CTA to the Playground.

### `/tools/osi-playground/` — interactive tool
Browser-only **MetricFlow → OSI Validator / Converter / Diff**. All logic lives client-side under `src/lib/osi` (YAML via `js-yaml`; a hand-written schema validator and line diff so we don't pull `ajv`/`diff` into the build). The page is SSR-prerendered, so the converted OSI output and all marketing copy ship in the static HTML for crawlers; React hydrates the interactive panels. Also includes a what-is-OSI section, MetricFlow→OSI mapping table, a How-to, why-it-matters cards, and an OSI-vs-MetricFlow-vs-Cube table.

## SEO / structured data
- Copy (titles, Title-Case marker phrases, ledes, cards, FAQ, meta) aligned **verbatim** with the template, rendered in neutral `--ink` (no marker/term colors on inline text); URLs use `datus.ai`.
- `/osi-field-mapping/`: Article + FAQPage + BreadcrumbList JSON-LD.
- `/tools/osi-playground/`: SoftwareApplication + HowTo + FAQPage + BreadcrumbList JSON-LD.
- Template dead links (`/data-engineer`, `/features`) redirected to docs / real pages.

## Wiring
Registered both routes in `vite.config.ts` MPA_ROUTES, `src/prerender.tsx` ROUTES, `sitemap.xml`, `build-og.mjs` CARDS, and the Integrations nav dropdown. Added `js-yaml` as an explicit dependency (was transitive) and OSI styles to `site.css` with mobile collapse.

## Verification
- `npx vite build` + `npm run prerender` → 15 pages prerendered, no errors; converted OSI output present in the static HTML (`osi_version`, `join_keys`, `8 mapped`).
- Puppeteer headless crawl of both pages: **0 pageerrors / 0 console errors**, hydration + tab switching + Validator/Converter/Diff interactivity confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OSI Field Mapping guide with cross-platform field comparisons, use cases, and FAQs.
  * Added an OSI Playground for converting, validating, comparing, copying, and downloading YAML.
  * Added example and intentionally invalid inputs to help explore the tools.
  * Added navigation links and dedicated pages for both new experiences.

* **Documentation**
  * Added SEO metadata, structured data, and sitemap entries for the new pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->