### PR TITLE
nav: trim Products and Integrations dropdown menus

### DIFF
--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -42,16 +42,6 @@ export const PRODUCTS: NavLink[] = [
     description: "The easiest way to start — free, no setup.",
   },
   {
-    label: "Web Chatbot",
-    href: "/chatbot/",
-    description: "Slack / web chat for analysts.",
-  },
-  {
-    label: "MCP Server",
-    href: "/mcp/",
-    description: "Connect Claude, Cursor, IDEs.",
-  },
-  {
     label: "Enterprise",
     href: "/products/enterprise/",
     description: "Shared context, governance, long-running agents.",
@@ -73,16 +63,6 @@ export const INTEGRATIONS: NavLink[] = [
     label: "Models",
     href: "/models/",
     description: "OpenAI, Claude, Gemini, DeepSeek…",
-  },
-  {
-    label: "OSI Field Mapping",
-    href: "/osi-field-mapping/",
-    description: "Semantic layers mapped to the OSI spec.",
-  },
-  {
-    label: "OSI Playground",
-    href: "/tools/osi-playground/",
-    description: "MetricFlow → OSI: validate, convert, diff.",
   },
 ];
 


### PR DESCRIPTION
## What
Remove four entries from the top-nav dropdowns:

- **Products** menu: drop **Web Chatbot** (`/chatbot/`) and **MCP Server** (`/mcp/`).
- **Integrations** menu: drop **OSI Field Mapping** (`/osi-field-mapping/`) and **OSI Playground** (`/tools/osi-playground/`).

## Not affected
The pages themselves stay live — routes (`vite.config.ts` MPA_ROUTES), prerender (`src/prerender.tsx`), `sitemap.xml`, OG cards and internal links are all unchanged. These pages are simply no longer surfaced in the nav dropdowns.

Single-file change in `src/config/nav.ts`. `npx vite build` passes.