### PR TITLE
blog: Datus — The Cursor for Data Engineering

### DIFF
--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -111,14 +111,22 @@ git checkout -b blog/<slug>
 git add blog/posts/<slug>.md scripts/build-blog.mjs src/glossary/glossaryData.ts
 #   (+ blog/public/images/<slug>/ if you added images, + any related post you edited)
 #   Note: do NOT stage sitemaps — they're generated into dist/ at build time.
+#   Note: the memory record (agent/memory/covered-topics.md) ships in this SAME PR too — committed in Step 7.
 git commit -m "blog: <Title>"
 git push -u origin blog/<slug>
 gh pr create --base main --title "blog: <Title>" --body "<what/why, target keyword, sources, local URL>"
 ```
 The repo auto-deploys to GitHub Pages when the PR is merged to `main` (`.github/workflows/deploy.yml` runs `build:all`). The operator merges.
 
-### Step 7 — Record it in memory
-Append a record to `memory/covered-topics.md` using the **full** format in `memory/README.md` — every field: slug, Title, Target keyword, Angle, Source direction, Key sources, **Internal links added**, **Glossary updated (yes/no)**, PR link **+ Status (open/merged)**, Date. This is what prevents duplicate posts next time.
+### Step 7 — Record it in memory (and commit it to the SAME PR)
+Append a record to `agent/memory/covered-topics.md` using the **full** format in `memory/README.md` — every field: slug, Title, Target keyword, Angle, Source direction, Key sources, **Internal links added**, **Glossary updated (yes/no)**, PR link **+ Status (open/merged)**, Date. This is what prevents duplicate posts next time.
+
+The `agent/` config — **including memory** — is tracked in this repo, so the memory record is **not** a local-only note: it must ship in the **same PR** as the post. Because the record references the PR link, it is written after Step 6 and lands as a follow-up commit on the same branch:
+```bash
+git add agent/memory/covered-topics.md
+git commit -m "blog: record <slug> in covered-topics memory"
+git push        # updates the SAME PR from Step 6 — never open a new one
+```
 
 ### Step 8 — Report to the operator (中文)
 Send: chosen direction + rationale, the sources you researched, the local review URL, and the PR link.
@@ -133,7 +141,7 @@ Send: chosen direction + rationale, the sources you researched, the local review
   git commit -m "blog: address review — <summary>"
   git push        # updates the SAME PR — never open a new one
   ```
-- Update the memory record if the angle/keyword changed materially.
+- Update the memory record if the angle/keyword changed materially, and push it to the same PR.
 
 ---
 
@@ -146,4 +154,4 @@ Send: chosen direction + rationale, the sources you researched, the local review
 - [ ] build-blog category + glossaryData `article` updated; post URL present in generated `dist/blog/sitemap.xml` (no manual sitemap edit).
 - [ ] `npm run build:all` succeeds; page verified at `http://localhost:4173/blog/<slug>/`.
 - [ ] Only relevant files staged (no `.idea/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`).
-- [ ] PR opened on `Datus-ai/Datus-website`; memory record appended; 中文 summary sent.
+- [ ] PR opened on `Datus-ai/Datus-website`; memory record appended **and committed to the same PR** (`agent/memory/covered-topics.md`); 中文 summary sent.

--- a/agent/memory/covered-topics.md
+++ b/agent/memory/covered-topics.md
@@ -155,3 +155,15 @@ Data Contract, Medallion Architecture, Change Data Capture.
 - Glossary updated: no (list article, no matching term)
 - PR: https://github.com/Datus-ai/Datus-website/pull/63   Status: open
 - Date: 2026-07-21
+
+### cursor-for-data-engineering
+- Title: Datus: The Cursor for Data Engineering
+- Target keyword: cursor for data engineering (agentic data engineering IDE, vertical AI agent, data engineering agent, context engine, evolvable context, AI SQL agent)
+- Angle: product-thesis / thought-leadership — defines "Cursor for data engineering" as an agent that operates the *data system* (warehouses, metrics, reference SQL, validation loops), not SQL autocomplete. Whitespace vs SERP: frames "Cursor for X" as a real 2026 vertical-agent CATEGORY (not a slogan) w/ agentic-IDE-vs-DE comparison table; three surfaces (IDE · agent runtime · evolvable context shell); honest platform-native-vs-open section that CREDITS Cortex Code/Genie/BigQuery DEA before naming the cross-stack gravity limit. Datus = the Cursor for data engineering, open-source + free Cloud Personal
+- Source direction: operator-supplied draft (~/Documents/32-cursor-for-data-engineering.md); reworked to full house style (head block, TL;DR-first, added Cortex/Genie FAQ + Related articles, dropped non-standard category/image/slug frontmatter). NOT a glossary term
+- Key sources (verified 2026-07-28): cursor.com; getpanto.ai Cursor stats (>$1B ARR 2025 — hedged); turing.com vertical AI agents (Harvey/Abridge scale, 2026 category); snowflake.com/en/blog/cortex-code-governed-agent-data-stack (Cortex Code cross-stack governed agent); agami.ai Cortex Analyst vs Genie vs BigQuery (GA mid-2026)
+- Internal links added: what-is-data-engineering-agent-2026, contextual-data-engineering, data-engineering-agent-vs-sql-copilot, mcp-data-engineering, subagents-domain-specific-data-agents, one-person-data-team, platform-native-data-agents-compared, data-engineering-agent-vs-claude-code, what-is-semantic-layer (no reciprocal links added yet)
+- Glossary updated: no (product-thesis article, no matching term)
+- Category: "What is Datus" (start-here thesis home) in scripts/build-blog.mjs
+- PR: https://github.com/Datus-ai/Datus-website/pull/64   Status: open
+- Date: 2026-07-28

--- a/blog/posts/cursor-for-data-engineering.md
+++ b/blog/posts/cursor-for-data-engineering.md
@@ -1,0 +1,147 @@
+---
+title: "Datus: The Cursor for Data Engineering"
+description: "\"Cursor for data engineering\" means an agent that runs your data system — warehouses, metrics, and reference SQL — with evolvable context, not autocomplete."
+author: "Datus Team"
+date: 2026-07-28
+lastmod: 2026-07-28
+head:
+  - - meta
+    - name: keywords
+      content: "cursor for data engineering, agentic data engineering IDE, data engineering agent, context engine, evolvable context, AI SQL agent, vertical AI agent"
+  - - meta
+    - property: og:title
+      content: "Datus: The Cursor for Data Engineering"
+  - - meta
+    - property: og:description
+      content: "\"Cursor for data engineering\" means an agent that runs your data system — warehouses, metrics, and reference SQL — with evolvable context, not autocomplete."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/cursor-for-data-engineering/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/cursor-for-data-engineering/
+---
+
+# Datus: The Cursor for Data Engineering
+
+## TL;DR
+
+- Software engineers got an agentic IDE. Data engineers still bounce between SQL clients, tickets, Slack threads, and half-remembered metric definitions.
+- **"Cursor for data engineering"** means an agent that operates the *data system* — warehouses, metrics, reference SQL, and validation loops — not autocomplete inside a file.
+- "Cursor for X" is now a real market pattern, not a slogan: vertical AI agents are the fastest-growing agent category of 2026. The question is what "for data engineering" actually demands.
+- Datus ships three surfaces on one foundation: an agentic workspace (CLI / chat), a [data engineering agent](/blog/what-is-data-engineering-agent-2026/) runtime, and an evolvable [context engine](/blog/contextual-data-engineering/).
+- It is open and cross-stack: use Datus as your daily DE workspace, or expose that context to the coding agent you already use via [MCP](/blog/mcp-data-engineering/).
+- The fastest way to try it is free <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Cloud Personal</a> — no local install required.
+
+**"Cursor for data engineering"** is the idea that the workflow leap agentic coding delivered — describe intent, review diffs, ship, iterate, all in one surface — should reach the people who own warehouses, transformations, and metrics. The phrase is an analogy, not a product affiliation. What it demands underneath is not a SQL autocomplete box; it is an agent grounded in durable, evolvable context. This post defines the term, explains why it is more than a slogan, and lays out what the leap actually requires.
+
+## 1. The problem: data engineering still feels like 2019 tooling
+
+<a href="https://www.cursor.com" rel="nofollow noopener">Cursor</a> changed how software gets written. You stay in one surface, describe intent, review diffs, and ship. The agent sees the repo, the terminal, and the feedback loop. The workflow compounds. By 2026 that shift is not niche — Cursor reportedly crossed <a href="https://www.getpanto.ai/blog/cursor-ai-statistics" rel="nofollow noopener">$1B in ARR during 2025</a>, and "agent mode" became the default way a large slice of engineers write code.
+
+Most data teams still work the other way. A request arrives in Slack. Someone opens a SQL client, greps old queries, pings finance for "the board definition," pastes a draft into a ticket, and hopes the join path is still correct. Pipelines live in one tool. Metrics live in another. Institutional knowledge lives in people. When the same question comes back next week, the organization pays the discovery tax again.
+
+That tax is not about typing speed. It is about **missing system context** at the moment work starts: which table is authoritative, which filter excludes test accounts, which FX rate finance locked last quarter, which model was deprecated in March. Generic coding agents can generate SQL. They cannot reliably remember your data system unless something purpose-built accumulates, versions, and reuses that context.
+
+Budgets are flat. Workloads are not. The teams that win are the ones that stop treating every ad-hoc question and every pipeline edit as a cold start.
+
+## 2. What "Cursor for data engineering" means
+
+The analogy is precise, not decorative. Cursor made coding *agentic*: edit, run, observe, iterate inside one environment. **Cursor for data engineering** means the same shift for people who own warehouses, transformations, metrics, and data products — with the guardrails and memory that data work actually needs.
+
+| Dimension | Agentic coding IDE | Cursor for data engineering |
+|-----------|--------------------|-----------------------------|
+| Primary object | Application codebase | Data system (schemas, SQL, metrics, pipelines) |
+| Context that matters | Repo, types, tests, terminal | Catalog, semantics, reference SQL, feedback history |
+| Success signal | Diff compiles and tests pass | Query is correct *and* reusable next week |
+| Failure mode | Bad code in a PR | Silently wrong numbers in a board deck |
+| Compounding asset | Project conventions | Evolvable institutional memory |
+
+This is not a one-off metaphor. "Cursor for X" has become a genuine category: <a href="https://www.turing.com/resources/vertical-ai-agents" rel="nofollow noopener">vertical AI agents</a> — systems specialized for one domain rather than a general chat box — are among the fastest-moving segments of 2026, with legal (Harvey) and healthcare (Abridge) scaling to hundreds of millions in revenue on domain-specific architectures. Verticalization works because the hard part is rarely the model; it is the domain's context, guardrails, and definition of "done." Data engineering has all three in abundance.
+
+So the bar is not "a chatbot that writes SQL." A SQL autocomplete in an editor is useful, but it is not an agentic data engineering environment. The difference is whether the system can operate across the stack, ground itself in durable context, validate outputs, and improve when humans correct it. That is the bar Datus sets for itself — and the reason we frame Datus as the Cursor for data engineering rather than another chat box on top of a warehouse.
+
+In short: **an IDE without context is autocomplete; an agent without evolvable context is a stranger every Monday.**
+
+## 3. Three surfaces, one system: IDE · Agent · Context shell
+
+People ask whether Datus is an IDE, an agent, or "just a shell around a model." The honest answer is that production data work needs all three — and that the third layer is what makes the first two trustworthy.
+
+**The IDE surface** is where engineers live day to day: a CLI-first workspace and chat that feel like an agentic workbench. You connect warehouses, inspect catalogs, generate and refine SQL, bootstrap knowledge from historical queries, and ship scoped subagents for a domain. It is the place you *do* data engineering with an agent in the loop — closer to how Cursor feels for code than how a classic SQL IDE feels for queries.
+
+**The agent runtime** is what executes the work. A [data engineering agent](/blog/what-is-data-engineering-agent-2026/) is not a one-shot text-to-SQL toy. It explores schema, retrieves metrics and reference SQL, proposes queries, runs validation loops, and packages repeatable workflows. Copilots stop when the suggestion appears. Agents continue until the task is done — or until a human correction teaches the system something new. That distinction is why [agent vs SQL copilot](/blog/data-engineering-agent-vs-sql-copilot/) is a category question, not a UI preference.
+
+**The context shell** is the foundation. Models are interchangeable; your institutional knowledge is not. Datus builds [evolvable context](/blog/contextual-data-engineering/) across physical catalog metadata, business semantics, and institutional memory — validated SQL, deprecation notes, feedback. The "shell" metaphor is deliberate: Datus wraps models, MCP tools, and your stack so the agent is never flying blind. Without that layer, any IDE or agent collapses into a clever stranger with amnesia.
+
+Together: **Datus is the agentic shell for your data stack — and the context layer those agents keep missing.** Use it as your data engineering Cursor, or plug the same context into a general coding agent through MCP when that fits your workflow better.
+
+## 4. From zero to a working data agent in minutes
+
+The product promise only lands if the path from empty account to useful agent is short. On free Cloud Personal, the loop looks like this:
+
+1. **Connect a warehouse** (or start from a tutorial dataset) and let Datus see real schemas instead of inventing them.
+2. **Bootstrap context** from catalog metadata and historical SQL so the agent inherits how your team already queries the world.
+3. **Generate semantic models and metrics** where definitions exist — or capture them as you correct the agent — so "net revenue" stops being a Slack archaeology project.
+4. **Scope a [subagent](/blog/subagents-domain-specific-data-agents/)** to a domain (finance, growth, ops): bounded tables, standing filters, reference queries.
+5. **Ask the real question** — weekly net revenue by region, excluding test accounts, board definition — and review the SQL before it becomes institutional memory.
+
+None of this requires rewriting your stack. You are not replacing dbt, Airflow, or your warehouse. You are putting an agentic surface on top of them and storing the context that used to live only in experts' heads. For a [one-person data team](/blog/one-person-data-team/), that is the difference between spending the week on translation tickets and spending it on engineering that compounds.
+
+## 5. How this differs from platform copilots and generic coding agents
+
+The market is noisy, and it is real. Warehouse vendors ship increasingly capable agents inside their control plane. Analytics platforms add chat. General coding agents get MCP plugins and suddenly look like they "do data." Each of those paths is legitimate for some teams. None of them is the same product thesis as Datus.
+
+**Platform-native agents** are excellent when your world is one cloud. They inherit IAM, lineage, and billing. And they are no longer toys: <a href="https://www.snowflake.com/en/blog/cortex-code-governed-agent-data-stack/" rel="nofollow noopener">Snowflake's Cortex Code</a> now positions itself as a governed agent that reaches beyond Snowflake into dbt, Airflow, and other tools; Databricks ships Genie for analytics and autonomous pipeline work; and BigQuery's Gemini-based data engineering agent reached general availability by mid-2026 (verify each vendor's current scope and pricing yourself — this space ships monthly). The honest limit is not capability, it is gravity: these agents are anchored to a home platform and its billing model. They thin out the moment your stack is genuinely heterogeneous — a lakehouse plus a second warehouse plus a semantic layer that does not live inside the same vendor wall. Datus is built for that open, cross-stack reality most mid-size teams actually run. See [platform-native data agents compared](/blog/platform-native-data-agents-compared/) for the fuller landscape.
+
+**Generic coding agents** are excellent at repositories, refactors, and terminal workflows. Data engineering fails on a different axis: silently wrong business logic. The durable fix is not a longer prompt. It is a specialized context system — metrics, reference SQL, feedback — that can sit beside [Claude Code](/blog/data-engineering-agent-vs-claude-code/) or Cursor and feed them through MCP when you want one brain for code and another memory for data.
+
+**ChatBI and SQL copilots** optimize the ask. Datus optimizes the system behind the ask: context that evolves, subagents you can share, and workflows you can reuse. The interface matters; the [semantic layer](/blog/what-is-semantic-layer/) and the memory matter more.
+
+We are not competing as a generic coding assistant, a warehouse-locked feature, or a one-shot chatbot. We are the open-source system that builds and evolves the data context those tools need to become reliable.
+
+## Conclusion
+
+Cursor made software engineering agentic. Data engineering deserves the same leap — not as a slogan pasted on autocomplete, but as an IDE surface, an agent runtime, and a context shell that remembers how your company actually defines the truth. Vertical AI agents win when they master a domain's context, not when they wrap a bigger model. For data engineering, that context is the whole game.
+
+That is what Datus is building: **the Cursor for data engineering**, open-source at the core, with free <a href="https://studio.datus.ai/overview" rel="nofollow noopener">Cloud Personal</a> as the fastest way to feel the workflow. Connect a warehouse, bootstrap context, ship a subagent, and let the next request start warmer than the last.
+
+If you want the deeper category vocabulary, start with [what a data engineering agent is](/blog/what-is-data-engineering-agent-2026/) and [contextual data engineering](/blog/contextual-data-engineering/). If you want to run it today, open Cloud Personal and treat your data stack like a system an agent can learn.
+
+## Frequently asked questions
+
+### Is Datus just Cursor with SQL plugins?
+
+No. Cursor is an agentic coding IDE for software repositories. Datus is purpose-built for data systems: catalog and semantic context, reference SQL, validation loops, and subagent delivery. You can use Datus as your daily DE workspace, or expose its context to a coding agent via MCP — complementary architectures, not a skin on the same product.
+
+### Do I need a semantic layer before I start?
+
+No. If you already have metric definitions or a semantic layer, Datus can operationalize them as agent context. If you do not, you can bootstrap from schemas and historical SQL, then grow definitions as the agent and your team correct each other. Context compounds either way; perfection is not a prerequisite.
+
+### Can I keep using Claude Code or Cursor alongside Datus?
+
+Yes. Many teams keep a general coding agent for application and infrastructure work and use Datus as the specialized data context layer. MCP is the bridge when you want those worlds to share tools and memory instead of competing for the same prompt window.
+
+### How is this different from Snowflake Cortex or Databricks Genie?
+
+Those are strong agents anchored to a home platform — ideal when your world is one cloud, because they inherit its IAM, lineage, and billing. Datus is stack-agnostic and open-source: it sits across multiple warehouses and a semantic layer that need not share a vendor, and stores evolvable context you own. Use a platform agent inside its wall; use Datus when your stack crosses walls.
+
+### Why start with Cloud Personal instead of only the open-source CLI?
+
+Both are valid. The <a href="https://github.com/Datus-ai/Datus-agent" rel="nofollow noopener">open-source CLI</a> is ideal when you want local control from day one. Cloud Personal removes install friction so you can connect data, build context, and feel the agentic loop in minutes — then decide what to self-host later. Setup details live in the <a href="https://docs.datus.ai" rel="nofollow noopener">Datus docs</a>.
+
+## Related articles
+
+- [What Is a Data Engineering Agent? (2026)](/blog/what-is-data-engineering-agent-2026/) — the category definition and a 2026 comparison of the field.
+- [Contextual Data Engineering](/blog/contextual-data-engineering/) — the evolvable, three-layer context that makes an agent trustworthy.
+- [Data Engineering Agent vs SQL Copilot](/blog/data-engineering-agent-vs-sql-copilot/) — why "agent" is a category, not a UI preference.
+- [Platform-Native Data Agents Compared](/blog/platform-native-data-agents-compared/) — Cortex, Genie, and BigQuery vs an open, cross-stack layer.
+- [The One-Person Data Team](/blog/one-person-data-team/) — how an agentic surface lets one engineer run the modern data stack.

--- a/scripts/build-blog.mjs
+++ b/scripts/build-blog.mjs
@@ -41,7 +41,7 @@ md.use(anchor, { permalink: anchor.permalink.headerLink() });
 /* -------- category structure (ported from the old VitePress sidebar) -------- */
 const CATEGORIES = [
   { label: "What is Datus", description: "Start here — the problem, the product, and the thesis behind it.",
-    slugs: ["meet-the-general-chat-agent", "meet_datus", "agentic-data-stack", "welcome"] },
+    slugs: ["cursor-for-data-engineering", "meet-the-general-chat-agent", "meet_datus", "agentic-data-stack", "welcome"] },
   { label: "Data Engineering Agent", description: "The category, the comparisons, and how to build with one — our core cluster.",
     slugs: ["sql-was-never-the-hard-part", "what-is-data-engineering-agent-2026", "what-is-data-engineering-agent",
       "contextual-data-engineering", "best-data-engineering-agents-2026", "open-source-data-engineering-agents",


### PR DESCRIPTION
## What
New thought-leadership / product-thesis post: **Datus: The Cursor for Data Engineering** at `/blog/cursor-for-data-engineering/`.

Defines what "Cursor for data engineering" actually means — an agent that operates the *data system* (warehouses, metrics, reference SQL, validation loops), not SQL autocomplete — and lays out the three surfaces (IDE · agent runtime · evolvable context shell) that the leap requires.

## Why / target keyword
- Primary keyword: **cursor for data engineering** (+ agentic data engineering IDE, vertical AI agent, data engineering agent, context engine).
- Whitespace vs the SERP: frames "Cursor for X" as a real 2026 vertical-agent category (not a slogan), and gives an honest platform-native-vs-open comparison instead of a pitch.

## Based on
Operator-supplied draft `~/Documents/32-cursor-for-data-engineering.md`, reworked to house style: full frontmatter `head` block (keywords/OG/Twitter/canonical), TL;DR-first, added FAQ Q on Cortex/Genie, added Related articles, removed non-standard `category`/`image`/`slug` fields.

## Research / sources (all external links `nofollow noopener`)
- Cursor 2026 state — Composer/Agent Mode, reportedly >$1B ARR in 2025 (hedged).
- Vertical AI agents as the fast-moving 2026 category (Turing) — Harvey/Abridge scale.
- Platform-native agents — Snowflake Cortex Code (governed, cross-stack), Databricks Genie, BigQuery DEA GA mid-2026 (official Snowflake blog cited; "verify vendor scope yourself" caveat).

## Wiring
- Added slug to `scripts/build-blog.mjs` → **"What is Datus"** category (start-here thesis home).
- 9 internal links, all verified to resolve in the build.
- Not a glossary term → no `glossaryData.ts` change.
- Sitemap auto-generated; post present in `dist/blog/sitemap.xml`.

## Verified locally
`npm run build:all` succeeds (65 posts); page 200 at `http://localhost:4173/blog/cursor-for-data-engineering/`; canonical correct; FAQPage JSON-LD emitted; "What is Datus" badge; all internal links resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new blog post, “Datus: The Cursor for Data Engineering.”
  * Explains Datus’s approach to agentic data engineering, contextual workflows, and domain-specific subagents.
  * Includes a TL;DR, FAQs, conclusion, and related articles.

* **Documentation**
  * Added the post to the “What is Datus” category for improved blog navigation and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->