### PR TITLE
fix(analytics): default Consent Mode analytics_storage to granted

### DIFF
--- a/chatbot/index.html
+++ b/chatbot/index.html
@@ -47,7 +47,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/databases/index.html
+++ b/databases/index.html
@@ -36,7 +36,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/datafun/index.html
+++ b/datafun/index.html
@@ -41,7 +41,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/faq/index.html
+++ b/faq/index.html
@@ -39,7 +39,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/glossary/index.html
+++ b/glossary/index.html
@@ -338,7 +338,7 @@
       }
       gtag("consent", "default", {
         ad_storage: "denied",
-        analytics_storage: "denied",
+        analytics_storage: "granted",
         ad_user_data: "denied",
         ad_personalization: "denied",
         wait_for_update: 500,

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
       }
       gtag("consent", "default", {
         ad_storage: "denied",
-        analytics_storage: "denied",
+        analytics_storage: "granted",
         ad_user_data: "denied",
         ad_personalization: "denied",
         wait_for_update: 500,

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -36,7 +36,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/mcp/index.html
+++ b/mcp/index.html
@@ -47,7 +47,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/models/index.html
+++ b/models/index.html
@@ -36,7 +36,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/osi-field-mapping/index.html
+++ b/osi-field-mapping/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/products/cli/index.html
+++ b/products/cli/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/products/enterprise/index.html
+++ b/products/enterprise/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/products/studio/index.html
+++ b/products/studio/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/products/vscode/index.html
+++ b/products/vscode/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>

--- a/scripts/build-blog.mjs
+++ b/scripts/build-blog.mjs
@@ -202,7 +202,7 @@ function footerHtml() {
 
 function gaHtml() {
   return `<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}
-gtag("consent","default",{ad_storage:"denied",analytics_storage:"denied",ad_user_data:"denied",ad_personalization:"denied",wait_for_update:500});</script>
+gtag("consent","default",{ad_storage:"denied",analytics_storage:"granted",ad_user_data:"denied",ad_personalization:"denied",wait_for_update:500});</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=${GA_ID}"></script>
 <script>gtag("js",new Date());gtag("config","${GA_ID}");</script>`;
 }

--- a/tools/osi-playground/index.html
+++ b/tools/osi-playground/index.html
@@ -40,7 +40,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag() { dataLayer.push(arguments); }
       gtag("consent", "default", {
-        ad_storage: "denied", analytics_storage: "denied",
+        ad_storage: "denied", analytics_storage: "granted",
         ad_user_data: "denied", ad_personalization: "denied", wait_for_update: 500,
       });
     </script>


### PR DESCRIPTION
## Problem
The site ships Consent Mode v2 with `analytics_storage: "denied"` as the default on every page. There is **no cookie consent banner** anywhere in the codebase (only a sidebar-state cookie), so nothing ever calls `gtag("consent", "update", ...)` to flip it to granted. Under Consent Mode v2, a permanent `denied` suppresses full GA4 hits — `page_view` / `session_start` don't land in GA4 Realtime.

## Fix
Per the "no banner + we accept default analytics collection" path, flip the default `analytics_storage` from `denied` to `granted`.

- 16 page entry HTML files (root `index.html` + product/glossary/etc.)
- `scripts/build-blog.mjs` (`gaHtml()`), which generates all blog + glossary pages
- Ad-related signals (`ad_storage`, `ad_user_data`, `ad_personalization`) intentionally stay `denied` — only analytics was requested.

## Verification
- `npm run build:all` succeeds; built `dist/` homepage and blog pages all emit `analytics_storage: "granted"`, with zero `analytics_storage:"denied"` remaining.
- Next: confirm `/g/collect` fires `page_view` + `session_start` with consent granted, cross-checked against GA4 Realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Privacy & Analytics**
  - Analytics storage is now enabled by default across site pages and generated content.
  - Advertising storage, ad personalization, and related advertising data remain denied by default.
  - Consent preferences can still update these settings when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->