### PR TITLE
blog: 9-post batch — ontology, platform data agents, Datus features

### DIFF
--- a/agent/memory/covered-topics.md
+++ b/agent/memory/covered-topics.md
@@ -253,3 +253,111 @@ Data Contract, Medallion Architecture, Change Data Capture.
 - Category: "Semantic Layer"
 - PR: https://github.com/Datus-ai/Datus-website/pull/70   Status: open
 - Date: 2026-08-10
+
+### what-is-ontology
+- Title: What Is an Ontology? Definition, Three Productizations & AI Agents
+- Target keyword: ontology (ontology in data, ontology vs semantic layer, OWL/RDF, Palantir Ontology, SQL ontology, knowledge graph, ontology for AI agents)
+- Angle: ontology = identity layer (classes/properties/relations/rules), NOT a semantic layer/taxonomy/knowledge graph; three productizations buyers confuse in 2026 (W3C OWL/RDF, Palantir Foundry Ontology, SQL ontologies); open-world vs closed-world as the undeclared design input; agent failures are wrong-subject not wrong-arithmetic (calibration walkthrough); "light ontology before a heavy one" checklist; Datus Subject Tree as a light ontology
+- Source direction: operator draft 40-what-is-ontology.md
+- Key sources: w3.org/TR/owl2-overview; palantir.com foundry ontology-system docs
+- Internal links added: semantic-layer-vs-ontology, what-is-semantic-layer, osi-vs-rdf-owl, what-is-timbr, what-is-atscale
+- Glossary updated: no (no matching /glossary term)
+- Category: "Semantic Layer"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-17
+
+### what-is-timbr
+- Title: What Is Timbr? Ontology-Based Semantic Layer Built on SQL
+- Target keyword: Timbr (Timbr.ai, ontology-based semantic layer, SQL ontology, virtual knowledge graph, Timbr vs Cube, Timbr vs AtScale)
+- Angle: Timbr.ai = SQL-native ontology over the warehouse (no separate graph store, traversals push down to SQL); how it differs from Cube (headless metrics) and AtScale (virtual OLAP); when the extra ontology layer is worth it
+- Source direction: operator draft 41-what-is-timbr.md
+- Key sources: timbr.ai; docs.timbr.ai
+- Internal links added: what-is-semantic-layer, what-is-ontology, semantic-layer-vs-ontology, cube-agentic-analytics, what-is-data-engineering-agent
+- Glossary updated: no (no matching /glossary term)
+- Category: "Semantic Layer"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-18
+
+### what-is-atscale
+- Title: What Is AtScale? Enterprise Semantic Layer for BI, Excel & AI
+- Target keyword: AtScale (AtScale semantic layer, virtual OLAP, Semantic Modeling Language SML, MDX/DAX, AtScale MCP, Excel/Power BI semantic layer)
+- Angle: virtual OLAP for Excel/Power BI/agents; SML, DSO pricing model, MDX/DAX surface, MCP; "when the cube is the wrong unit" for agentic analytics
+- Source direction: operator draft 42-what-is-atscale.md
+- Key sources: atscale.com; github.com (AtScale SML)
+- Internal links added: what-is-semantic-layer, what-is-timbr, semantic-layer-tools-list-osi, cube-agentic-analytics
+- Glossary updated: no (no matching /glossary term)
+- Category: "Semantic Layer"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-19
+
+### what-is-databricks-genie
+- Title: What Is Databricks Genie? Agents for Conversational Analytics
+- Target keyword: Databricks Genie (Genie Spaces, conversational analytics, Unity Catalog, Databricks text-to-SQL, Genie vs Genie Code, AI/BI Genie)
+- Angle: domain-scoped agents (formerly Spaces) answering with SQL + charts under Unity Catalog governance; how Genie differs from Genie Code; grounding/trust model
+- Source direction: operator draft 43-what-is-databricks-genie.md
+- Key sources: databricks.com; docs.databricks.com/genie
+- Internal links added: what-is-data-agent, what-is-cortex-analyst, what-is-claude-data-plugin, platform-native-data-agents-compared, what-is-data-engineering-agent
+- Glossary updated: no (no matching /glossary term)
+- Category: "Data Engineering Agent"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-20
+
+### what-is-cortex-analyst
+- Title: What Is Cortex Analyst? Snowflake Natural-Language SQL for BI
+- Target keyword: Cortex Analyst (Snowflake Cortex Analyst, Snowflake text-to-SQL, Semantic Views, verified query repository, Cortex Analyst vs Genie, Cortex Analyst API)
+- Angle: Snowflake's managed text-to-SQL REST API grounded in Semantic Views; verified queries; why it is not Cortex Code; REST integration into apps
+- Source direction: operator draft 44-what-is-cortex-analyst.md
+- Key sources: docs.snowflake.com (Cortex Analyst, Semantic Views)
+- Internal links added: what-is-data-agent, what-is-databricks-genie, what-is-claude-data-plugin, what-is-snowflake-osi, what-is-data-engineering-agent
+- Glossary updated: no (no matching /glossary term)
+- Category: "Data Engineering Agent"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-21
+
+### what-is-claude-data-plugin
+- Title: What Is the Claude Data Plugin? SQL, Charts & Warehouse MCP
+- Target keyword: Claude Data plugin (Anthropic Data plugin, Claude Code data, Cowork, warehouse MCP, Claude SQL charts, Claude vs Genie vs Cortex Analyst)
+- Angle: Anthropic's Data plugin across Cowork and Claude Code for SQL/charts/dashboards over warehouse MCP; how it differs from Genie and Cortex Analyst (general agent + MCP vs platform-native)
+- Source direction: operator draft 45-what-is-claude-data-plugin.md
+- Key sources: claude.com; github.com (Anthropic MCP)
+- Internal links added: what-is-data-agent, what-is-cortex-analyst, what-is-databricks-genie, data-engineering-agent-vs-claude-code, what-is-data-engineering-agent
+- Glossary updated: no (no matching /glossary term)
+- Category: "Data Engineering Agent"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-22
+
+### introducing-datus-knowledge
+- Title: Introducing Datus Knowledge: The Memory Layer for Data Engineering Agents
+- Target keyword: Datus Knowledge (data engineering agent memory, semantic model store, reference SQL, context engine, schema retrieval, agent memory layer)
+- Angle: product intro — Knowledge stores schema, semantic models, metrics, reference SQL, templates, platform docs so the agent retrieves meaning (not a schema dump); Tree + Vector retrieval; feeds Subagents and the OSI adapter
+- Source direction: operator draft 46-introducing-datus-knowledge.md
+- Key sources: docs.datus.ai; docs.getdbt.com; lancedb.com; github.com
+- Internal links added: what-is-data-engineering-agent, contextual-data-engineering, what-is-semantic-model, datus-osi-semantic-adapter, introducing-datus-subagents, what-is-data-catalog
+- Glossary updated: no (product/feature post)
+- Category: "Releases"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-17
+
+### datus-osi-semantic-adapter
+- Title: The Datus OSI Semantic Adapter: OSI In, MetricFlow Out
+- Target keyword: Datus OSI semantic adapter (Open Semantic Interchange, OSI YAML, MetricFlow, vendor-neutral metrics, semantic layer interoperability, dbt MetricFlow adapter)
+- Angle: product intro — authors vendor-neutral OSI YAML, validates it, and queries metrics via MetricFlow without leaking backend fields into source models; the OSI-in/MetricFlow-out pipeline
+- Source direction: operator draft 47-datus-osi-semantic-adapter.md
+- Key sources: docs.datus.ai
+- Internal links added: open-semantic-interchange-osi, osi-vs-dbt-metricflow, introducing-datus-knowledge, introducing-datus-subagents
+- Glossary updated: no (product/feature post)
+- Category: "Releases"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-17
+
+### introducing-datus-subagents
+- Title: Introducing Datus Subagents: Specialized Workers for SQL and KPIs
+- Target keyword: Datus Subagents (task subagents, AskMetrics, gen_sql, data engineering agent, specialized agents, governed metrics)
+- Angle: product intro — Datus 0.3 built-in task subagents; AskMetrics answers KPIs from governed metrics, gen_sql + explore handle SQL/schema; specialized workers vs one universal chat agent
+- Source direction: operator draft 48-introducing-datus-subagents.md
+- Key sources: docs.datus.ai
+- Internal links added: subagents-domain-specific-data-agents, what-is-data-engineering-agent, introducing-datus-knowledge, datus-osi-semantic-adapter
+- Glossary updated: no (product/feature post)
+- Category: "Releases"
+- PR: https://github.com/Datus-ai/Datus-website/pull/71   Status: open
+- Date: 2026-08-17

--- a/blog/posts/datus-osi-semantic-adapter.md
+++ b/blog/posts/datus-osi-semantic-adapter.md
@@ -1,0 +1,138 @@
+---
+title: "The Datus OSI Semantic Adapter: OSI In, MetricFlow Out"
+description: "The Datus OSI semantic adapter authors vendor-neutral YAML, validates it, and queries metrics via MetricFlow without leaking backend fields into source models."
+author: "Kostja"
+date: 2026-08-17
+lastmod: 2026-08-17
+head:
+  - - meta
+    - name: keywords
+      content: "Datus OSI semantic adapter, Open Semantic Interchange, OSI YAML, MetricFlow, vendor-neutral metrics, semantic layer interoperability, dbt MetricFlow adapter"
+  - - meta
+    - property: og:title
+      content: "The Datus OSI Semantic Adapter: OSI In, MetricFlow Out"
+  - - meta
+    - property: og:description
+      content: "The Datus OSI semantic adapter authors vendor-neutral YAML, validates it, and queries metrics via MetricFlow without leaking backend fields into source models."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/datus-osi-semantic-adapter/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/datus-osi-semantic-adapter/
+---
+
+
+# The Datus OSI Semantic Adapter: OSI In, MetricFlow Out
+
+The Datus OSI semantic adapter lets the agent author metrics in vendor-neutral [Open Semantic Interchange](/blog/open-semantic-interchange-osi/) YAML, validate them, and query the certified ones through MetricFlow — without writing MetricFlow fields into the source model.
+
+## TL;DR
+
+- **OSI is the authoring format** in this path. MetricFlow is the default **execution backend** that renders SQL. They are not two products competing for the same file.
+- `gen_semantic_model` and `gen_metrics` write strict OSI core YAML. Datus-specific hints (time grain, dataset, `offset_window`) live in `custom_extensions`, not as MetricFlow `type_params`.
+- Nothing reaches [Datus Knowledge](/blog/introducing-datus-knowledge/) until `validate_semantic` and a `query_metrics` dry-run succeed. Failed drafts stay drafts.
+- `ask_metrics` then lists, dimensions, and queries those published metrics. It does not invent a second formula when a certified one exists.
+- As of August 2026 this is Datus 0.3: one global semantic layer setting, MetricFlow as the current backend, equality joins only. Configuration lives in the <a href="https://docs.datus.ai/0.3/adapters/osi_semantic_adapter/">OSI Semantic Adapter docs</a>.
+
+## 1. Do not let the agent author the execution format
+
+A semantic model that only exists as MetricFlow YAML is useful until the next tool needs the same KPI. Then someone copies `measure_proxy` and `type_params` into a second file, or the agent "helps" by emitting warehouse SQL that happens to match last quarter's number. The syntax is fine. The contract is not: the source of truth has become an execution artifact.
+
+That is the failure [OSI vs MetricFlow](/blog/osi-vs-dbt-metricflow/) already names. OSI says what a metric means so another tool can read it. MetricFlow computes it so the warehouse returns the right grain. An agent that writes MetricFlow YAML as if it were the interchange format collapses those layers. Six months later you cannot move the definition, and you cannot tell which fields were business meaning and which were compiler hints.
+
+The Datus OSI adapter exists so generation stays on the portable side of that line. The agent authors OSI core. The adapter compiles an internal IR and lowers it to MetricFlow. The YAML you keep in git should still look like OSI after a successful run.
+
+## 2. OSI in, MetricFlow out: the adapter's two jobs
+
+The adapter is a one-way boundary between the document and the compiler: [OSI in](/blog/open-semantic-interchange-osi/), MetricFlow out.
+
+> `datus-semantic-osi` loads strict OSI core YAML, validates the schema, compiles it to Datus Semantic IR, and lowers that IR to an execution backend. In 0.3 the backend is MetricFlow. OSI is what users and generation agents write. MetricFlow YAML is a disposable plan, not the file you maintain.
+
+Two repositories share the work. `datus-agent` generates OSI, dry-runs it, and syncs queryable metrics into Knowledge. `datus-semantic-adapter` ships the `datus-semantic-osi` package that does validate → compile → lower. You do not hand-write `data_source`, `measures`, or `measure_proxy` in OSI mode. If those strings appear in the source document, the adapter is no longer doing its job.
+
+The authoring surface is deliberately narrow. Basic and conditional aggregates, ratios, rolling and cumulative windows, period-over-period via `offset_window`, and equality joins expressed as OSI relationships are in scope. Detail lists, `ROW_NUMBER` rankings, and TopN-per-group queries are not metrics; they stay on a SQL or query-layer path. Every execution construct that looks tempting — a window function, a `QUALIFY`, a hard-coded grain — is a reason to reach for the gate in step 4 instead of editing the source document.
+
+## 3. The four-step loop: generate, validate, publish, ask
+
+The product claim is a four-step loop, not a YAML tour.
+
+**Generate.** Point `gen_semantic_model` at a table and you get one canonical dataset per physical table: fields, a time dimension marked `dimension.is_time`, keys only after they pass a full-table uniqueness check, relationships at the model — not a second dataset for every report. `gen_metrics` appends metrics under that model. The business expression stays in OSI `expression`. Grain, unit, and period offsets sit in `custom_extensions` with `vendor_name: DATUS`.
+
+**Validate.** `validate_semantic` runs on the model, then on the full layer. `query_metrics(..., dry_run=True)` renders SQL without publishing a number. If either step fails, Knowledge does not receive the metric.
+
+**Publish.** `publish_semantic_model` / `publish_metrics` sync the validated objects into Datus Knowledge. The store still does retrieval; the adapter still does execution. You do not get a second metric layer inside the knowledge base.
+
+**Ask.** `ask_metrics` uses the same adapter interface — `list_metrics`, `get_dimensions`, `query_metrics` — and reads Datus metadata (`dataset`, `time_dimension`, `offset_window`, `grain_to_date`) to pick grain and comparison period. A question that names a certified KPI should not fall back to an invented aggregate because the column looked confident.
+
+The loop is easiest to read on a question that would tempt a generalist to reach for raw SQL. Finance asks for month-over-month gross margin. The agent does not paste `LAG(margin) OVER (...)` into an OSI expression — window functions are not the authoring contract. It authors a base `gross_margin` metric, derives the period comparison with `offset_window: 1 month`, dry-runs both, publishes both, then answers from `query_metrics`. The SQL MetricFlow emits is an implementation detail. The file in the repo still says what "previous month" means.
+
+## 4. The gate: drafts stay drafts
+
+Validation is not a formality that runs after generation; it is the adapter's second job and the only reason its first job is safe. Because the source model stays OSI — portable, readable by any tool that speaks the standard — executability cannot come from the file itself. It comes from the gate.
+
+`validate_semantic` first checks the model, then the full layer. `query_metrics` with `dry_run=True` renders the SQL MetricFlow would run and returns without executing or publishing a number. A metric passes only when both succeed. A draft that fails either check never enters [Datus Knowledge](/blog/introducing-datus-knowledge/); it stays in the generation session until it compiles.
+
+Generation can be fast and optimistic precisely because publication is slow and strict; `publish_semantic_model` / `publish_metrics` sync only validated objects, so `ask_metrics` cannot see a file that looks structured but would fail at query time.
+
+## 5. Peers, not migration: when to stay on MetricFlow
+
+The adapter is a global setting, not a per-model migration you must finish this week. Set the semantic layer to `osi` in `agent.yml` and `gen_semantic_model`, `gen_metrics`, and `ask_metrics` all follow that format:
+
+```yaml
+agent:
+  services:
+    semantic_layer:
+      osi:
+        default: true
+```
+
+Node-level leftover fields are ignored. MetricFlow mode remains available when you want to author MetricFlow YAML directly. The two adapters are peers: if you already maintain MetricFlow YAML, stay on the MetricFlow adapter until you want the source files to be OSI. Existing MetricFlow projects keep working until you choose to move them.
+
+That "not yet" is the honest part of the pitch. The adapter is not a replacement for MetricFlow, Cube, or a warehouse semantic view — those tools still execute or certify. It is not Snowflake OSI the product, and it is not a claim that every BI tool now imports OSI; the standard's native import story is still maturing. It is not a license to model every `SELECT` as a metric: ranked lists and row-level extracts need `gen_sql` or a pre-joined dataset, composite equality joins work, and non-equality predicates still need a query layer.
+
+`execution_backend` defaults to MetricFlow. After you flip the switch, generate a model for one table you already trust, dry-run a metric you already know the number for, and only then ask `ask_metrics` a question whose answer you can check. Flags, extras, and join limits belong in the <a href="https://docs.datus.ai/0.3/adapters/osi_semantic_adapter/">0.3 adapter docs</a>, not in a product introduction.
+
+## Conclusion
+
+The Datus OSI semantic adapter is the product connection between a vendor-neutral authoring format and a governed query path: OSI in the repo, validation before Knowledge, MetricFlow at execution time, `ask_metrics` at the question. The work it saves is not typing YAML. It is the second copy of the same KPI that appears the first time someone treats an execution field as a definition — and the draft that would have reached Knowledge if the gate had not stopped it.
+
+The standard itself is [Open Semantic Interchange](/blog/open-semantic-interchange-osi/). The layer split is [OSI vs MetricFlow](/blog/osi-vs-dbt-metricflow/). The store that receives a published metric is [Datus Knowledge](/blog/introducing-datus-knowledge/). When the question is a named KPI, the worker that should answer it is a [Datus subagent](/blog/introducing-datus-subagents/) — not a general chat inventing SQL.
+
+## Frequently asked questions
+
+### Does this replace MetricFlow?
+
+No. MetricFlow is the default execution backend. OSI is what you author. The adapter compiles and lowers. You can still run the MetricFlow adapter and author MetricFlow YAML if that is the file you already govern.
+
+### Is this the same as Snowflake OSI?
+
+No. Snowflake's OSI work is a platform and working-group story. This adapter is Datus 0.3: agent generation, validation, Knowledge sync, and metric query through the configured backend. Do not treat a successful dry-run here as proof that a BI tool will import the same YAML tomorrow.
+
+### What happens if validation fails?
+
+The metric is not published. `ask_metrics` only sees objects that passed `validate_semantic` and a dry-run render. A broken draft stays in the generation session until it compiles.
+
+### Can I write LAG or ROW_NUMBER in an OSI metric?
+
+Not as the expression. Period comparisons use a base metric plus `offset_window` on a derived metric. Rankings and TopN detail queries are out of `gen_metrics` scope; use SQL or a precomputed dataset.
+
+### Do I have to migrate every model to OSI this week?
+
+No. MetricFlow and OSI are peer adapters. Switch the global semantic layer when you want new generation to emit OSI. Existing MetricFlow projects keep working until you choose to move them.
+
+## Related articles
+
+- [Open Semantic Interchange (OSI)](/blog/open-semantic-interchange-osi/) — the standard the adapter authors.
+- [OSI vs dbt MetricFlow](/blog/osi-vs-dbt-metricflow/) — the two layers the adapter bridges.
+- [Introducing Datus Knowledge](/blog/introducing-datus-knowledge/) — where the authored models live.
+- [Introducing Datus Subagents](/blog/introducing-datus-subagents/) — the workers that query these metrics.

--- a/blog/posts/introducing-datus-knowledge.md
+++ b/blog/posts/introducing-datus-knowledge.md
@@ -1,0 +1,142 @@
+---
+title: "Introducing Datus Knowledge: The Memory Layer for Data Engineering Agents"
+description: "Datus Knowledge stores schema, semantic models, metrics, reference SQL, templates, and platform docs so a data engineering agent retrieves meaning — not a schema dump."
+author: "Kostja"
+date: 2026-08-17
+lastmod: 2026-08-17
+head:
+  - - meta
+    - name: keywords
+      content: "Datus Knowledge, data engineering agent memory, semantic model store, reference SQL, context engine, schema retrieval, agent memory layer"
+  - - meta
+    - property: og:title
+      content: "Introducing Datus Knowledge: The Memory Layer for Data Engineering Agents"
+  - - meta
+    - property: og:description
+      content: "Datus Knowledge stores schema, semantic models, metrics, reference SQL, templates, and platform docs so a data engineering agent retrieves meaning — not a schema dump."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/introducing-datus-knowledge/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/introducing-datus-knowledge/
+---
+
+
+# Introducing Datus Knowledge: The Memory Layer for Data Engineering Agents
+
+Datus Knowledge is the memory layer of the Datus agent: a searchable store of schema, semantics, metrics, proven SQL, templates, and platform docs, retrieved by meaning instead of dumped into the prompt.
+
+## TL;DR
+
+- **Datus Knowledge** is six components in one repository: schema metadata, semantic models, business metrics, reference SQL, reference templates, and platform documentation.
+- Storage is dual-track — vectors for semantic search, a relational store for tasks, feedback, and success stories — isolated per datasource.
+- When a question names a KPI, the agent looks up a governed metric first and generates ad-hoc SQL only when no metric exists.
+- It is not a human data catalog, not a replacement for MetricFlow or Cube, and not "paste the DDL into ChatGPT."
+- Configuration and commands live in the <a href="https://docs.datus.ai/0.3/knowledge_base/introduction/">Knowledge Base docs (0.3)</a>; this article is the product introduction.
+
+## 1. Agents fail on memory, not on SQL
+
+A [data engineering agent](/blog/what-is-data-engineering-agent/) that only sees `CREATE TABLE` statements will write SQL that runs. Running is the least interesting property of that SQL. The failures that show up in production are failures of meaning, and each one maps to something your team already knows but never stored. A model reads a column named `amount` in a line-item table and sums it into a headline number without checking whether the grain is order-level or line-level. It recomputes a KPI finance certified last quarter and lands a decimal off the board number. It drafts the schedule against last year's fiscal calendar because the query finance actually signed off on was never saved anywhere the agent could reach.
+
+Each of those failures names a store in the next section: a semantic model for the grain, a business metric for the certified formula, reference SQL for the signed-off calendar. Column names do not encode "exclude test accounts," "this join duplicates rows," or "the fiscal quarter closes on `order_completed_at`, not `order_date`." A prompt that stuffs a thousand-table schema into context does not fix that. It dilutes the signal and still omits the tribal rules that never made it into DDL.
+
+Datus Knowledge exists so the agent does not start from a stranger's view of your warehouse every Monday. It is the storage face of the context engine: inspect what exists, retrieve what this question needs, and keep what the team already proved. The accuracy argument for that loop is a different article; this one is the product — what gets stored, how the six parts cooperate on one question, and what you should not expect it to replace.
+
+## 2. The six stores, one retrieval path
+
+The six parts are easier to remember as a single path than as six products. Schema says what exists. Semantic models say how tables relate in business language. Metrics say how to compute the KPIs you already certified. Reference SQL says what worked last time. Templates say which parameterized queries are safe to rerun. Platform docs say whether this warehouse's SQL dialect will accept the draft. A question walks the path front to back; it does not open six apps.
+
+> **Datus Knowledge** is a multi-modal repository that turns scattered data assets — tables, semantic models, KPIs, historical SQL, parameterized templates, and vendor docs — into one searchable memory for the Datus agent. It finds objects by business meaning, not by exact table names.
+
+The name in the product docs is **Knowledge Base**. We introduce it here as **Datus Knowledge** because that is the job it does in the stack: hold what the agent is allowed to know, keep datasources from contaminating each other, and improve as feedback and new SQL land. Subagents — finance, growth, a metrics generator — read the same store with different scopes. They do not each maintain a private copy of a certified number.
+
+| Component | Stores | The agent uses it to |
+|-----------|--------|----------------------|
+| **Schema metadata** | Table and column definitions, sample rows, statistics | Pick the right tables and see shape before writing SQL |
+| **Semantic models** | Dimensions, measures, entity relationships | Join correctly and treat columns as grain, not as string labels |
+| **Business metrics** | KPI definitions, subject-tree paths | Answer named metrics without reinventing the formula |
+| **Reference SQL** | Historical queries, summaries, patterns | Reuse a proven shape instead of generating from zero |
+| **Reference templates** | Jinja2 SQL with typed parameters | Produce stable, repeatable SQL for production questions |
+| **Platform documentation** | Official docs chunked by platform and version | Check dialect and features before the query hits the engine |
+
+Here is the same table as a walkthrough. An analyst asks: "What was gross margin by product family for the last closed quarter, using the board pack definition?" Schema metadata narrows the candidates to `fct_invoices` and `dim_products`, not `fct_sessions`. A [semantic model](/blog/what-is-semantic-model/) on those tables marks `gross_margin_usd` as a measure, `product_family` as a dimension, and `product_id` as the join key — so the agent does not invent a second path through a name that merely looks like a key. If `gross_margin` exists as a business metric, the agent queries that metric (grain, filter, time window included) instead of re-deriving the formula by hand. If the team has a validated board-pack query in reference SQL, that pattern is retrieved as a prior, not as a rumor. If this report runs every week, a reference template supplies the parameters (`start_date`, `product_family`) without letting the model rewrite the join. Platform documentation confirms the date function and the `QUALIFY` qualifier the warehouse actually supports.
+
+That walkthrough is the product claim in one paragraph: six stores, one question, one retrieval, no schema dump. Think of it as Google for your data estate, with the extra requirement that the results have to be executable — a search that returns the right table but the wrong metric grain is a failed retrieval; one that returns validated SQL, the metric definition finance owns, and the dialect note that `QUALIFY` is legal here is a successful one.
+
+The path runs on a dual-track backend. The **vector** track holds embeddings, which is what makes "gross margin by product family" retrieve `margin_by_family` even when the strings do not match. The **relational** track holds structured records — tasks, feedback, success stories — the proof that a retrieval was accepted or corrected. Semantic search without those records is a similarity toy; records without vectors cannot find the table whose name is `amt_usd_net_v2`. As of August 2026 the 0.3 docs describe exactly these six components and this dual-track backend. Unified search and incremental updates are how the store stays current; they are not a seventh component. Domain rules that never became YAML still show up as success stories and feedback in the relational track — they are not a separate "external knowledge" product in the 0.3 introduction.
+
+## 3. Metrics first: the ordering rule that stops five "net revenue"s
+
+A named KPI is where the retrieval path stops being search and starts being governance. The rule: when the question is a named KPI, Datus Knowledge is **metrics-first**. The agent searches semantic objects for a matching metric and executes it — typically through a MetricFlow-compatible path, documented in the <a href="https://docs.getdbt.com/docs/build/about-metricflow" rel="nofollow noopener">MetricFlow docs</a> for the YAML shape. Only if no metric exists does it fall back to composing SQL from models, reference queries, and templates.
+
+Order is the feature, not the ranking. Without metrics-first, every KPI question is a fresh negotiation: the agent infers a formula, the analyst diffs it against the board number, the correction dies in a Slack thread, and the next chat starts over. One metric asked five ways becomes five implementations, each defensible, none authoritative. Metrics-first removes the negotiation by checking the registry before a single line of SQL is composed. The fifth `net_revenue` is never born because the first one was never forgotten.
+
+That is also why Datus Knowledge does not pretend to be the authoring tool. MetricFlow, Cube, or a warehouse semantic view can still own the certified formula. Datus stores it, retrieves it, and keeps the ad-hoc tail those tools never modeled — the weekly query that became a template, the fix that never made it back to the semantic file.
+
+## 4. The boundaries: catalog, semantic layer, and RAG slogans
+
+Datus Knowledge sits next to three products it does not replace, and the boundary is a division of labor rather than a feature list. A [data catalog](/blog/what-is-data-catalog/) inventories assets so people can find tables; Datus Knowledge retrieves the subset an agent should use *this question*, including filters and SQL that catalogs usually do not execute. A semantic layer (or metric layer) is the governed dictionary; Datus Knowledge includes semantic models and metrics as two of six stores, then adds reference SQL, templates, and feedback that move faster than a modeling sprint. Retrieval-augmented generation is an access pattern; Datus Knowledge is the corpus and the update loop — embeddings plus records plus incremental rebuilds after schema and SQL change. Dumping DDL into a chat window has no such loop.
+
+Two labels from the definition are worth retiring: it is not a generic wiki, and it is not a synonym for "vector database." A wiki is written for people to browse; a vector database is plumbing. Datus Knowledge is a product with an opinion about what gets stored and in what order it gets retrieved.
+
+The division applies even when you already run one of these. You do not throw the catalog or the metric layer away. Datus Knowledge consumes what they already know and adds the layers they rarely store: reference SQL, templates, and the corrections that never became a pull request. Complementary, not a rip-and-replace.
+
+## 5. Start small: bootstrap and inspect
+
+To try it, connect a datasource and bootstrap the store. The smallest command is:
+
+```bash
+datus-agent bootstrap-kb --database <your_datasource>
+```
+
+Flags for check / overwrite / incremental, SQL directories, and subject trees belong in the docs, not in a feature introduction. After bootstrap, ask a question you already know the answer to and inspect what was retrieved — tables, a metric, a reference query — before you trust a number you have not seen. Cloud Personal on studio.datus.ai is the zero-install path if you do not want a local backend yet.
+
+What you run on a laptop is intentionally boring: <a href="https://lancedb.com/" rel="nofollow noopener">LanceDB</a> for vectors and SQLite for records, with files under `data/datus_db_<datasource>/`. That path is enough for development and a single warehouse. Production teams that already operate Postgres can switch to <a href="https://github.com/pgvector/pgvector" rel="nofollow noopener">pgvector</a> plus native PostgreSQL, still through the same product interface. Isolation is per **datasource**: one LanceDB directory or one Postgres schema each, so a staging replica cannot leak tables into the production agent. You do not configure a "namespace" as a separate product concept in 0.3; you connect a datasource and the knowledge for that connection stays there.
+
+This page is the product introduction, not the operator handbook — the docs hold flags, schemas, and templates. What should stick here is the ordering rule from the previous section and the bootstrap command above. It is not a migration guide and not a replacement pitch for your catalog or dbt project. If those systems exist, Datus Knowledge is the layer that reads them and remembers what they forget between sprints.
+
+## Conclusion
+
+Datus Knowledge is the memory layer for the Datus agent: six stores that behave as one retrieval path, metrics-first when a KPI already exists, generated SQL when it does not. The work it saves is not typing. It is the Monday cold start — the hunt for the board definition, the join that duplicates, the dialect note someone left in Slack.
+
+The operating model behind that store is [contextual data engineering](/blog/contextual-data-engineering/). For the modeling object the agent retrieves most often, see [what a semantic model is](/blog/what-is-semantic-model/). For the category this memory serves, see [what a data engineering agent is](/blog/what-is-data-engineering-agent/). When a named KPI should hit a worker that cannot invent SQL, see [Datus subagents](/blog/introducing-datus-subagents/). When generation should emit portable OSI instead of backend YAML, see the [OSI semantic adapter](/blog/datus-osi-semantic-adapter/). Read the 0.3 docs when you are ready to wire storage; use this page when you need to explain to a teammate what actually sits under the chat.
+
+## Frequently asked questions
+
+### Is Datus Knowledge a data catalog?
+
+No. A catalog answers "what exists?" for humans. Datus Knowledge answers "what should the agent use for this question?" — including metric logic, reference SQL, and templates. Many teams feed catalog metadata *into* the knowledge base. That does not make the knowledge base a catalog UI.
+
+### Does it replace MetricFlow, Cube, or a warehouse semantic view?
+
+No. Those tools author and serve certified metrics. Datus Knowledge retrieves them (metrics-first) and covers the long tail they never modeled. If you have no metric layer yet, generated semantic models are drafts for review, not an auto-committed certified layer.
+
+### Should we run LanceDB or PostgreSQL?
+
+LanceDB plus SQLite is the default: zero extra infrastructure, one directory per datasource, fine for development and single-machine use. PostgreSQL with pgvector is the production-shaped backend when you already operate Postgres and want native relational storage plus vector search. The product interface does not change; the backend does.
+
+### How is this different from pasting DDL into the prompt?
+
+A schema dump has no retrieval ranking, no metric execution path, no reference SQL, and no place for a correction to live until next week. Datus Knowledge stores those objects, searches them by meaning, and updates them incrementally. The prompt still has a context window; the knowledge base is how you stop filling that window with the wrong thousand columns.
+
+### Where does "external knowledge" fit?
+
+The 0.3 introduction centers six components. Business rules that are not metrics still enter as success stories, feedback, and subagent-scoped notes on the relational track. Treat that as part of the memory loop, not as a seventh product to buy separately.
+
+## Related articles
+
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the product Knowledge grounds.
+- [Contextual data engineering](/blog/contextual-data-engineering/) — why durable context beats bigger prompts.
+- [What is a semantic model?](/blog/what-is-semantic-model/) — one artifact Knowledge stores and retrieves.
+- [The Datus OSI semantic adapter](/blog/datus-osi-semantic-adapter/) — how Knowledge feeds vendor-neutral metrics.
+- [Introducing Datus Subagents](/blog/introducing-datus-subagents/) — the workers that consume Knowledge.

--- a/blog/posts/introducing-datus-subagents.md
+++ b/blog/posts/introducing-datus-subagents.md
@@ -1,0 +1,148 @@
+---
+title: "Introducing Datus Subagents: Specialized Workers for SQL and KPIs"
+description: "Datus 0.3 ships built-in task subagents. AskMetrics answers KPIs from governed metrics; gen_sql and explore handle SQL and schema — not one universal chat."
+author: "Kostja"
+date: 2026-08-17
+lastmod: 2026-08-17
+head:
+  - - meta
+    - name: keywords
+      content: "Datus Subagents, task subagents, AskMetrics, gen_sql, data engineering agent, specialized agents, governed metrics"
+  - - meta
+    - property: og:title
+      content: "Introducing Datus Subagents: Specialized Workers for SQL and KPIs"
+  - - meta
+    - property: og:description
+      content: "Datus 0.3 ships built-in task subagents. AskMetrics answers KPIs from governed metrics; gen_sql and explore handle SQL and schema — not one universal chat."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/introducing-datus-subagents/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/introducing-datus-subagents/
+---
+
+
+# Introducing Datus Subagents: Specialized Workers for SQL and KPIs
+
+Datus subagents are specialized workers with their own prompt, tools, and session: `ask_metrics` answers named KPIs from published metrics, `gen_sql` writes warehouse SQL, `explore` reads schema first — so one chat does not carry every tool.
+
+## TL;DR
+
+- A **task subagent** is not a second product. It is a bounded worker: separate prompt, tool surface, conversation history, and optional scoped context, sharing the same project config as the main chat.
+- **AskMetrics** is the KPI worker. It queries existing semantic metrics. If no published metric can answer, it says so. It does not invent SQL to look helpful.
+- **Chat can delegate.** A metric-first question can go to `ask_metrics` through `task()`; a multi-table draft goes to `gen_sql`; unknown tables go to `explore` first.
+- Domain chatbots — finance vs marketing, scoped tables, a link you hand a team — remain the [domain delivery model](/blog/subagents-domain-specific-data-agents/). This page is the 0.3 built-in roster, not that lifecycle.
+- As of August 2026, configuration and the full built-in list live in the <a href="https://docs.datus.ai/0.3/subagent/introduction/">Subagent docs (0.3)</a>. This article is the product introduction.
+
+## 1. The surface-area problem, not a model problem
+
+An agent that holds every database, metric, and artifact tool in one prompt will answer with whichever tool looks fastest. That is the failure mode, not an edge case. A named KPI gets composed from a raw table because the metric tool and the SQL tool sat in the same tray. A schema-discovery pass dumps fifty tables into a report that only needed two. A visual-artifact run is allowed to `CREATE TABLE` because its tool list was copied from chat. One missing boundary, three different answers.
+
+The failure is the surface area a worker is allowed to touch — the same defect that shows up when a [data engineering agent](/blog/what-is-data-engineering-agent/) is handed one prompt for a whole warehouse. A worker that may search metrics, write SQL, and mutate files will pick the path that looks fastest. Named KPIs need a path that cannot "helpfully" fall back to ad-hoc SQL. Unknown tables need a path that cannot write. Reports need a path that cannot wander the whole warehouse. When every tool has the same rights, every answer has the same odds.
+
+Datus subagents exist so the main chat does not start every Monday as a generalist with a full keyring. The memory those workers read is [Datus Knowledge](/blog/introducing-datus-knowledge/). The workers themselves are how a question picks a lane.
+
+## 2. The lane system: who is allowed to do what
+
+The contract, in one paragraph:
+
+> **Datus subagents** (0.3) are task-specific agents: a dedicated system prompt, a trimmed tool list, an independent session, and optional scoped context. Built-ins cover metric QA, SQL, exploration, semantic generation, and artifacts. Custom nodes in `agent.yml` wrap the same idea for a team. They share datasources and Knowledge. They do not share a junk-drawer of tools.
+
+You invoke a built-in with `/ask_metrics` or `/gen_sql`, switch the default with `/agent`, or let chat call `task(type=...)`. Web and API can pin `subagent_id`. The lane is fixed before the question is answered — that is the point.
+
+The roster below is the set that changes how a question is answered. Pipeline, scheduler, and skill-authoring nodes exist in docs; they are not this introduction.
+
+| Subagent | The question it should get | What it refuses |
+|----------|----------------------------|-----------------|
+| **ask_metrics** | A named KPI in the subject tree, plus a time window and a group-by dimension — trends, attribution on **published** metrics | Raw-table SQL; inventing a metric that was never validated |
+| **gen_sql** | Multi-table SQL when no metric exists, or a query that is not a KPI | Owning the certified formula |
+| **explore** | "What tables and samples matter before we write anything?" | Writes, DDL, "just run it" |
+| **gen_semantic_model** / **gen_metrics** | Draft a model or metric file from a table or from proven SQL | Publishing without validation |
+| **gen_visual_report** | A shareable HTML narrative from a question, a metric, or SQL | Live filter-and-requery BI (that is a dashboard path) |
+
+Delegation is shallow on purpose. Chat may hand work to a subagent. That subagent does not get a nested `task()` of its own. Depth stops at two. Most specialized nodes may only call `explore`. Chat is the orchestrator; workers do not become a second orchestrator.
+
+Custom nodes reuse these types. A `sales_metric_qa` with `type: ask_metrics` is still AskMetrics: same metric tools, tighter description, optional tighter allowlist. It is not a new product. AskMetrics' default surface is metric tools for a reason; a custom node that widens that list to raw SQL is how a lane stops being a lane.
+
+## 3. AskMetrics: the worker that cannot leave its lane
+
+AskMetrics is the walkthrough because it is the sharpest lane change in the roster. The Knowledge store already says metrics-first; AskMetrics is the worker that **cannot** leave that lane.
+
+It needs a configured semantic adapter and at least one published metric. MetricFlow and the [Datus OSI semantic adapter](/blog/datus-osi-semantic-adapter/) are both valid backends; OSI-authored metrics still execute through the configured engine. No adapter means no AskMetrics. That is a feature. A KPI chatbot that can silently become a SQL chatbot is how five "net revenue" implementations appear in five threads.
+
+The path is short. Match a subject-tree path when the name is unambiguous. Search metrics only when the tree is missing or fuzzy. Call `get_dimensions` before grouping or attributing. Execute with `query_metrics`. If the question is "what drove the drop?", run attribution across candidate dimensions. Return Markdown: interpreted window, metric names, values, limits. No SQL dump. No invented number.
+
+Now the refusal, which is the actual product. Ask for a number that no published metric can answer — a KPI validated in a spreadsheet and never published, a board definition that exists only as a slide. AskMetrics matches nothing in the subject tree, searches the metric store, finds nothing, and stops. It does not compose the answer from a confident-looking column, because its lane does not include raw-table SQL. It returns one line: not answerable from published metrics.
+
+The handoff belongs to chat, not to AskMetrics. The next worker might be `gen_metrics` (turn signed-off SQL into a definition), `gen_sql` (the long tail), or `explore` (you do not yet know the tables). Chat can make that call. AskMetrics itself cannot — and that incapacity is the boundary holding.
+
+Slash form, once the datasource is the one that owns the metrics:
+
+```text
+/ask_metrics What was total revenue last month by customer segment?
+```
+
+Turn limits, custom `type: ask_metrics` nodes, and the tool table belong in the <a href="https://docs.datus.ai/0.3/subagent/ask_metrics/">AskMetrics docs</a>.
+
+## 4. Task workers vs domain delivery: two units, one word
+
+One word, two deliverables. The [subagents delivery article](/blog/subagents-domain-specific-data-agents/) ships a *team* an interface: curated tables, a domain description, a feedback loop, eventually an API. The unit there is a business area. The built-ins on this page ship a *job*: ask a certified KPI, draft SQL, read the schema before drafting. The unit here is the task. Both are called "subagents"; they are not the same product.
+
+A finance chatbot with ten tables and twenty metrics is still how you ship an interface to a team. This page does not retell that lifecycle, does not prescribe "start with five tables," and does not export an API. When the job is "give marketing a scoped chat," that is the delivery article. When the job is "this question may only be answered from a published metric," that is `/ask_metrics`. The two coexist: chat delegates to the task worker, and the domain chatbot is the interface the team talks to.
+
+Nor is the word one more synonym for "agent." Chat remains the default conversational node; subagents are the specialists it may call. Publish every built-in as a public chatbot with no description and users end up asking revenue questions of `explore`.
+
+## 5. Feel the fork: a two-question first session
+
+The fastest way to see the product is not to reread the roster. Connect a datasource that already has a published metric and ask the same question you know the answer to twice.
+
+1. **Ask once with `/ask_metrics`.** The worker matches the subject-tree path, confirms the group-by dimension, executes `query_metrics`, and returns Markdown — window, names, values, limits. No SQL dump.
+2. **Ask the same question in ordinary chat.** The conversational node decides. If it recognizes a named KPI it delegates; if it does not, it may draft from schema. Inspect which worker ran and whether SQL appeared.
+3. **Ask something that is not a KPI** — a row-level extract. AskMetrics refuses: not answerable from published metrics.
+
+That two-question contrast is the whole design: one question, two lanes, one refusal you can verify by hand. The 0.3 introduction lists every built-in; this page only needs you to feel the fork. It is not a CLI reference and not a replacement for a domain rollout plan.
+
+## Conclusion
+
+Datus subagents are the task split we are introducing on top of shared memory: AskMetrics for published KPIs, `gen_sql` for the tail, `explore` before a draft, generation workers behind a validation gate. The work they save is not clicking `/agent`. It is the Monday answer that used a certified metric because the KPI worker was not allowed to write SQL.
+
+The store those workers read is [Datus Knowledge](/blog/introducing-datus-knowledge/). The OSI authoring path that feeds AskMetrics is the [OSI semantic adapter](/blog/datus-osi-semantic-adapter/). The domain chatbot you hand a team is still [subagents as a delivery model](/blog/subagents-domain-specific-data-agents/). Use this page when you need to explain why one chat should not hold every tool.
+
+## Frequently asked questions
+
+### Is this the same as a finance or marketing subagent?
+
+Same word, different job. A domain subagent is a scoped interface you deliver to a team. A task subagent is a built-in worker (`ask_metrics`, `gen_sql`, `explore`) with a fixed tool surface. You can wrap AskMetrics as `sales_metric_qa`. You should not expect `/ask_metrics` to replace a domain rollout.
+
+### What if AskMetrics cannot find a metric?
+
+It says the question is not answerable from published metrics. It does not generate SQL. Use `gen_metrics` to draft a definition from signed-off SQL, or `gen_sql` / `explore` for work that is not a KPI.
+
+### Does chat always delegate?
+
+No. Simple questions on known tables can stay on chat. Metric-first questions can go to AskMetrics; discovery goes to `explore`; heavy SQL goes to `gen_sql`. You can also invoke a worker directly with `/name` or pin it in the web UI.
+
+### Can a subagent call another subagent?
+
+Chat can. Nested workers cannot start a third level. Most specialists may only call `explore`. That cap is how you avoid an agent of agents with no owner.
+
+### Do I need OSI to use AskMetrics?
+
+No. You need a semantic adapter and published metrics. MetricFlow authoring is enough. OSI is the portable authoring format when you want source files that are not MetricFlow YAML. Either way, AskMetrics queries what already passed validation.
+
+## Related articles
+
+- [Subagents: domain-specific data agents](/blog/subagents-domain-specific-data-agents/) — the concept behind the feature.
+- [What is a data engineering agent?](/blog/what-is-data-engineering-agent/) — the platform Subagents run on.
+- [Introducing Datus Knowledge](/blog/introducing-datus-knowledge/) — the memory Subagents read from.
+- [The Datus OSI semantic adapter](/blog/datus-osi-semantic-adapter/) — how AskMetrics resolves governed KPIs.

--- a/blog/posts/what-is-atscale.md
+++ b/blog/posts/what-is-atscale.md
@@ -1,0 +1,154 @@
+---
+title: "What Is AtScale? Enterprise Semantic Layer for BI, Excel & AI"
+description: "Virtual OLAP for Excel, Power BI, and agents — AtScale's SML, DSO pricing, MDX/DAX, and MCP, and when the cube is the wrong unit."
+author: "Kostja"
+date: 2026-08-19
+lastmod: 2026-08-19
+head:
+  - - meta
+    - name: keywords
+      content: "AtScale, AtScale semantic layer, virtual OLAP, semantic modeling language SML, MDX DAX, AtScale MCP, Excel Power BI semantic layer"
+  - - meta
+    - property: og:title
+      content: "What Is AtScale? Enterprise Semantic Layer for BI, Excel & AI"
+  - - meta
+    - property: og:description
+      content: "Virtual OLAP for Excel, Power BI, and agents — AtScale's SML, DSO pricing, MDX/DAX, and MCP, and when the cube is the wrong unit."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-atscale/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-atscale/
+---
+
+
+# What Is AtScale? Enterprise Semantic Layer for BI, Excel & AI
+
+AtScale is a universal semantic layer aimed at enterprises that still live in Excel, Power BI, and Tableau. It virtualizes multidimensional models over cloud warehouses, speaks MDX and DAX as well as SQL, and now exposes the same governed definitions to agents over MCP.
+
+## TL;DR
+
+- **AtScale** sits between Snowflake, Databricks, BigQuery (and similar platforms) and the tools executives actually open. Models stay virtual: queries push down, data is not copied into a new mart as a precondition for consistent metrics.
+- The historical wedge is **OLAP for the modern warehouse**: hierarchies, semi-additive measures, aggregate awareness, and the dialects spreadsheet users already speak (MDX, DAX), plus SQL, REST, Python, and MCP.
+- The modeling language **SML** (Semantic Modeling Language) is open source under Apache 2.0 in the <a href="https://github.com/semanticdatalayer/SML" rel="nofollow noopener">semanticdatalayer/SML</a> repository. The AtScale *platform* is not open source. Opening the language is not the same as opening the engine — a distinction buyers should keep sharp.
+- Pricing, per AtScale's public pricing page, is **Deployed Semantic Objects (DSOs)**: you pay for governed metrics, dimensions, and models published to production, not for seats, queries, dashboards, or agent calls. That is a genuine design choice with a genuine failure mode (object sprawl).
+- AtScale is the wrong default when the job is a headless API for embedded apps (Cube's home) or a SQL ontology for typed identity (Timbr's home). It is the right default when the crisis is "the CFO's Excel cube does not match Looker" and you are not willing to exile Excel.
+
+## 1. The deal AtScale closes: cube without the extract
+
+Most enterprise analytics still ends in a pivot table. Cloud warehouses did not retire that fact; they moved the extract. Teams built marts so Power BI and Excel could feel fast, then watched the marts diverge from the warehouse, then watched AI pilots query whichever copy was easiest to connect.
+
+Here is the failure in one close. A consumer-goods finance team certifies `net_revenue` as invoice amount minus returns. The "official" cube is a weekly extract into a Power Pivot model. In March the warehouse starts booking marketplace fees as a separate column that should reduce net revenue. The extract job is not updated. Tableau connected to Snowflake is right. The CFO workbook is wrong by the fee. An agent pointed at the warehouse agrees with Tableau and "contradicts" Finance. They have two cubes.
+
+AtScale's bargain is older than the agent wave and still the reason it wins deals Cube does not: **keep the multidimensional experience, lose the extract**, so Excel, Tableau, and the agent hit one virtual model. The semantic layer defines metrics, hierarchies, and relationships once. Excel and Tableau issue the dialects they already know. AtScale translates those queries into warehouse SQL with aggregate awareness so the cube is a view of live cloud data rather than a weekly dump. When that works, Finance stops maintaining a shadow warehouse in a workbook. For the category definition, see [what a semantic layer is](/blog/what-is-semantic-layer/).
+
+That is a different pain from the pain Cube optimized for (developers embedding analytics behind REST/GraphQL) and a different pain from Timbr's (agents confusing classes). Scorecards that ask "does it have MCP?" will make the three look interchangeable. CFOs who live in Excel will not.
+
+The 2026 pitch adds AI without changing the wedge. AtScale's MCP story is that agents should consume the *same* governed objects the pivot table consumes — metrics, relationships, policies — rather than generating freelance SQL against `fact_orders`. If you have already paid the political cost of getting Finance onto a certified cube, reusing that cube as agent context is rational. If you never had a cube, starting with AtScale because "MCP" appeared on a slide is how you buy an OLAP platform you will not operate.
+
+## 2. Virtual OLAP on the warehouse: MDX/DAX to SQL pushdown
+
+Call it a **virtual OLAP semantic layer**, which is how <a href="https://www.atscale.com/" rel="nofollow noopener">AtScale</a> now brands the platform for both BI and agents. Models are multidimensional: facts, dimensions, hierarchies, calculated measures, many-to-many where the language allows it. Query dialects include MDX, DAX, SQL, REST, and Python, with MCP for agents. Every dialect is a compilation problem: the engine turns a cell request from Excel or a DAX query from Power BI into efficient SQL against the warehouse, using aggregates when they exist and the base tables when they do not. The cube is recomputed on demand; the SQL is where the work happens.
+
+"Virtual" here means the semantic objects are not a mandatory physical copy of the warehouse. You still need engineering: aggregate tables, warehouse compute, model design. What you are supposed to stop doing is maintaining a second, drifting dimensional database as the price of spreadsheet access. Compare that to the classic SSAS cube, which *was* a physical store. AtScale is betting that the warehouse plus a planning layer of aggregates can replace that store for a useful class of enterprise workloads.
+
+SML is the YAML-facing way to write those models so they are Git-friendly rather than trapped in a click-ops UI. AtScale announced the open-source release in September 2024. The GitHub organization `semanticdatalayer` hosts the language spec, sample models (TPC-DS, AdventureWorks, and similar), an SDK, a CLI, and converters. As of August 2026 the SML repository is a small but active Apache-2.0 project — **170 GitHub stars**, not Cube Core's tens of thousands. That star count is information about community gravity, not about whether SML is a serious language. It is a serious language with a thin public ecosystem. Converters exist so other dialects can move toward SML; they do not make AtScale's runtime open.
+
+Deployment is Kubernetes in public cloud, private cloud, or hybrid, with marketplace listings on Snowflake and GCP in AtScale's current product writing. That matters for enterprises that will not send cube queries through a multi-tenant SaaS they do not control. It also means you are operating a platform, not dropping a YAML file into dbt Cloud.
+
+## 3. DSO pricing: the meter is the product
+
+AtScale's <a href="https://www.atscale.com/pricing/" rel="nofollow noopener">pricing page</a> is unusually explicit. Consumption is **deployed semantic objects**: metrics, dimensions, hierarchies, calculated measures, and models that are published and visible to end users in production tools. Objects in development do not count. Users, queries, dashboard counts, agent calls, and data volume do not count. Standard versus Enterprise is about capability and governance breadth, not seats.
+
+The incentive is the point. Per-seat BI pricing punishes putting the cube in front of the whole company. Per-query pricing punishes exploration and punishes agents, which are chatty. DSO pricing says: pay for the *certified surface area* you are willing to govern. That is aligned with a semantic layer's actual job.
+
+The failure mode is also the point. If every analyst publishes another calculated measure to production, the bill tracks sprawl rather than value. The monthly invoice turns into a map of it: forty DSOs billing for three measures that matter, because nobody has the authority to unpublish. DSO pricing only works if someone does — organizations that cannot retire semantic objects will experience AtScale as an unexpectedly expensive glossary. Ask, in the POC, who can delete a DSO and whether they have done it.
+
+Public list prices move and AtScale's own pricing page does not currently print a dollar-per-DSO table. Industry roundups as of mid-2026 commonly cited Growth-class floors around $2,500 per month and Standard-class floors around $7,000, with per-object rates in a roughly $10–28 per DSO per month band. Treat those figures as **directional, as-of, and quote-verified** — not as a contract. The architectural fact you can take to a design review without a quote is the meter: objects deployed, not people who touch them.
+
+## 4. Agents drink from the same well: MCP as context supply, not a new analyst UX
+
+AtScale's AI narrative is conservative in a way that is easy to underestimate. The company does not need to win "best text-to-SQL." It needs agents to stop inventing metrics that Finance already certified in the Excel cube. MCP is the pipe: the model receives approved metrics, relationships, and policies from the semantic layer instead of a raw schema dump.
+
+That is the same "LLMs should not query databases directly" thesis Cube argues, implemented for a different buyer. Cube's D3 productizes an analyst agent and an engineer agent on top of Cube models. AtScale's MCP server, in the company's own demo writing, can also *author* SML — generating hierarchies and semi-additive measures from warehouse metadata, then validating before deploy. Treat that as modeling acceleration on the same control plane, not as a Cube D3-style end-user analyst app. The durable product is still context supply: Copilot, a vendor agent, or an internal bot drinking the same objects the CFO pivot table uses. If your AI program is "we have Copilot / a vendor agent / an internal bot, and it must not disagree with the CFO workbook," AtScale's shape fits. If your AI program is "we want Cube's workbook agent and embedded analytics in our app," you are shopping in Cube's aisle.
+
+OSI status should stay honest. AtScale is in the Open Semantic Interchange working group. As of the July 2026 snapshot in our [semantic layer tools directory](/blog/semantic-layer-tools-list-osi/), it did **not** have a merged reference converter in Apache Ossie. Participation is intent. Intent is not import/export. Teams that need an exit from AtScale models into a portable format should test SML converters and OSI paths as a project, not assume them as a feature.
+
+## 5. The cube is the wrong unit for three jobs
+
+AtScale wins when the consuming population is **Excel, Power BI, and Tableau**, the grain is multidimensional (hierarchies, semi-additives, allocation), and IT will not bless another extract. It wins when identity management has to follow the user into the warehouse (impersonation, native audit). It wins when the AI requirement is "same definitions as the cube" rather than "new agent UX." But the cube is the wrong unit of work for three adjacent jobs.
+
+Cube wins when the consuming population is **applications and developers**: Postgres-compatible SQL, REST, GraphQL, embedding, pre-aggregation as a product (CubeStore), and an open-source core you can run without AtScale's control plane. See [Cube's three-era trajectory](/blog/cube-agentic-analytics/). dbt Semantic Layer wins when the consuming population is **analytics engineers already living in YAML next to transformations**, and you want MetricFlow as the metric brain with OSI converter work already merged. [Timbr](/blog/what-is-timbr/) wins a different RFP: typed ontology over SQL, inheritance, multi-source concept maps. If your incident queue is "the agent joined the wrong customer table," AtScale's cube will not forgive you for skipping classes. If your incident queue is "the Power BI dataset disagrees with SAP extracts in a workbook," Timbr will feel like a philosophy seminar.
+
+A compact chooser:
+
+- Spreadsheet-native OLAP, MDX/DAX, warehouse virtualization → AtScale
+- Headless APIs, embedding, open-source engine → Cube
+- Metrics as code beside dbt models → dbt Semantic Layer
+- Classes, relationships, inheritance as the product → Timbr
+- Producing and evolving the models those tools serve → a data engineering agent, which is a different layer than all four
+
+Datus belongs on that last line. It does not speak MDX. It does not replace AtScale in a Fortune 500 Excel estate. It is a candidate for *authoring and refreshing* semantic artifacts — including, in principle, feeding definitions toward SML or other layers — so the cube does not freeze the day after the warehouse schema changes. Use AtScale when distribution to BI is the bottleneck. Use an engineering agent when freshness of the *definitions* is the bottleneck. Enterprises usually have both bottlenecks and try to buy one tool for both.
+
+## 6. Budget the limits: closed platform, OSI yellow, DSO sprawl
+
+The platform is closed. SML's Apache license is real and useful; it is not AtScale-the-product on GitHub. Switching costs live in the runtime, the aggregate strategy, and the operational skill of the team, not only in YAML.
+
+Modeling skill is scarce. Virtual OLAP still demands grain discipline. Semi-additive measures, many-to-many, and hierarchy design are how these projects slip a quarter.
+
+OSI is yellow. Plan a portability test if lock-in is a board topic.
+
+DSO sprawl is a financial risk as well as a governance risk. Pair the purchase with a publishing policy — the meter only bills what you refuse to retire.
+
+Agents will not save a bad cube. MCP will faithfully serve whatever you certified, including a wrong hierarchy.
+
+If those limits are acceptable — and for a large class of enterprises they are — AtScale is one of the few semantic layers that takes Excel seriously without pretending the rest of the company should learn a new BI product. That seriousness is the product.
+
+## Conclusion
+
+AtScale is the enterprise semantic layer you buy when the cube is the unit of work: virtual OLAP over a cloud warehouse, MDX/DAX for the tools that already run the business, SML for Git-shaped modeling, DSO pricing for a certified surface rather than a headcount tax, MCP so agents drink from the same well. It is not Cube, not dbt, not Timbr, and not an open-source engine with a language spec taped on. Choose it for Excel-grade multidimensional access to live warehouse data. Choose something else for headless embedding, metrics-as-code, or an explicit ontology. Then fund the unglamorous owner who unpublishes objects and updates models when the schema moves — because no dialect, including DAX, will do that job for you.
+
+Next reading: [what a semantic layer is](/blog/what-is-semantic-layer/), [what Timbr is](/blog/what-is-timbr/), and the [semantic layer tools list](/blog/semantic-layer-tools-list-osi/).
+
+## Frequently asked questions
+
+### What is AtScale?
+
+AtScale is a universal semantic layer platform. It defines metrics, dimensions, and hierarchies once and serves them to BI tools (Excel, Power BI, Tableau), applications, and AI agents, translating those requests into warehouse SQL without requiring a separate extracted cube as the system of record.
+
+### Is AtScale open source?
+
+The **Semantic Modeling Language (SML)** is open source (Apache 2.0). The AtScale query engine, control plane, and product are commercial. You can write SML without buying AtScale; you cannot assume the runtime is free.
+
+### How does AtScale pricing work?
+
+AtScale meters **deployed semantic objects (DSOs)** — production-published metrics, dimensions, and models visible to end users. It does not charge per user, per query, per dashboard, or per agent call. Dollar rates are quote-specific; confirm current list or contract pricing rather than relying on roundups.
+
+### How is AtScale different from Cube?
+
+Cube is API-first and developer-centric (SQL/REST/GraphQL, CubeStore, open-source core, D3 agents). AtScale is BI-and-spreadsheet-centric (MDX/DAX, virtual OLAP, enterprise deployment). Both now talk MCP. They optimize different consumers.
+
+### Does AtScale support AI agents?
+
+Yes, by exposing governed semantic context — including via MCP — so agents use certified metrics and policies. It is a context provider for agents, not primarily a consumer-facing "chat with your data" app in the Cube D3 sense.
+
+### When should we not buy AtScale?
+
+When you need an open-source headless engine, when your consumers are embedded apps rather than Excel/Power BI, when your problem is entity identity rather than cubes, or when nobody will govern published objects. In those cases look at Cube, dbt, Timbr, or a data engineering agent respectively.
+
+## Related articles
+
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the category AtScale competes in.
+- [What is Timbr?](/blog/what-is-timbr/) — a SQL-native, ontology-based alternative.
+- [Semantic layer tools, mapped to OSI](/blog/semantic-layer-tools-list-osi/) — where AtScale fits the landscape.
+- [Cube for agentic analytics](/blog/cube-agentic-analytics/) — headless semantics for agents.

--- a/blog/posts/what-is-claude-data-plugin.md
+++ b/blog/posts/what-is-claude-data-plugin.md
@@ -1,0 +1,157 @@
+---
+title: "What Is the Claude Data Plugin? SQL, Charts & Warehouse MCP"
+description: "What Anthropic's Data plugin is: Cowork and Claude Code workflows for SQL, charts, and dashboards — plus how it differs from Genie and Cortex Analyst."
+author: "Kostja"
+date: 2026-08-22
+lastmod: 2026-08-22
+head:
+  - - meta
+    - name: keywords
+      content: "Claude Data plugin, Anthropic Data plugin, Claude Code data, Cowork, warehouse MCP, Claude SQL charts, Claude vs Genie vs Cortex Analyst"
+  - - meta
+    - property: og:title
+      content: "What Is the Claude Data Plugin? SQL, Charts & Warehouse MCP"
+  - - meta
+    - property: og:description
+      content: "What Anthropic's Data plugin is: Cowork and Claude Code workflows for SQL, charts, and dashboards — plus how it differs from Genie and Cortex Analyst."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-claude-data-plugin/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-claude-data-plugin/
+---
+
+
+# What Is the Claude Data Plugin? SQL, Charts & Warehouse MCP
+
+Anthropic's **Data plugin** is not a warehouse product named "Claude Data Agent." It is an official plugin that turns Claude — primarily in <a href="https://claude.com/product/cowork" rel="nofollow noopener">Cowork</a>, also in Claude Code — into a data-analyst collaborator: SQL, profiling, charts, HTML dashboards, and a pre-share QA pass. It becomes a [data agent](/blog/what-is-data-agent/) only to the extent you connect tools (especially a warehouse MCP server) or feed it files. The decision that matters is not the category but **where the contract lives**: the file, the query, or a governed endpoint.
+
+## TL;DR
+
+- The Data plugin is a **workflow pack**: skills plus slash commands (`/analyze`, `/explore-data`, `/write-query`, `/create-viz`, `/build-dashboard`, `/validate`). Anthropic ships it as a verified plugin; install is `claude plugins add knowledge-work-plugins/data`.
+- **Two modes.** With a warehouse MCP (Snowflake, Databricks, BigQuery, or any SQL database), Claude can explore schemas and run queries. Without one, you upload CSV/Excel or paste SQL results; Claude still writes dialect-aware SQL for you to run elsewhere.
+- It is a **client**, not a catalog object. It does not create Unity Catalog Genie Agents, Snowflake Semantic Views, or verified-query records. Those live in Databricks Genie and Cortex Analyst.
+- It is also not **Claude Code's data-engineer subagent** (a persona prompt for pipelines). That comparison lives with platform-native DE agents and Claude Code vs a data engineering agent. This plugin is analyst work: questions, viz, QA.
+- Use it for exploration, dialect-specific SQL, and file-based analysis. Its answers inherit their definition from the file or the query you pointed it at — only a governed endpoint makes a number certified.
+
+## 1. A workflow pack, not a warehouse SKU
+
+An analyst who works across files and warehouses has a fixed routine: profile a table, write Snowflake-flavored SQL, chart the result, wrap a dashboard for a stakeholder, and check whether the churn denominator silently dropped trials. A general Claude chat can do pieces of that if you prompt well. It will not remember the house style for SQL, Chart.js dashboards, or survivorship-bias checks unless you paste a novel every session.
+
+The Data plugin is Anthropic's answer to that repetition: bake analyst practice into **skills** (`sql-queries`, `data-exploration`, `data-visualization`, `statistical-analysis`, `data-validation`, `interactive-dashboard-builder`) and expose them as commands. The <a href="https://github.com/anthropics/knowledge-work-plugins/blob/main/data/README.md" rel="nofollow noopener">plugin README</a> is explicit that it is designed first for **Cowork** — Anthropic's agentic desktop/web product for knowledge work — and also runs in Claude Code.
+
+That origin explains the shape. Cowork is "hand Claude a goal across files and connectors." The Data plugin is how that goal becomes *analyst-shaped* instead of *generic-assistant-shaped*. It is closer to Type 2 in our taxonomy (analysis agent) than to a warehouse SKU. When MCP is connected it also behaves like a Type 1 query agent. The type is not the interesting part. **Where the contract lives** is.
+
+ChatGPT's file analysis (Code Interpreter / Advanced Data Analysis) is the sibling pattern: a generalist runtime plus a sandbox, excellent on a CSV, silent on your Semantic View. The Data plugin adds structured commands and MCP. Neither is Genie. Neither is Analyst.
+
+## 2. What you install: commands, skills, connectors
+
+The public directory page is <a href="https://claude.com/plugins/data" rel="nofollow noopener">claude.com/plugins/data</a>. Anthropic marks it verified. The pack is open in the knowledge-work-plugins repo; you are not buying a separate Snowflake-style SKU.
+
+**Commands** (from the README, paraphrased):
+
+| Command | Job |
+| --- | --- |
+| `/analyze` | Ad-hoc questions through full analyses |
+| `/explore-data` | Profile shape, quality, odd values |
+| `/write-query` | Dialect-aware SQL with comments and performance notes |
+| `/create-viz` | Publication-oriented Python charts |
+| `/build-dashboard` | Self-contained HTML (Chart.js, filters) |
+| `/validate` | Methodology and bias QA before you send the deck |
+
+**Warehouse path.** Point MCP at Snowflake, Databricks, BigQuery, or another SQL engine. Claude can then query, read metadata, and iterate without copy-paste. The README also lists optional MCP categories: Amplitude/Looker/Tableau, Jupyter/Hex, Sheets/Excel, Airflow/dbt/Dagster/Prefect, Fivetran/Airbyte/Stitch. Treat that list as a **capability map**, not a promise that every connector is equally mature in your tenant.
+
+**File path.** No MCP: upload or paste. Claude still writes SQL for the dialect you name ("we use Snowflake") for *you* to run. That path is how shadow analytics happens — and why platform vendors built Genie and Analyst. The plugin is honest about it. Buyers should be too.
+
+**Cowork vs Claude Code.** Cowork is the non-coding agent surface (research, files, scheduled tasks). Claude Code is the engineering agent. The same Data plugin can ride on both. If your team only has Claude Code, they can still `/write-query`. They should not confuse that with a data engineering agent that persists semantic models for the whole company, or with the [Claude Code vs data engineering agent](/blog/data-engineering-agent-vs-claude-code/) comparison.
+
+## 3. Where the contract lives: files, MCP, or a governed endpoint
+
+Every number Claude produces is defined somewhere. The question that separates the Data plugin from Genie and Analyst is not "what kind of agent is this" but **where the contract lives** — the definition that decides whether two people get the same answer.
+
+| Contract lives in | What that means | Certified number? |
+| --- | --- | --- |
+| The uploaded file | The export job decided the definition | No |
+| The SQL in a raw-MCP session | The analyst decided it, this session | No |
+| A Genie Agent's curated dataset + Metric Views | Databricks object, UC ACLs on every answer | Yes |
+| A Semantic View + verified queries | Analyst's authored View / YAML, Snowflake RBAC on generated SQL | Yes |
+| ChatGPT file analysis | The uploaded file, inside the OpenAI client | No |
+
+**File.** Upload a CSV; the definition of "converted" is whatever the export job decided. Re-export next week and it can silently change. Claude will profile it, chart it, and validate it — all of it honest, none of it certified.
+
+**Raw MCP.** Point Claude at raw warehouse tables; the definition is the SQL written this session. Dialect-correct, commented, gone tomorrow. If you connect Claude to raw Snowflake tables with no View, you have recreated schema-only text-to-SQL inside a nicer IDE.
+
+**Governed endpoint.** [Databricks Genie](/blog/what-is-databricks-genie/) is a domain-scoped lakehouse chat object (ex-Space): curated datasets, example SQL, Metric Views, and instructions, with Unity Catalog ACLs on every answer. [Cortex Analyst](/blog/what-is-cortex-analyst/) is a managed NL-to-SQL API built on a Semantic View, whose verified queries carry Snowflake RBAC and can leave an audit field like `verified_query_used` when you embed it in an app you own. The plugin is not the author here — but if you point Claude's MCP at that governed endpoint, Claude becomes a *client* of the contract, not a competitor to it.
+
+The plugin's own governance is real but local: the folder and tool permissions you grant Claude. That is not a grant on a specific warehouse table. Genie serves Databricks estates and business teams, not pipeline authoring (that's Genie Code) or other warehouses; Analyst is for governed, app-embedded NL-to-SQL, not documents or pipelines (Cortex Code). The type label — query agent vs analysis agent — matters far less than which of these three homes your number lives in.
+
+## 4. The same question, three runtimes
+
+Same question, three runtimes: "what fraction of June trials converted to a paid subscription?" The SQL is nearly identical each time. The answer's authority is not.
+
+**A. Data plugin, CSV only.** Growth exports `trial_events.csv` and `/analyze`s it in Cowork. Claude counts a trial as converted when `paid_at` is non-null and charts conversion by cohort into an HTML dashboard. The definition — what counts as converted — was applied by the export job, not by the analyst. `/validate` may catch a suspicious spike (internal test rows, trials that never started); it cannot consult a semantic layer it was never connected to. The dashboard looks executive-ready. The contract lives in the CSV.
+
+**B. Data plugin + Snowflake MCP, no View.** Claude `/write-query`s against `trials` and `subscriptions`: join on trial id, first payment inside the trial window, comments and performance notes. Idiomatic, readable — and the property of whoever wrote the join this afternoon. A different analyst can `/write-query` a different window tomorrow and no object in the warehouse will object. The plugin did its job: dialect, comments, maybe a chart. The contract was missing.
+
+**C. A Genie Agent or Analyst behind a Semantic View.** The metric `trial_conversion` is authored — the rule about what counts as converted is stored with verified SQL, not retyped. The same question returns the company definition every time. The plugin is not in the path — unless you point Claude's MCP at that governed endpoint, in which case Claude is a client of the SKU, not a competitor.
+
+The three runtimes are the buying rule. If your incident is analysts drowning in notebooks, the plugin is a fit. If your incident is the same metric quoted three different ways in one afternoon, buy the governed endpoint (or a semantic layer) and optionally let Claude sit in front of it.
+
+## 5. When the client is enough — and the shadow analytics risk
+
+The plugin is enough when the contract does not need to be governed: a small team that lives in Claude, questions that are exploratory, files that are the source of truth *this week*, or work that spans tools — a warehouse plus a CSV plus a Looker MCP. It wins on the exploratory, cross-tool jobs and on "write me the Snowflake SQL and a Chart.js page this afternoon."
+
+The shadow analytics risk is the other side. File and raw-MCP answers are computed outside the governed contract and then pasted into decks. The CSV counts `paid_at` non-null as converted; the governed metric says otherwise; two numbers for one question ship in the same slide. Nothing about the plugin stops that — it will produce the confident dashboard either way, because it cannot see a contract it was never connected to.
+
+Skip it as the *enterprise* channel when you need Unity Catalog or Horizon to be the permission system of record for every answer. Cowork permissions are real (folders, connectors, admin toggles); they are not UC grants on `finance.fct_invoices`. Skip it when you need verified queries, Metric Views, or a Conversation API branded as your company portal — those are Genie/Analyst features. Skip it when you need a producer that evolves models as schemas drift — that is a data engineering agent, not a Cowork skill pack. Datus can expose tools to Claude Desktop over MCP; that still does not make the Data plugin a Context Engine.
+
+And if you assumed "Claude Data plugin" was Anthropic's answer to Genie One, it is not a coworker SKU with Slack/mobile lakehouse chat. Cowork is the coworker; this plugin is the analyst specialty inside it.
+
+Most data teams will run **both**: Genie or Analyst for certified self-serve, the Data plugin for the messy analysis that never deserved a Space.
+
+## Conclusion
+
+The Claude Data plugin is Anthropic's analyst workflow layer on Cowork and Claude Code: commands and skills for SQL, exploration, charts, dashboards, and validation, with optional warehouse MCP. It is a strong generalist **client**. It is not [Databricks Genie](/blog/what-is-databricks-genie/), not [Cortex Analyst](/blog/what-is-cortex-analyst/), not ChatGPT-as-a-warehouse, and not a [data engineering agent](/blog/what-is-data-engineering-agent/). Connect it to a contract if the number must be the company's number. Leave it on files if the number is a prototype. Do not staff it as the only certified channel and then blame the model.
+
+## Frequently asked questions
+
+### What is the Claude Data plugin?
+
+An Anthropic-verified plugin that turns Claude into a data-analyst collaborator — SQL, profiling, visualization, HTML dashboards, and pre-share QA — mainly in Cowork, also in Claude Code.
+
+### Is it a Claude "data agent" product?
+
+No SKU by that name. It is a plugin. It behaves like a data agent when you attach warehouse MCP or data files. The agent runtime is Cowork or Claude Code.
+
+### Does it connect to Snowflake or Databricks?
+
+Yes, if you configure a warehouse MCP server. Without MCP it still writes SQL and analyzes uploads. Connecting to a warehouse is not the same as using Genie Agents or Cortex Analyst's Semantic Views.
+
+### How is this different from Claude Code?
+
+Claude Code is an engineering agent. The Data plugin is analyst workflows that can run *on* Claude Code or Cowork. A community "data-engineer" persona for pipelines is a different artifact — see §2.
+
+### How is this different from Databricks Genie or Cortex Analyst?
+
+Genie and Analyst are **platform-native query agents** with catalog objects and warehouse governance. The plugin is a **client** with skills and commands. See §3.
+
+### When should we not standardize on the Data plugin?
+
+When answers must match certified metrics for the whole company, when auditors need warehouse-native verification fields, or when you need an agent that authors and evolves semantic context rather than consuming whatever MCP you pointed at today.
+
+## Related articles
+
+- [What is a data agent?](/blog/what-is-data-agent/) — the category.
+- [What is Cortex Analyst?](/blog/what-is-cortex-analyst/) — Snowflake's managed text-to-SQL.
+- [What is Databricks Genie?](/blog/what-is-databricks-genie/) — Databricks' conversational analytics.
+- [Data engineering agent vs Claude Code](/blog/data-engineering-agent-vs-claude-code/) — where a general coding agent stops.

--- a/blog/posts/what-is-cortex-analyst.md
+++ b/blog/posts/what-is-cortex-analyst.md
@@ -1,0 +1,155 @@
+---
+title: "What Is Cortex Analyst? Snowflake Natural-Language SQL for BI"
+description: "What Cortex Analyst is: Snowflake's managed text-to-SQL API grounded in Semantic Views — verified queries, REST integration, and why it is not Cortex Code."
+author: "Kostja"
+date: 2026-08-21
+lastmod: 2026-08-21
+head:
+  - - meta
+    - name: keywords
+      content: "Cortex Analyst, Snowflake Cortex Analyst, Snowflake text-to-SQL, Semantic Views, verified query repository, Cortex Analyst vs Genie, Cortex Analyst API"
+  - - meta
+    - property: og:title
+      content: "What Is Cortex Analyst? Snowflake Natural-Language SQL for BI"
+  - - meta
+    - property: og:description
+      content: "What Cortex Analyst is: Snowflake's managed text-to-SQL API grounded in Semantic Views — verified queries, REST integration, and why it is not Cortex Code."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-cortex-analyst/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-cortex-analyst/
+---
+
+
+# What Is Cortex Analyst? Snowflake Natural-Language SQL for BI
+
+Cortex Analyst is Snowflake's fully managed text-to-SQL service: business questions in, SQL against Snowflake tables out. It is a [data agent](/blog/what-is-data-agent/) of the query-agent kind — a consumer of semantic context — delivered as a REST API you embed in Slack, Streamlit, or an internal chat, not as a generic chatbot that lives outside the warehouse.
+
+## TL;DR
+
+- **Cortex Analyst** is a Cortex feature that turns natural-language questions over **structured Snowflake data** into SQL, executed in your warehouse under existing RBAC. Snowflake positions it as a managed agentic system so teams do not have to stand up their own RAG-plus-text-to-SQL stack.
+- Grounding is the product. Schema-only NL-to-SQL misses metric grain and business process. Analyst is designed to read a **Semantic View** (recommended) or a legacy semantic-model YAML on a stage. Verified queries pin high-value questions to known-good SQL.
+- The commercial shape is **API-first**. You do not "log into Cortex Analyst" the way you log into a BI tool. You call `POST /api/v2/cortex/analyst/message` from an app you control. That is a different buyer motion from Databricks Genie, which ships a curated chat object in the platform UI.
+- **Cortex Analyst is not Cortex Code.** Analyst answers questions. Code writes pipelines and dbt. Collapsing both into "Snowflake Cortex" is how engineering pilots get staffed as self-serve BI.
+- Analyst is the right default when the system of record is Snowflake and you will maintain Semantic Views. It is the wrong default when the question must span two warehouses, or when you wanted a desktop analyst plugin with no semantic contract.
+
+## 1. The product is an API, not a chat
+
+Nobody logs into Cortex Analyst. There is no Analyst chat window in Snowsight the way there is a worksheet. The product is an endpoint: `POST /api/v2/cortex/analyst/message`, called from an application you control. Streamlit, Slack, Teams, and custom chat are the integration patterns the docs describe; none of them is a canonical UI. Analyst is sold to **builders of applications**, not only to analysts sitting in Snowsight.
+
+That shapes what an evaluation is. A team that clicks around a demo chat and never designs the host application will underuse the product and then over-blame the model. The real purchase decision is an API contract decision: which app hosts the questions, which roles may call the endpoint, and which semantic objects the endpoint may touch.
+
+Two operational facts follow from "API, not chat." First, Analyst does not copy data into a chat index as a precondition. It generates SQL and runs it in your warehouse, so latency and cost are warehouse latency and cost plus Cortex inference; capacity planning stays a Snowflake admin problem. Second, the endpoint's door policy is explicit: callers need `SNOWFLAKE.CORTEX_USER` or the narrower `SNOWFLAKE.CORTEX_ANALYST_USER`, plus usage on the Semantic View's objects (and stage `READ` if you still point at YAML files). `CORTEX_USER` is granted to `PUBLIC` by default; many enterprises revoke that and grant Analyst only to analyst roles. Skipping this step is how "we turned on Cortex" becomes "every employee can probe every semantic model."
+
+Behind the endpoint sits a managed inference runtime. Default generation uses Snowflake-hosted models (documentation cites Mistral and Meta among the mix; Snowflake may change the combination at runtime). In the default configuration, prompts and metadata used for SQL generation are described as staying inside Snowflake's governance boundary, and Snowflake states it does not train models for other customers on your Customer Data. Those are vendor security claims; put them in the review, do not treat them as a substitute for your own DPA reading.
+
+## 2. Semantic Views: the mandatory contract
+
+Worksheet autocomplete can draft SQL. It cannot be the company's self-serve analytics channel. The moment a business user types "revenue," a schema-aware model has to choose a table, a grain, a currency, and a filter for test accounts. Database DDL does not contain those rules. Snowflake's own <a href="https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-analyst" rel="nofollow noopener">Cortex Analyst documentation</a> states the problem in engineering language: generic text-to-SQL given only a schema lacks business process definitions and metric handling.
+
+The documentation therefore treats a semantic layer as mandatory infrastructure, not as an optional glossary. **Semantic Views** — schema-level objects with logical tables, dimensions, facts, metrics, and relationships — are the recommended contract. As the <a href="https://docs.snowflake.com/en/user-guide/views-semantic/overview" rel="nofollow noopener">Semantic Views</a> overview spells out, a View carries the decisions a schema cannot: business entities, metrics, joins, synonyms, custom instructions, and access modifiers (public vs private facts and metrics). Legacy YAML semantic models stored on stages still work for compatibility; new implementations should not start on the legacy path.
+
+That contract is what makes Analyst trustworthy rather than merely plausible. Analyst is Snowflake executing SQL that an LLM proposed against a contract you authored. It uses the View's metadata to generate SQL, and the SQL then runs in *your* warehouse, so compute and data access follow warehouse roles: if a role cannot `SELECT` the underlying tables, Analyst cannot magically return the rows. If you skip the contract, you have bought a hosted text-to-SQL endpoint with the same failure mode every vendor warns about.
+
+Two details decide how the contract behaves in production. First, if you register several Semantic Views, Analyst can choose among them rather than requiring the client to pass the right file on every question — convenient, and a reason to keep Views tightly scoped so "revenue" cannot jump from Finance to Growth. Second, Semantic Views support **custom instructions** (how to generate SQL, how to categorize questions). Those instructions are Snowflake-side policy. They do not automatically travel if you export the View through Ossie; that gap is documented in our [Snowflake OSI](/blog/what-is-snowflake-osi/) piece and is why "we exported YAML" is not the same as "every agent behaves the same."
+
+## 3. Verified queries: the audit field no demo can fake
+
+The contract has a second part that no schema can express: the answers that must not improvise. For those questions — a board metric, a renewal figure, a number under compliance review — you store a named, verified SQL statement next to the question in a **Verified Query Repository (VQR)**. Analyst can reuse that statement when a similar question arrives, instead of generating a fresh join.
+
+The REST response can indicate which verified query was used (`confidence.verified_query_used`). That field is the product's audit surface. High-stakes questions should light up VQR, not a novel join — and this is the difference between a demo and a governed system. In production, read the field in QA: a certified-number question that comes back with `verified_query_used: false` is a regression to investigate before the number ships, no matter how plausible the SQL looks. Demos rarely include this step. Systems that survive an audit do.
+
+Verified queries are the part of the contract you author explicitly: a subject-matter expert signs the SQL, you register it, and Analyst's confidence output tells you when it was used. That is a different accountability model from "the LLM wrote something that looks right."
+
+## 4. Cortex the umbrella: Analyst, Code, and Search
+
+"Cortex" is a brand umbrella. The SKUs do different jobs.
+
+| Product | Job | Grounding | Typical user |
+| --- | --- | --- | --- |
+| **Cortex Analyst** | Natural-language questions → SQL on structured data | Semantic View / semantic YAML + VQR | App builder + business user via your chat |
+| **Cortex Code** | Generate and operate pipelines, dbt, engineering tasks | Platform + repo context | Data engineer |
+| **Cortex Search** | Retrieval over unstructured/document indexes | Search service you provision | RAG / document Q&A |
+| **Claude Data plugin / ChatGPT file analysis** | Generalist analyst in a desktop or chat client | Whatever MCP or file you attach | Individual analyst; **no** Snowflake Semantic View unless you wire it — see [Claude Data plugin](/blog/what-is-claude-data-plugin/) |
+
+The expensive mix-up is Analyst vs Code. A team that wanted "the VP can ask revenue in Slack" and staffed a Cortex Code POC will get pipeline diffs and wonder why there is no Semantic View. A team that wanted "generate Dataform-equivalent models" and bought Analyst will get a chat API.
+
+The other mix-up is Analyst vs a generalist. The Claude Data plugin is a client-side workflow pack on Cowork / Claude Code, plus optional warehouse MCP. It can talk to Snowflake if you connect a server. It does not author Semantic Views, does not run inside Horizon as a Snowflake feature, and does not give you `verified_query_used` in a Snowflake API response. Use it for exploratory analysis. Do not use it as the enterprise certified-number channel unless you have put a semantic contract *behind* the MCP.
+
+Genie is the closest peer SKU: a warehouse-native query agent. The productization differs. Databricks leads with a curated **Genie Agent** object in the UI (and an embed API) — see [what Databricks Genie is](/blog/what-is-databricks-genie/). Snowflake leads with a **REST service** plus Semantic Views you already govern as catalog objects. If your culture is "ship a Space/Agent per domain in the lakehouse UI," Genie will feel native. If your culture is "we already have a portal, give us an API and RBAC," Analyst will feel native. Neither is a portable semantic layer for a second cloud.
+
+Snowflake's role in Open Semantic Interchange / Ossie is relevant only at the handoff. Semantic Views can import and export Ossie YAML with fidelity limits. Analyst still runs on the View inside Snowflake. Interchange does not make Analyst a multi-warehouse agent.
+
+## 5. What Analyst cannot fix
+
+The data does not live in Snowflake, or not only in Snowflake. Analyst will not become your Databricks or BigQuery agent, and no Semantic View export changes that.
+
+You refuse to maintain Semantic Views (or you planned to "let the LLM read INFORMATION_SCHEMA"). You will recreate the schema-only failure the product exists to avoid.
+
+You needed unstructured document Q&A. That is Cortex Search plus a RAG design, or a document agent, not Analyst.
+
+You needed pipeline generation. Cortex Code.
+
+You needed Excel cubes and MDX. That is a BI/semantic-layer problem, not Analyst.
+
+You needed a single portable metric document for every agent in the company. Semantic Views plus Ossie export can *move* a model; they do not *operate* Genie or Power BI Copilot. Plan the consumer per platform.
+
+And there is a limit inside the contract itself. Analyst cannot notice when the world under the View drifts. Register the View today, and a schema change tomorrow — a new marketplace-fee column, a repartitioned events table — leaves the model generating against what the View still says. Keeping the contract true is an engineering job: a data engineering agent or a human modeling sprint will catch the drift, and Analyst will not flag it on its own.
+
+Datus is not a Cortex Analyst replacement. Analyst is the Snowflake-native question runtime. Datus is a producer of evolvable semantic context — `/gen_semantic_model`, `/gen_metrics`, subject-scoped Subagents — including toward Snowflake. Use Analyst when the bottleneck is "business users have no trustworthy NL path inside Snowflake." Use a data engineering agent when the bottleneck is "the View froze the day after the schema changed." Most Snowflake estates eventually have both bottlenecks and try to buy one SKU for both.
+
+## 6. The buying test: read `verified_query_used`
+
+The fastest honest evaluation does not measure the model; it measures the contract. Wire a Streamlit app to a raw schema — `ANALYTICS.PUBLIC`, no Semantic View, "we'll add YAML later." Ask a real question: "How many accounts churned this quarter?" Analyst returns valid SQL that counts cancellation events. The number is plausible. It is also wrong: "churned" means no paid activity for 90 days, reactivations are double-counted, and internal test accounts carry no flag that DDL reveals. The SQL is valid. The class is wrong.
+
+Now register the View: `churned_accounts` as a measure with the 90-day definition, a relationship that keeps usage events from being counted as accounts, and a verified query for the board's churn number that Finance signed. Ask the same question. The response either hits the verified query or generates against the View's metrics — and the payload carries `confidence.verified_query_used`. The Streamlit UI did not change. The contract did.
+
+Run that test across your real question set and keep two numbers: how many responses light up VQR, and how many return the right answer class. Then make your QA harness read `verified_query_used` on every certified question. That is the difference between a demo and a governed system, and it is measurable.
+
+## Conclusion
+
+Cortex Analyst is Snowflake's managed query agent: natural language in, warehouse SQL out, grounded in Semantic Views and optional verified queries, consumed through a REST API you embed where the business already works. It is not Cortex Code, not Cortex Search, and not a desktop data plugin. The closest lakehouse peer is [Databricks Genie](/blog/what-is-databricks-genie/); the closest generalist client is the [Claude Data plugin](/blog/what-is-claude-data-plugin/). When Semantic Views freeze after a schema change, that is a [data engineering agent](/blog/what-is-data-engineering-agent/) problem, not an Analyst prompt problem. Buy Analyst when Snowflake is the system of record and someone will own the View the way they own a certified dashboard. Author the grain. Verify the questions that matter. Read `verified_query_used`.
+
+## Frequently asked questions
+
+### What is Cortex Analyst?
+
+Cortex Analyst is a fully managed Snowflake Cortex feature that converts natural-language questions about structured data into SQL, using a Semantic View or semantic model as grounding, and executes that SQL in your warehouse.
+
+### Is Cortex Analyst the same as Cortex Code?
+
+No. Analyst is conversational/query text-to-SQL for business questions. Cortex Code is a data-engineering agent for pipelines and transformation code. They share a brand, not a runtime.
+
+### Does Cortex Analyst need a semantic model?
+
+Practically, yes, if you want production accuracy. Snowflake recommends **Semantic Views**. Legacy YAML semantic models on stages remain supported. Schema-only use recreates the failure Analyst is meant to fix.
+
+### How do verified queries work?
+
+You store question-plus-SQL pairs (Verified Query Repository). Analyst can reuse them for similar questions. The REST response can name which verified query was used — `confidence.verified_query_used` — and that is the field to assert in QA.
+
+### Can we embed Cortex Analyst in Slack or an internal app?
+
+Yes. The product is API-first (`/api/v2/cortex/analyst/message`). Slack, Teams, Streamlit, and custom chats are documented integration patterns, not separate SKUs.
+
+### When should we not use Cortex Analyst?
+
+When the data is not in Snowflake, when you will not maintain Semantic Views, when the workload is documents or pipelines, or when you need one agent over multiple clouds. Then look at Genie, Cortex Code, Cortex Search, or a cross-stack data engineering agent.
+
+## Related articles
+
+- [What is a data agent?](/blog/what-is-data-agent/) — the category.
+- [What is Databricks Genie?](/blog/what-is-databricks-genie/) — the Databricks counterpart.
+- [What is the Claude Data plugin?](/blog/what-is-claude-data-plugin/) — Anthropic's approach.
+- [What is Snowflake OSI?](/blog/what-is-snowflake-osi/) — the Semantic Views to OSI bridge Cortex Analyst grounds on.

--- a/blog/posts/what-is-databricks-genie.md
+++ b/blog/posts/what-is-databricks-genie.md
@@ -1,0 +1,153 @@
+---
+title: "What Is Databricks Genie? Agents for Conversational Analytics"
+description: "What Databricks Genie is: domain-scoped agents (formerly Spaces) that answer with SQL and charts under Unity Catalog — and how they differ from Genie Code."
+author: "Kostja"
+date: 2026-08-20
+lastmod: 2026-08-20
+head:
+  - - meta
+    - name: keywords
+      content: "Databricks Genie, Genie Spaces, conversational analytics, Unity Catalog, text-to-SQL Databricks, Genie vs Genie Code, AI/BI Genie"
+  - - meta
+    - property: og:title
+      content: "What Is Databricks Genie? Agents for Conversational Analytics"
+  - - meta
+    - property: og:description
+      content: "What Databricks Genie is: domain-scoped agents (formerly Spaces) that answer with SQL and charts under Unity Catalog — and how they differ from Genie Code."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-databricks-genie/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-databricks-genie/
+---
+
+
+# What Is Databricks Genie? Agents for Conversational Analytics
+
+Databricks Genie is the platform's conversational [data agent](/blog/what-is-data-agent/) for business questions on lakehouse data. The object teams actually curate is now called a **Genie Agent** (formerly a Genie Space): a domain-scoped chat that returns SQL, tables, and charts, governed by Unity Catalog.
+
+## TL;DR
+
+- A **Genie Agent** is a domain-specific natural-language interface on Databricks. Users ask questions; the agent returns SQL, result tables, and visualizations. Analysts curate each agent with Unity Catalog datasets, example SQL, SQL expressions for business semantics, and written instructions in the company's language.
+- **Genie Agents were formerly Genie Spaces.** The rename matters for search, not for the core bargain: *scope the agent to a topic*, do not dump the entire lakehouse into one chatbot.
+- Genie is a **family**, not a single SKU. **Genie One** is the business-user coworker (chat across data, dashboards, apps, Slack/Teams). **Genie Agents** are the shareable, domain-scoped agents this article defines. **Genie Code** is the data engineering assistant for pipelines and Spark. **Genie Ontology** is Databricks's automatic context graph behind the answers.
+- Accuracy is a curation problem. Unscoped Genie on raw tables behaves like any schema-only text-to-SQL bot. A finance-scoped agent with verified SQL and Metric Views behaves like a governed query agent.
+- Genie is the right default when the estate already lives in Databricks and the buyer is a business team that must not write Spark. It is the wrong default when you need a portable agent across warehouses, or when the job is building pipelines rather than answering questions.
+
+## 1. The rename that matters: Spaces are now Agents
+
+Search "Genie Space" and you land on decks that say Databricks customers created more than a million of them. Search "Genie Agent" and you land on the July 2026 documentation for the same object. The name you type decides which docs, which product pages, and which demos you find. The rename is a search problem before it is a branding problem.
+
+The name you should search for is **Genie Agent**. The <a href="https://docs.databricks.com/aws/en/genie-agents/" rel="nofollow noopener">Genie Agents documentation</a> is explicit: each agent is domain-specific; authors attach Unity Catalog datasets, example queries, semantic SQL expressions, and instructions; consumers get SQL plus charts. The former name, Genie Space, remains in older decks and in Databricks's own claim that customers created more than a million Spaces. Treat "Space" and "Agent" as the same object unless a vendor diagram splits them.
+
+Why does one object need two names? Because the scoped object exists to answer a question the lakehouse cannot. A lakehouse does not automatically produce a trustworthy answer to "what was net revenue last quarter?" Unity Catalog can tell you which tables exist. It cannot tell a general-purpose model that Finance's `net_revenue` excludes marketplace fees, that Marketing's `revenue` is checkout events, and that the CEO's slide uses the Finance number. Without a scoped agent, two failure modes show up in the first week. The first is **global chat**: one assistant over every catalog, schema, and sandbox; the model picks the table whose column names look like "revenue," and the number is reproducible and wrong. The second is **shadow extracts**: analysts paste CSVs into ChatGPT or a Claude session because the official chat is untrusted. Governance did not fail at the table ACL. It failed at *which question is allowed to see which grain*.
+
+Genie's original product, AI/BI Genie, attacked that gap as conversational analytics: a chat experience sitting on curated datasets, not on the entire metastore. The rename changes the label, not the core bargain: *scope the agent to a topic*, do not dump the entire lakehouse into one chatbot. Whatever you call it, this remains a query agent in the taxonomy of data agents — a consumer of context — not a producer that authors the semantic layer for every other tool in the company.
+
+## 2. A family, not a SKU: Genie Agent, Genie One, Genie Code, Genie Ontology
+
+Search "Databricks Genie" and you will land on four names. Treating them as synonyms is how RFPs ask whether Genie "does pipelines and Slack and ontology."
+
+| Name | Buyer | Job | Not the same as |
+| --- | --- | --- | --- |
+| **Genie Agent** (ex-Space) | Domain owner + business users | Scoped Q&A with SQL/charts on curated data | A company-wide ChatGPT |
+| **Genie One** | Business users | Coworker surface: chat, dashboards, apps, Slack/Teams, mobile, MCP into other assistants | The authoring object itself |
+| **Genie Code** | Data engineers | Pipelines, Spark, notebooks — a [platform-native data engineering agent](/blog/platform-native-data-agents-compared/) | Conversational analytics |
+| **Genie Ontology** | Platform / AI owners | Automatic context graph (tables, queries, dashboards, apps) that ranks which definition to trust | A W3C ontology or a portable semantic layer |
+
+Databricks's June 2026 product blog presents Genie One, Genie Agents, and Genie Ontology as one announcement stack. Read it as packaging. Genie One is "put the coworker where work happens." Genie Agents are "turn a scoped prompt into a shareable agent that can also take actions (MCP, schedules, artifacts)." Genie Ontology is "stop hand-building all the context." The last claim is the one to test in a POC. Automatic extraction of metric meaning from dashboards and query history is valuable *and* it can encode a popular wrong definition. Authority ranking (Databricks analogizes PageRank) is a design, not a substitute for a certified `net_revenue`.
+
+Databricks published an **internal** June 2026 suite: 28 real-world analysis questions, Genie at 84.5% correct on the first attempt versus 52.4% for the strongest general-purpose coding agent in that test. Treat that as a vendor benchmark with a disclosed size, not as an industry score. It supports a directional claim you can believe without the number: a platform agent with catalog context beats a generic coding agent on warehouse questions. It does not prove Genie beats [Cortex Analyst](/blog/what-is-cortex-analyst/) on Snowflake, or that Ontology extraction replaces Metric Views.
+
+Genie Code remains a different article. If your RFP is "write and babysit Lakeflow/Spark pipelines," you are shopping Genie Code. If your RFP is "the VP of Sales asks questions in Slack," you are shopping Genie One plus a set of Genie Agents. Mixing the two produces a pilot that is good at neither.
+
+## 3. Authoring is curation, not configuration
+
+Call it a **governed, domain-scoped conversational analytics agent**. Databricks's <a href="https://www.databricks.com/product/genie/agents" rel="nofollow noopener">Genie Agents product page</a> frames it for business teams who should not open a notebook.
+
+**The authoring surface is the agent, not the prompt.** Someone with data privileges chooses which tables and views the agent may see, adds example SQL that encodes joins and filters, writes instructions ("net revenue is invoice collections minus refunds; never use `fact_web_events.amount`"), and can attach Metric Views or equivalent semantic expressions so the model is not inventing KPI math. Quality work — Databricks's own docs call it tuning, testing, and monitoring — is a job. An empty agent pointed at `main.prod.*` is a demo.
+
+**The runtime stays inside Databricks governance.** Queries run with the consumer's Unity Catalog permissions. That is the point of a platform-native agent: you do not build a second entitlement system for the chatbot. It is also the lock-in: the agent is only as portable as the catalog, the compute, and the semantic objects you authored there.
+
+**The output is inspectable SQL, not a vibe.** A serious Genie deployment shows the generated statement. If your stakeholders will not read SQL, you still need an owner who will, because "the agent said so" is not an audit trail.
+
+**Unstructured and files are add-ons, not the original wedge.** Docs now cover attaching Unity Catalog Volumes and uploading CSV/Excel alongside tables. Useful for "explain this deck against the warehouse." It does not turn Genie into a document RAG product; the center of gravity is still structured data plus instructions.
+
+**There is an API.** The Conversation API lets you embed a Genie Agent in an internal app or a bot. That is how Genie shows up in a custom portal without forcing every executive into the Databricks UI. Embed does not change the architecture: the agent is still a Databricks object with a Databricks permission boundary.
+
+Authoring is an operations loop, not a launch checkbox. Databricks documents quality tuning (metrics, business rules, verified answers), testing and monitoring, and an explicit "curate an effective agent" guide: pick a tight data slice, write instructions in the vocabulary the business actually uses, and manage agents as you would manage a certified dashboard. If your POC is a single agent over `main` with no verified answers, you have tested the model, not the product.
+
+## 4. The refusal is the product
+
+A retailer has `finance.fct_invoices` and `growth.fct_checkout_events` in the same Unity Catalog. Both have an `amount` column. The CFO asks a workspace-wide assistant: "Which category drove revenue last quarter?" The model joins checkout events to the product catalog because `category` lives on the growth tables and the question came from a retail Slack channel that also talks about conversion. The ranking is a list of merchandising categories by GMV. Finance's number — collections minus returns, excluding gift-card breakage — is never computed. Nobody violated an ACL. The agent saw both tables.
+
+A Genie Agent named `finance-revenue` is attached only to the invoice mart, a Metric View for `net_revenue`, three example SQLs that encode the return filter, and an instruction that checkout GMV is out of scope. The same question now either answers on the Finance grain or refuses and tells the user to open the growth agent. Domain-scoped agents are how you encode *which questions are legal* — and the refusal is the product working.
+
+## 5. Where the family cannot reach
+
+Every member of the family assumes the same two things: the system of record is Databricks, and someone will curate. Skip Genie Agents as the *company-wide* data agent when:
+
+The warehouse is not Databricks. Cortex Analyst, BigQuery conversational analytics, or a stack-agnostic query agent will spend the decade you would spend federating everything into Unity Catalog "so Genie can see it."
+
+The painful job is pipeline authoring and on-call. That is Genie Code, or a data engineering agent if you span more than one platform.
+
+Nobody will own curation. An uncared-for Genie Agent is a schema dump with a chat box. Unity Catalog descriptions help; they are not a semantic model.
+
+You need the same certified metric in Snowflake, a BI tool, and an external agent runtime. Genie Ontology and Metric Views are Databricks-native context. Portable interchange is a different layer — OSI / Apache Ossie — and it does not replace Databricks's agent.
+
+You wanted a generalist analyst in Claude or ChatGPT. The [Claude Data plugin](/blog/what-is-claude-data-plugin/) (Cowork / Claude Code) plus warehouse MCP is a **client**: SQL, charts, and QA against whatever you connect. It does not ship Unity Catalog, Metric Views, or curated Genie Agents. Genie is the opposite shape: the agent lives in the platform, and MCP is how *other* clients come to it.
+
+Datus does not replace Genie for a Databricks-only business user. It sits on the producer side: generating and evolving semantic models and metrics as schemas drift, so whatever consumer you run — Genie, Cortex Analyst, or an MCP client — is not guessing joins from column names. If the bottleneck is "Finance will not open Databricks," buy Genie (and staff the authors). If the bottleneck is "every agent in the company is drifting off last quarter's definitions," you have a context-evolution problem, which is a different SKU.
+
+## 6. Score a POC with one overlapping noun
+
+The refusal case doubles as the scoring rubric. Do not demo "ask anything about the lakehouse." Demo two agents — `finance-revenue` and `growth-checkout` — one overlapping business noun, and a question that must not cross the grain. The overlapping noun is `amount`. The question is the CFO's "Which category drove revenue last quarter?" A pass is the finance agent answering on the Finance grain or refusing and pointing at the growth agent. A fail is the GMV ranking coming back anyway.
+
+If the platform cannot keep those two agents from sharing a wrong table, you have bought a nicer text-to-SQL box.
+
+## Conclusion
+
+Databricks Genie, in the sense buyers mean, is a family of lakehouse-native data agents. The object to understand first is the **Genie Agent** — the domain-scoped conversational analytics surface formerly known as a Genie Space. Search for the object by its new name, curate it the way you curate a certified dashboard, and treat its refusal to answer across grains as the product working. Genie One is how business users meet that family in Slack and mobile. Genie Code is the engineering twin. Genie Ontology is the automatic context bet. The closest warehouse peer is [Cortex Analyst](/blog/what-is-cortex-analyst/); the closest generalist client is the [Claude Data plugin](/blog/what-is-claude-data-plugin/). When the job is evolving context across stacks rather than answering questions in Databricks, that is a [data engineering agent](/blog/what-is-data-engineering-agent/). Buy Genie when the question's home is Databricks and you are willing to curate agents the way you curate dashboards. Scope the agent. Name the grain. Read the SQL.
+
+## Frequently asked questions
+
+### What is Databricks Genie?
+
+Genie is Databricks's conversational analytics and data-agent family. In current docs, a **Genie Agent** is a domain-specific chat over Unity Catalog data that returns SQL, tables, and visualizations. It is the evolution of **Genie Spaces**.
+
+### What is a Genie Agent vs a Genie Space?
+
+The same product object, renamed. Older materials say Space; Databricks documentation as of July 2026 says Genie Agent. If a slide still says Space, map it to Agent unless the vendor has split the SKU in your contract.
+
+### How is Genie different from Genie Code?
+
+Genie (Agents / One) answers business questions. Genie Code writes and operates data-engineering artifacts (pipelines, Spark) on Databricks. See [platform-native data engineering agents](/blog/platform-native-data-agents-compared/) for the Code-side comparison with Cortex Code and BigQuery's DE agent.
+
+### Does Genie replace a semantic layer?
+
+No. Genie *consumes* semantic context — Metric Views, instructions, example SQL, and optionally Genie Ontology's extracted graph. Someone still has to certify `net_revenue`. Automatic ontology extraction can help and can also promote a popular wrong metric.
+
+### Can I embed Genie in my own app?
+
+Yes. Databricks documents a Conversation API and a Genie MCP app so other assistants can call Genie. Embedding does not move governance off Unity Catalog.
+
+### When should we not use Databricks Genie?
+
+When the system of record is not Databricks, when you need a pipeline agent rather than a question agent, when no one will curate domain agents, or when you need the same metric definitions outside the lakehouse. In those cases look at Cortex Analyst, a portable semantic layer, or a data engineering agent that feeds whatever consumer you already run.
+
+## Related articles
+
+- [What is a data agent?](/blog/what-is-data-agent/) — the category Genie belongs to.
+- [What is Cortex Analyst?](/blog/what-is-cortex-analyst/) — Snowflake's counterpart.
+- [What is the Claude Data plugin?](/blog/what-is-claude-data-plugin/) — Anthropic's take on the same job.
+- [Platform-native data agents compared](/blog/platform-native-data-agents-compared/) — Genie, Cortex Analyst, and the trade-offs.

--- a/blog/posts/what-is-ontology.md
+++ b/blog/posts/what-is-ontology.md
@@ -1,0 +1,166 @@
+---
+title: "What Is an Ontology? Definition, Three Productizations & AI Agents"
+description: "Ontology in data and AI: classes, relationships, and rules — and the three productizations buyers confuse in 2026: OWL/RDF, Palantir, and SQL ontologies."
+author: "Kostja"
+date: 2026-08-17
+lastmod: 2026-08-17
+head:
+  - - meta
+    - name: keywords
+      content: "ontology, ontology in data, ontology vs semantic layer, OWL RDF, Palantir Ontology, SQL ontology, knowledge graph, ontology for AI agents"
+  - - meta
+    - property: og:title
+      content: "What Is an Ontology? Definition, Three Productizations & AI Agents"
+  - - meta
+    - property: og:description
+      content: "Ontology in data and AI: classes, relationships, and rules — and the three productizations buyers confuse in 2026: OWL/RDF, Palantir, and SQL ontologies."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-ontology/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-ontology/
+---
+
+
+# What Is an Ontology? Definition, Three Productizations & AI Agents
+
+An agent reports that 400 machines are overdue for calibration. The number is precise — and the wrong set of machines, because a base class's rule was applied to subtypes that override it. This entry defines ontology in data and AI, and when agents actually need one.
+
+## TL;DR
+
+- An **ontology**, in data and AI work, is a formal, machine-readable model of a domain: the classes of things that exist, the properties they carry, the relationships allowed between them, and the rules that must hold — independent of which warehouse table stores the rows.
+- It is **not** a [semantic layer](/blog/what-is-semantic-layer/) (which maps those concepts onto executable metrics and SQL), **not** a taxonomy (which is mostly hierarchy), and **not** automatically a knowledge graph (which is one way to store and traverse the model).
+- Three productizations confuse buyers in 2026: **W3C OWL/RDF** ontologies for open-world reasoning; **Palantir Ontology** as an operational object/action/security system; and **SQL ontologies** that virtualize concepts over existing warehouses without a graph database.
+- Agents fail ontology problems as **wrong identity**, not wrong arithmetic: the metric is computed exactly, and the rows still come back from the wrong class.
+- You need an ontology when questions cross entities, subtypes, and domain boundaries. You need a semantic layer when the question is how to measure. Most production stacks need a light version of both, not a full OWL toolchain. For the dedicated comparison, see [semantic layer vs ontology](/blog/semantic-layer-vs-ontology/).
+
+## 1. Ontology: a working definition
+
+Search results still mix Aristotle, OWL primers, and Palantir screenshots. In analytics the useful sense is narrower: an argument about whether "in service" means owned by the plant, leased, or merely present on site is already an ontology dispute. The formal artifact is that argument written so software can use it.
+
+A useful working definition:
+
+> **An ontology** is a formal, machine-readable specification of a domain: the classes of things that exist (`Customer`, `Contract`, `Shipment`), the properties those classes may have, the relationships that may connect them (`Customer places Order`), and the constraints that must hold (`a Subscription cannot remain active after its Contract end date`). It answers "what is this, and how does it relate?" rather than "how do I calculate this metric in SQL?" It is implementation-independent: moving `orders` from Snowflake to BigQuery does not change whether an `Enterprise Customer` is a kind of `Customer`. It is not a semantic layer, not a catalog of tables, and not automatically a graph database — those are neighboring layers that consume or store the model.
+
+That definition has four pieces that have to travel together. Drop classes and you have a glossary. Drop relationships and you have a taxonomy. Drop constraints and you have a diagram that cannot reject illegal states. Drop machine-readability and you have a Confluence page that an agent cannot query. The reason ontologies keep reappearing in 2026 AI architecture posts is the last piece: large language models are fluent at labels and weak at identity. They will read a `calibration_policy` column as an ordinary attribute and miss that `ProductionTool` overrides it, because subtype identity is not something a column name can carry. An ontology is the place you write that a `ProductionTool` is an `Equipment` whose policy differs, unless the typed hierarchy says so.
+
+What an ontology is **not** follows directly. It does not know that `days_overdue` is computed from `calibration_certificates` filtered by `status = 'valid'`. That mapping is the job of a semantic model and the semantic layer that executes it. An ontology that tries to become the query engine usually collapses into an unmaintainable hybrid: too formal for analysts, too vague for SQL.
+
+## 2. Taxonomy, knowledge graph, semantic layer: the neighbors that get mislabeled
+
+Four terms get used as if they were synonyms. They share a family resemblance and fail different jobs.
+
+| Abstraction | Primary job | Typical artifact | What it cannot do alone |
+| --- | --- | --- | --- |
+| **Taxonomy** | Arrange concepts in a hierarchy | Industry → Sector → Ticker | Typed non-hierarchical relations (`Customer places Order`); inference beyond parent/child |
+| **Ontology** | Define classes, properties, relations, rules | OWL/RDF, SQL ontology, object model | Execute warehouse SQL; certify a KPI formula |
+| **Knowledge graph** | Store and traverse instance data as nodes and edges | Neo4j, RDF store, virtual graph | Invent the schema of meaning; a graph without an ontology is just linked rows |
+| **Semantic layer** | Map business concepts to executable metrics, dimensions, joins | MetricFlow YAML, Cube model, LookML | Reason about subtype identity ("enterprise customer") independently of a measure |
+
+Read the table as a stack, not a menu. A taxonomy is often the `is-a` slice of an ontology. A knowledge graph becomes ontological only when node and edge types are constrained. A semantic layer is the execution plane that makes `days_overdue` the same number in a dashboard and in an agent. Confusing the last two is the expensive mix-up; the dedicated comparison is in the TL;DR and FAQ.
+
+The practical test is the question you are trying to answer. "Is this row a `TestBench` or a `ProductionTool`?" is ontology. "What is the mean time between calibrations for production tools this quarter?" is semantic layer, *once* the class is defined. Teams that buy a graph database to fix inconsistent metrics usually discover they bought a store for a model they never wrote.
+
+## 3. Three productizations that RFP teams flatten into one SKU
+
+Search "ontology" in 2026 and you will land on three incompatible productizations. Treating them as one SKU is how RFPs go sideways.
+
+**W3C OWL and RDF.** The <a href="https://www.w3.org/TR/owl2-overview/" rel="nofollow noopener">OWL 2 Web Ontology Language</a> is the standards-track way to write classes, properties, and axioms so reasoners can check consistency and infer facts. RDF provides the graph data model underneath. This stack is the right tool when the domain is genuinely open-world, multi-source, and inference-heavy — life sciences, government statistical publishing, some supply-chain graphs. The cost is real: URI management, reasoner behavior, SPARQL, and a toolchain most warehouse teams do not run. OSI's ontology working group exists in part to *map* this world into analytics interchange rather than replace it; see [OSI vs RDF/OWL](/blog/osi-vs-rdf-owl/) for that bridge.
+
+**Palantir Ontology.** Palantir's Foundry Ontology is an operational system: object types, link types, actions, functions, and security bound together so applications and AIP agents can read *and write* against a live object graph. Palantir's own <a href="https://www.palantir.com/docs/foundry/architecture-center/ontology-system/" rel="nofollow noopener">architecture writing</a> states that this fourfold integration of data, logic, action, and security cannot be accomplished with a thin semantic layer. If you need writeback, kinetic actions, and object-level policy in one platform, this is the shape. If you need portable metric definitions for BI, it is the wrong purchase. The trade-off is coupling: you adopt the platform to get the ontology.
+
+**SQL ontologies / virtual knowledge graphs.** A third camp models concepts, relationships, inheritance, and measures in SQL over data that never leaves the warehouse. No SPARQL requirement, no separate graph store, traversals compiled to push-down SQL. This is the pattern [Timbr](/blog/what-is-timbr/) describes as an ontology-based semantic layer — the closest productization to what most data-engineering teams can actually operate. It is cheaper than OWL operations and less operational than Palantir, with less writeback and less formal inference. You still add a modeling layer and a governance process.
+
+The three share a claim — meaning should be explicit — and disagree about where it lives, who can query it, and whether it can act. An honest architecture review names which of the three you are buying before you compare vendors inside one camp.
+
+## 4. Open-world vs closed-world: the design input nobody declares
+
+Underneath the three productizations sits an assumption that almost never makes it into the RFP: what an unanswered question means. W3C-style OWL is typically **open-world** — if the model does not state that a `TestBench` follows the base calibration policy, a reasoner treats that as *unknown*, not as false. Warehouse SQL is **closed-world** — if the join produces no row, the answer is empty. Analytics teams almost always want closed-world execution even when they want open-world documentation. That tension is a design input, not a religious war.
+
+The three productizations map onto this line. OWL is the open-world camp by construction: its reasoners are built to leave facts undecided. SQL ontologies are the closed-world camp: every virtual concept compiles to a join, and a join with no rows returns nothing. Palantir's object graph sits between them but leans closed-world, because an operational system that lets agents act on objects cannot dispatch an action on "unknown".
+
+The default, though, is inherited rather than chosen. The warehouse behaves closed-world before anyone opens an ontology editor, and "no row means no" quietly becomes the behavior of every agent that queries it. When a certificate is absent, the agent answers "not calibrated"; a reasoner might answer "unknown". Both readings are defensible, and only one is usually declared. Teams that flatten the three SKUs into one purchase without deciding this input are buying open-world semantics while running closed-world workloads — the mismatch shows up as confidently wrong answers in the walkthrough below.
+
+## 5. Identity failures in agent pipelines: wrong subject, not wrong arithmetic
+
+A text-to-SQL pipeline has a well-known failure taxonomy: intent, schema linking, synthesis, validation. Ontology failures sit mostly in linking and in the question *behind* intent. The model heard "equipment" and linked it to a table. The table held the wrong class of rows.
+
+That is why "just add a semantic layer" is an incomplete agent strategy. The semantic layer tells the agent how to measure `days_overdue`; it does not tell it whether the subject is a `ProductionTool` or a leased unit. Agents that only consume metrics will be consistently wrong at identity even when they are consistently right at arithmetic. Agents that only consume an ontology will talk fluently about equipment and still emit SQL that ignores grain and certified filters. The architecture that holds in production is layered. The ontology constrains which entities and relationships are legal to mention. The semantic layer binds those entities to metrics and join paths. A data engineering agent *builds and refreshes* both as schemas move; analyst-facing agents *consume* them. Palantir is explicit that its Ontology is not a thin semantic layer; Timbr is explicit that a metric-only layer does not give agents a grammar of reasoning. Both claims can be true because they describe different layers.
+
+The failure shows up the same way in practice. A plant keeps `equipment`, `calibration_certificates`, and `lease_contracts`. A compliance agent is asked: "Which machines are overdue for calibration?" Without an ontology, schema linking binds "calibration" to any row with a certificate, joins by `equipment_id`, and ranks by days since the last `status = 'valid'` record. The ranking is arithmetically exact and wrong by membership. `TestBench` overrides the calibration interval it inherits, so the base-class policy is applied to rows it does not govern. Leased machines are calibrated on the vendor's system, so their certificates are absent; the query reads absence as "never calibrated" and pulls them into the list. The metric was never wrong. The class was.
+
+Two more failures share the same root. **Label collision**: `calibration` means the certificate status in the quality system, the hours booked in the maintenance system, and the lease obligation in the contracts system. Each system is locally consistent; the cross-system question — "which machines are production-ready?" — silently mixes the three readings. A semantic layer can freeze the `days_overdue` formula and still attach it to the wrong reading of machine. **Scope creep in domain agents**: a compliance agent asked to "include everything about equipment" will pull maintenance hours and contractor invoices if the only map it has is schema similarity. Domain boundaries — which classes belong to quality, which to contracts — are ontology, even when stored as a subject tree rather than OWL.
+
+With a minimal ontology the agent is not allowed to treat those rows as interchangeable. `Equipment` is a class; `ProductionTool` and `TestBench` are subtypes that inherit and override `calibration_policy`. `CalibrationCertificate` certifies an `Equipment` through a typed relationship, and `lease_contracts` changes which equipment the plant may report on. The agent queries the typed hierarchy instead of a column, and roll-up to an `EquipmentGroup` happens at a declared grain.
+
+Notice what did *not* need OWL. No open-world inference was required, and no reasoner had to prove that a test bench is equipment. The win was naming the subtype overrides and forbidding the "absence means never calibrated" reading — which is exactly the closed-world decision from the previous section. That is the production-sized ontology most data teams actually need: typed identity, not a dissertation.
+
+The same walkthrough is how you evaluate vendors. If a product can certify the calibration policy and still lets the agent rank at base-class grain, it is a metric layer doing ontology's job badly. If a product can express the class map but cannot bind the policy to the certificates SQL, it is an ontology that still needs a semantic layer.
+
+For data engineering teams the implication is unglamorous: someone has to author and evolve the class map. If you do not, every new agent re-derives it from column names. That re-derivation is cheap in a demo and expensive in a regulated metric.
+
+## 6. A light ontology before a heavy one
+
+Use an ontology-first approach when the painful questions are about **what things are**: identity, subtypes, allowed relationships, domain scope, writeback to objects. Skip a formal ontology — and invest first in a semantic layer and a metric layer — when the painful questions are about **how things are measured**: one certified `days_overdue`, consistent time grain, BI-tool agreement.
+
+A short checklist before you start an ontology program:
+
+1. Write down three questions that currently produce two conflicting "equipment" lists. If you cannot, you do not have an ontology problem yet.
+2. Name the classes and the forbidden joins in one page. If that page already matches your semantic model's entities, extend the semantic model; do not stand up a second system.
+3. Decide closed-world versus open-world *in writing*. Analytics defaults to closed-world.
+4. Decide whether you need actions/writeback (Palantir-shaped), warehouse-native SQL traversal (SQL-ontology-shaped), or interchange with existing OWL (standards-shaped).
+5. Assign an owner who will reject illegal states, not only add classes. An ontology without rejection is a second glossary.
+6. Bind each class you care about to at least one certified metric or dataset. Unbound classes become philosophy.
+
+Lightweight ontology-like structure is often enough: a subject tree of domains, typed relationships in a semantic model, and agent scope that cannot see out-of-domain tables. Heavier stacks earn their keep in multi-source enterprises where the same `Contract` must be true in CRM, ERP, and the warehouse, or where agents are allowed to *do* things to objects, not only query them.
+
+Datus's Context Engine is built for the producer side of this split. It generates and evolves semantic models and metrics from schema and SQL (`/gen_semantic_model`, `/gen_metrics`), while the Subject Tree organizes domains into a hierarchical map that behaves like a light ontology for scoping Subagents — without requiring OWL. That is a pragmatic posture, not a claim that a Subject Tree replaces Palantir or a W3C reasoner.
+
+If your crisis is that agents cannot tell a `TestBench` from a `ProductionTool`, extra metrics will not help until the class map exists. If the crisis is cube consistency in Excel, a virtual OLAP semantic layer is the more direct fix.
+
+## Conclusion
+
+An ontology is the formal account of what exists in a domain and how those things may relate. In data work it is the identity layer: classes, properties, relationships, constraints — independent of tables, and not a substitute for certified metrics. Taxonomies, knowledge graphs, and semantic layers sit beside it; Palantir, OWL, and SQL ontologies are different ways to ship it. For the measurement side, stay with the semantic layer. For the OWL interchange question, see [OSI vs RDF/OWL](/blog/osi-vs-rdf-owl/). For a SQL-native productization, see [Timbr](/blog/what-is-timbr/); for virtual OLAP, see [AtScale](/blog/what-is-atscale/). Start from the conflicting answers about what things are, not from the standards catalog.
+
+## Frequently asked questions
+
+### What is an ontology in data and AI?
+
+In data and AI, an ontology is a machine-readable model of a domain: classes of things, their properties, legal relationships, and constraints. It defines meaning and identity — what a `Customer` is — rather than how to calculate a KPI. It is independent of any one database schema.
+
+### Is an ontology the same as a semantic layer?
+
+No. A semantic layer maps business concepts onto executable metrics, dimensions, and SQL. An ontology defines the concepts and relationships themselves. They complement each other: measurement versus meaning. See [semantic layer vs ontology](/blog/semantic-layer-vs-ontology/).
+
+### Is an ontology the same as a knowledge graph?
+
+No. A knowledge graph is a way to store and traverse instance data as nodes and edges. An ontology is the schema of types and rules those nodes must obey. You can have a graph without a real ontology (linked rows, weak types) and an ontology without a dedicated graph database (SQL ontologies over a warehouse).
+
+### Do we need OWL or RDF to have an ontology?
+
+No. OWL and RDF are the standards-track languages for formal ontologies and open-world reasoning. Many teams ship ontology-like models as object types, SQL ontologies, or domain trees. Use OWL when you need reasoners, public-data interchange, or an existing RDF estate; do not start there for a warehouse KPI problem.
+
+### What is Palantir Ontology, and is that the same thing?
+
+Palantir Ontology is a productized, operational ontology: objects, links, actions, and security inside Foundry, including writeback. It is one implementation of the idea, optimized for applications and agents that act — not a generic synonym for "semantic layer," and not the same as a W3C OWL file.
+
+### Do AI agents need an ontology or a semantic layer?
+
+They need the layer that matches the failure. If the agent gets the *number* wrong, fix metrics and the semantic layer. If it gets the *subject* wrong — the wrong class, the wrong domain tables — you need an ontology or an ontology-like class map. Production systems that answer cross-entity questions usually need both, at different depths.
+
+## Related articles
+
+- [Semantic layer vs ontology](/blog/semantic-layer-vs-ontology/) — the dedicated comparison — measurement vs meaning.
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the execution plane that binds concepts to metrics and SQL.
+- [OSI vs RDF/OWL](/blog/osi-vs-rdf-owl/) — how the two generations of machine-readable meaning relate.
+- [What is Timbr?](/blog/what-is-timbr/) — a SQL-native productization of the ontology idea.

--- a/blog/posts/what-is-timbr.md
+++ b/blog/posts/what-is-timbr.md
@@ -1,0 +1,157 @@
+---
+title: "What Is Timbr? Ontology-Based Semantic Layer Built on SQL"
+description: "What Timbr.ai is: a SQL-native ontology over your warehouse — how it differs from Cube and AtScale, and when the extra layer is worth it."
+author: "Kostja"
+date: 2026-08-18
+lastmod: 2026-08-18
+head:
+  - - meta
+    - name: keywords
+      content: "Timbr, Timbr.ai, ontology-based semantic layer, SQL ontology, virtual knowledge graph, semantic layer vs Cube, semantic layer vs AtScale"
+  - - meta
+    - property: og:title
+      content: "What Is Timbr? Ontology-Based Semantic Layer Built on SQL"
+  - - meta
+    - property: og:description
+      content: "What Timbr.ai is: a SQL-native ontology over your warehouse — how it differs from Cube and AtScale, and when the extra layer is worth it."
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: og:url
+      content: https://datus.ai/blog/what-is-timbr/
+  - - meta
+    - property: og:image
+      content: https://datus.ai/logo_dark.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - link
+    - rel: canonical
+      href: https://datus.ai/blog/what-is-timbr/
+---
+
+
+# What Is Timbr? Ontology-Based Semantic Layer Built on SQL
+
+Timbr is an ontology-based semantic layer: it models business concepts, relationships, inheritance, and measures as a virtual SQL knowledge graph on top of data you already have. Its central claim is that filters are not inheritance — and that one distinction is the difference between buying a metric layer and buying a type system. The claim decides the architecture, the maintenance surface, and the buying decision, in that order.
+
+## TL;DR
+
+- **Timbr** (timbr.ai) sits virtually above warehouses and lakes. It does not copy data into a graph database and does not ask analysts to write SPARQL. Concepts and relationships are modeled in SQL; traversals compile to push-down queries on Snowflake, Databricks, BigQuery, PostgreSQL, and other sources.
+- The bet is that AI agents need a **grammar of reasoning** — what a High-Value Customer *is*, how Accounts relate to Transactions — not only a catalog of certified metrics. Cube, AtScale, and dbt MetricFlow occupy the metric-governance camp; Timbr occupies the ontology camp. Both camps are real; they are not the same product.
+- Measures and OLAP-style cubes can live *inside* the ontology, with inheritance, rather than in a separate metrics YAML. That is the overlap with a [semantic layer](/blog/what-is-semantic-layer/), not a reason to pretend the modeling paradigm is identical.
+- The honest cost: you are deploying and governing another layer. Teams with a single warehouse and a stable dimensional model often get further, faster, with Cube or dbt. Timbr starts to win when identity, subtypes, and multi-source joins are the thing agents get wrong.
+- Datus does not replace Timbr. Datus is a data engineering agent that *produces and evolves* context. Timbr is a place that context can *live* as an explicit class map. Complementary if you want both; competing only if you expected one tool to be the entire meaning stack.
+
+## 1. Filters are not inheritance: the claim that separates Timbr from metric-only layers
+
+Most of the 2025–2026 "semantic layer for AI" wave is a metric-governance wave. Define `net_revenue` once. Expose it through JDBC, SQL, GraphQL, or MCP. Stop two dashboards from disagreeing. That work is necessary. It is also incomplete for any question whose hard part is not the formula.
+
+An agent that asks "which high-value customers expanded after we changed packaging?" has to know that High-Value Customer is a *kind of* Customer, that Customers have Accounts, that Accounts have Transactions, and that "expanded" is not a column on the customer dimension. A Cube model or a MetricFlow YAML can encode a `high_value` segment as a filter. Filters are not inheritance. When the next question uses a different subtype — "strategic accounts," "resellers," "internal tenants" — the metric layer grows another boolean, and the agent still does not have a type system.
+
+Timbr's public framing splits the market into camps and puts itself in the third: ontology as the grammar, not only the vocabulary. The first camp is metric governance (dbt, Cube, AtScale, warehouse-native semantic views). The second is catalog-and-glossary context. The third starts from classes and relationships and treats metrics as objects in that model. You do not have to accept the marketing taxonomy to accept the engineering claim underneath it: **agents misfire on identity at least as often as they misfire on arithmetic.** An [ontology](/blog/what-is-ontology/) is the artifact that makes identity explicit. A metric platform is the artifact that makes measurement explicit. Buying only the second and hoping the first appears from column names is how demos look smart and production tickets pile up.
+
+## 2. A SQL ontology at query time: push-down, no graph store, no SPARQL
+
+None of this is a claim that Timbr invented ontologies. OWL has existed for decades; Palantir productized an operational object graph; knowledge-graph vendors have sold traversal for years. Timbr's specific move is to put a **SQL-native, virtual** ontology on the modern data stack so warehouse teams do not have to stand up SPARQL or ship data into Neo4j in order to get typed relationships.
+
+Timbr Intelligent Semantic Layer is a virtual modeling plane, documented as an <a href="https://timbr.ai/timbr-core/ontology-based-semantic-layer" rel="nofollow noopener">ontology-based semantic layer</a>. Concepts map to underlying tables. Relationships replace a class of JOINs at query time. Hierarchies and `is-a` inheritance let a subtype carry properties of its parent. Business rules attach to the model. SQL measures and cubes can be defined as reusable objects in the same ontology rather than in a parallel metrics project.
+
+Two implementation details matter more than the adjectives. First, **data does not move**. Timbr's <a href="https://docs.timbr.ai/doc/docs/platform/" rel="nofollow noopener">platform documentation</a> describes a virtual layer over existing databases: no mandatory ETL into a graph store. Second, **the query language stays SQL**. Graph-style navigation is compiled into source SQL and pushed down, which is why the company argues LLMs should talk to this layer in SQL rather than Cypher or SPARQL. That is a bet on what models are already good at generating, not a claim that SQL can express every graph pattern.
+
+Timbr is therefore not a database, not a BI tool, and not Palantir Foundry. Palantir Ontology integrates objects, actions, writeback, and security into an application platform; Timbr leaves systems of record where they are and puts meaning on top. Graph databases copy or stream data into a store optimized for traversal; Timbr treats the warehouse as the store. Semantic layers in the Cube/AtScale sense start from facts, dimensions, and measures; Timbr starts from concepts and treats measures as part of the ontology. If a vendor comparison flattens all four into "semantic layer," the RFP will select on logo familiarity and miss the architecture.
+
+Consumption is deliberately broad in the pitch: SQL, BI, REST/OpenAPI, agents, and LLMs against one governed model. Treat that list as a capability map, not a promise that every connector is equally mature. The architectural point is single-model, many consumers — the same point Cube makes from the API side and AtScale makes from the MDX/DAX side. Timbr's differentiator is what the model *contains* (classes, relations, inheritance, rules, measures) rather than how many dialects it speaks.
+
+## 3. The maintenance surface: cloned KPIs vs subtype tickets
+
+Start from a familiar warehouse: `customers`, `accounts`, `orders`, `order_lines`, `products`. A dimensional semantic layer maps these to a sales cube. A SQL ontology names `Customer`, `Account`, `Order`, `Product` as concepts, maps them to those tables, and declares that `Customer` has `Account`, `Account` places `Order`, `Order` contains `Product`. A `StrategicAccount` *is a* `Account` with extra properties. A measure such as `net_revenue` can hang on `Order` and inherit filters from parent concepts instead of being rewritten per subtype.
+
+When an analyst or agent asks for net revenue of strategic accounts in EMEA, the engine is not hoping the LLM remembers the join path. The relationship is in the model. The subtype is in the model. The measure is in the model. The generated SQL is still warehouse SQL — Timbr is not introducing a new execution engine in the SPARQL sense — but the *choice* of joins and grain is constrained before generation, which is the same safety idea Cube uses when it insists agents query the semantic layer rather than raw tables. The constraint language is different: types and inheritance versus cubes and measures.
+
+That difference shows up in maintenance. Adding `Reseller` as a kind of `Customer` is an ontology change. In a metric-only layer it is often a new dimension value plus a new filtered metric, copied from the last filtered metric, drifting the week someone edits only one of them. Inheritance is not magic — someone still has to model `Reseller` correctly — but it is a different failure surface. You get fewer cloned KPIs and more "the subtype was wrong" tickets. Teams should pick the failure surface they would rather debug.
+
+The asymmetry is easiest to see in a POC. A happy-path NL question makes every layer look fine; the differentiator appears when the schema changes — `dim_account` grows a reseller flag, or one "customer" class splits into two subtypes. In the metric layer that means cloning and re-filtering every dependent KPI and hoping the copies stay in sync. In the ontology it means declaring the new subtype and letting inheritance carry the old definitions — which is when you discover who is actually allowed to edit the model. If the ontology cannot be updated without a specialist week, you have bought a beautiful constraint system you will work around.
+
+## 4. Timbr vs Cube vs AtScale: three answers to three questions
+
+A head-to-head only helps if each product is allowed to win its home game.
+
+| Dimension | Timbr | Cube | AtScale |
+| --- | --- | --- | --- |
+| **Home game** | Typed concepts, relationships, inheritance over live warehouse data | Headless metrics APIs, pre-aggregation, embedded/agentic analytics | Virtual OLAP for Excel, Power BI, Tableau; MDX/DAX |
+| **Modeling unit** | SQL ontology concepts and relations | Cube data models (YAML/JS/Python) | Multidimensional models / SML |
+| **Data movement** | Virtual; push-down SQL | Queries sources; CubeStore caches aggregates | Virtual; query pushdown / aggregate awareness |
+| **Graph store required?** | No | No | No |
+| **Primary consumer historically** | SQL, BI, APIs, agents | Apps, embedded analytics, BI, agents | Spreadsheet and enterprise BI users |
+| **AI hook** | LLM-agnostic agents + SQL/GraphRAG on the ontology | D3 agents + MCP/SQL/REST on the semantic layer | MCP + governed metrics/context |
+| **Open source core** | Commercial platform (SQL-ontology approach is the IP) | Cube Core Apache 2.0 | Platform closed; SML language Apache 2.0 |
+| **When it is the wrong tool** | Simple single-star-schema metric consistency | Excel-native OLAP / MDX estates | Teams that need an explicit class/inference model |
+
+Cube remains the better default when the job is **serve the same metric to many applications with caching and a broad API surface**. That is a real advantage: Cube Core is open source, the consumption story is mature, and D3 is an agent product on top of a semantic layer rather than a graph pitch. AtScale remains the better default when the job is **leave analysts in Excel and Power BI without extracting a new warehouse mart**. Timbr is the better default when the job is **stop agents from treating three customer tables as one class**, especially across more than one platform.
+
+None of the three is "the semantic layer." They are three answers to three questions. Pretending otherwise produces spreadsheet scorecards where Timbr loses on CubeStore latency and Cube loses on OWL-style inference — categories neither product was designed to win.
+
+The same honesty runs the other way, so write this down before a POC. Timbr is dead weight when:
+
+- The metric problem is the *only* problem. If Finance and Growth disagree about `net_revenue` and agree about what a customer is, buy a metric layer. Ontology modeling will feel like ceremony.
+- The estate is one warehouse, one star schema, and one BI tool. Cube or dbt Semantic Layer plus discipline will ship faster. Timbr's own writing admits the extra layer is not free and that native warehouse agents are a reasonable start for simple, single-platform needs. Believe them.
+- The team cannot staff model ownership. An ungoverned ontology is a second undocumented schema. Inheritance amplifies mistakes: a wrong parent poisons every subtype.
+- You need operational writeback, actions, and object-level applications. That is Palantir's shape, not a virtual SQL layer's.
+- You need a public OWL reasoner and RDF interchange as the system of record. Timbr can <a href="https://timbr.ai/solutions/owl-to-sql-ontologies-upgrade/" rel="nofollow noopener">import OWL and map it into SQL ontologies</a>; that is a migration path, not a replacement for a Semantic Web stack, and it should not be sold as one.
+
+If those bullets describe you, Timbr is not "worse Cube." It is a different layer you do not need yet. Decide the layer first — the [ontology definition](/blog/what-is-ontology/) and the [semantic layer vs ontology](/blog/semantic-layer-vs-ontology/) comparison — then pick a vendor inside it.
+
+## 5. GraphRAG: a retrieval prior for wrong joins, not a document index
+
+Timbr also talks about GraphRAG: retrieval that can walk relationships because the ontology is explicit, while the actual fetch is still SQL against the warehouse. Evaluate that as a pattern, not as a benchmark score. If your RAG corpus is documents, a SQL ontology will not magically become a document index. If your RAG corpus is structured enterprise data and the misses are wrong joins, walking typed relationships is a better retrieval prior than embedding table names.
+
+That is a narrow but real use. The failure being fixed is not "the model could not find the text" — it is "the model picked a join path that does not exist in the business." An ontology changes the space the retriever searches: instead of nearest text over embedded table names, the search runs over relationships the organization has already declared. A document corpus will not benefit, and a vector store will not get faster. What improves is the prior — the agent stops guessing which tables connect and starts walking the ones that are modeled.
+
+## 6. The producer problem: who keeps the class map true
+
+Timbr's agents, in the company's telling, generate governed SQL against the ontology. Cube's D3 agents generate Semantic SQL against cubes. Warehouse-native agents generate SQL against tables, sometimes with a semantic view in the middle. The pattern is identical: **do not let the model see raw schema as the only map.** The disagreement is which map is sufficient.
+
+A [data engineering agent](/blog/what-is-data-engineering-agent/) is still doing a different job from all three. It is supposed to *create and refresh* the map as schemas drift, metrics get redefined, and yesterday's "customer" splits into two classes. A virtual ontology that nobody updates is a more elegant way to be stale. The producer question — who notices that `dim_account` grew a reseller flag and that `Reseller` should become a class — is not answered by Timbr's existence any more than Cube's API answers who authors the YAML.
+
+That is the Datus-shaped hole, described without pretending Timbr is deficient at being Timbr. Datus generates semantic models and metrics from schema and SQL and keeps a subject-tree map of domains so Subagents do not wander. If an organization runs Timbr, the engineering agent should be feeding and validating the ontology, not bypassing it. If an organization runs Cube, the same agent should be feeding cubes. The consumer product does not erase the producer problem.
+
+## Conclusion
+
+Timbr is a SQL-native, virtual ontology sitting on the warehouse: concepts, relationships, inheritance, rules, and measures, queried in SQL, without a mandatory graph database. It is the most direct commercial answer to the complaint that metric-only semantic layers do not give agents a type system. It is not a drop-in Cube alternative, not an AtScale alternative for Excel cubes, and not Palantir. Buy it when identity and multi-source meaning are the incident class you cannot close with another certified KPI. Skip it when measurement consistency on a single star schema is the whole job. And whatever you buy, budget the unfashionable work of keeping the model true after the first demo.
+
+Next reading: [what an ontology is](/blog/what-is-ontology/), [semantic layer vs ontology](/blog/semantic-layer-vs-ontology/), and [what a semantic layer is](/blog/what-is-semantic-layer/).
+
+## Frequently asked questions
+
+### What is Timbr.ai?
+
+Timbr is an ontology-based semantic layer. It models business concepts, relationships, hierarchies, and measures as a virtual SQL knowledge graph over existing warehouses and lakes, without moving data into a separate graph store.
+
+### How is Timbr different from Cube?
+
+Cube is a headless semantic layer and agentic analytics platform: metrics, dimensions, APIs, caching. Timbr is a SQL ontology: classes, relationships, inheritance, with measures inside that model. Cube wins distribution and open-source core. Timbr wins typed identity. See [Cube.dev's trajectory](/blog/cube-agentic-analytics/).
+
+### How is Timbr different from a graph database?
+
+Timbr is not a database. Graph databases store nodes and edges, usually by ingesting data. Timbr maps an ontology onto tables that stay where they are and compiles traversals to source SQL.
+
+### Does Timbr replace a semantic layer?
+
+It *is* a semantic layer of a particular kind — ontology-based — and it can host SQL measures and cubes. It does not replace a Cube or AtScale deployment if your requirement is their consumption surface (embedded APIs, MDX/DAX). It can replace a metric-only layer if your requirement is an explicit class map.
+
+### Is Timbr open source?
+
+The product is a commercial platform. The approach (SQL ontologies over warehouses) is documented publicly; do not confuse that with Cube Core's Apache-2.0 engine or AtScale's open-sourced SML language spec.
+
+### When should a data team skip Timbr?
+
+When the disagreement is only KPI formulas; when one warehouse and one BI tool already agree on entities; when nobody will own the ontology; or when you need Palantir-style writeback. Start with [what is an ontology](/blog/what-is-ontology/), then choose a productization.
+
+## Related articles
+
+- [What is a semantic layer?](/blog/what-is-semantic-layer/) — the category Timbr sits in.
+- [What is an ontology?](/blog/what-is-ontology/) — the identity layer Timbr productizes in SQL.
+- [Semantic layer vs ontology](/blog/semantic-layer-vs-ontology/) — measurement vs meaning, side by side.
+- [Cube for agentic analytics](/blog/cube-agentic-analytics/) — a headless alternative modeling approach.

--- a/scripts/build-blog.mjs
+++ b/scripts/build-blog.mjs
@@ -48,13 +48,14 @@ const CATEGORIES = [
       "build-your-first-data-engineering-agent", "data-engineering-agent-vs-claude-code",
       "data-engineering-agent-vs-sql-copilot", "one-person-data-team", "context-engine-data-engineering-agent-accuracy",
       "mcp-data-engineering", "enterprise-data-engineering-agent", "subagents-domain-specific-data-agents",
-      "best-data-engineering-agents", "ai-native-data-platforms", "platform-native-data-agents-compared"] },
+      "best-data-engineering-agents", "ai-native-data-platforms", "platform-native-data-agents-compared",
+      "what-is-databricks-genie", "what-is-cortex-analyst", "what-is-claude-data-plugin"] },
   { label: "Semantic Layer", description: "What a semantic layer is, and how it differs from a metric layer, model, ontology, or catalog.",
     slugs: ["what-is-semantic-layer", "what-is-metric-layer", "what-is-semantic-model", "semantic-layer-vs-ontology",
       "open-semantic-interchange-osi", "what-is-snowflake-osi", "osi-vs-metricflow", "osi-vs-dbt-metricflow", "osi-vs-lookml",
       "osi-vs-warehouse-native-semantics", "osi-vs-rdf-owl", "osi-vs-cube", "semantic-vs-syntactic-interoperability",
       "dbt-semantic-layer-metricflow", "cube-agentic-analytics", "what-is-gooddata",
-      "semantic-layer-tools-list-osi"] },
+      "semantic-layer-tools-list-osi", "what-is-ontology", "what-is-timbr", "what-is-atscale"] },
   { label: "Glossary", description: "Core data engineering terms — defined, with how they connect to agents and context.",
     slugs: ["what-is-text-to-sql", "what-is-schema-linking", "rag-data-engineering", "what-is-data-catalog",
       "what-is-data-mesh", "what-is-data-agent", "what-is-lakehouse", "what-is-lakehouse-catalog",
@@ -78,7 +79,8 @@ const CATEGORIES = [
     slugs: ["data-engineering-agent-use-cases", "the-operating-model-of-an-agentic-data-team",
       "make-data-agents-truly-usable-ask-explore-and-control-with-confidence"] },
   { label: "Releases", description: "What's new in Datus.",
-    slugs: ["datus-0-2-6-release-equipping-the-agent-with-a-brain"] },
+    slugs: ["introducing-datus-subagents", "introducing-datus-knowledge", "datus-osi-semantic-adapter",
+      "datus-0-2-6-release-equipping-the-agent-with-a-brain"] },
 ];
 
 // slug -> category label, for the hero eyebrow badge. First category wins.


### PR DESCRIPTION
Publishes 9 house-style, SEO-optimized posts from the operator's numbered drafts (40–48). One batch PR (same pattern as #70).

## Posts

**Semantic Layer**
- `what-is-ontology` — ontology in data/AI; three productizations (OWL/RDF, Palantir, SQL ontologies); identity vs measurement; agent identity failures.
- `what-is-timbr` — Timbr.ai as a SQL-native ontology-based semantic layer; vs Cube/AtScale.
- `what-is-atscale` — AtScale virtual OLAP for Excel/Power BI/agents; SML, MDX/DAX, MCP.

**Data Engineering Agent**
- `what-is-databricks-genie` — Genie (formerly Spaces) conversational analytics under Unity Catalog; vs Genie Code.
- `what-is-cortex-analyst` — Snowflake managed text-to-SQL grounded in Semantic Views; vs Cortex Code.
- `what-is-claude-data-plugin` — Anthropic's Data plugin (Cowork + Claude Code) for SQL/charts/warehouse MCP.

**Releases (Datus features)**
- `introducing-datus-knowledge` — the memory layer for the data engineering agent.
- `datus-osi-semantic-adapter` — OSI in, MetricFlow out; vendor-neutral YAML.
- `introducing-datus-subagents` — task subagents (AskMetrics, gen_sql, explore) in Datus 0.3.

## Wiring
- Added all 9 slugs to the correct `CATEGORIES` in `scripts/build-blog.mjs`.
- Internal links normalized to short trailing-slash form `/blog/<slug>/`; `## Related articles` added to each; frontmatter converted to house format (keywords + OG/Twitter + canonical).
- No glossary cross-links (no matching `/glossary` terms for these topics).

## Verification
- `npm run build:all` succeeds (81 posts). All 9 pages return 200 at `http://localhost:4173/blog/<slug>/`.
- All 9 present in generated `dist/blog/sitemap.xml`; index references it. FAQPage JSON-LD + canonical verified.
- Internal-link integrity check: 0 broken targets across the batch.

Sitemaps are generated into `dist/` at build time — not hand-edited.