### PR TITLE
feat(databases): add the Apache Doris adapter (EN + /zh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,8 @@ page.
 | governance | 治理 | |
 | long-running agents | 长时运行 Agent | |
 | warehouse | 数仓 / 数据仓库 | 数仓 when the context is clear |
+| lakehouse / lakehousing | 湖仓 / 湖仓一体 | 湖仓一体 for the capability, 湖仓 as a modifier |
+| hybrid search | 混合检索 | never 混合搜索 |
 | catalog | 数据目录 | |
 | MCP (Model Context Protocol) | MCP | do not expand in headings |
 | adapter | 适配器 | database support is always adapters — **not** "MCP connectors" |

--- a/databases/index.html
+++ b/databases/index.html
@@ -7,7 +7,7 @@
     <title>Supported Databases — Datus</title>
     <meta
       name="description"
-      content="Datus supports 11+ databases out of the box, including SQLite, DuckDB, PostgreSQL, MySQL, Snowflake, StarRocks, ClickHouse, ClickZetta, Hive, Spark, and Trino."
+      content="Datus supports 12+ databases, including SQLite, DuckDB, PostgreSQL, MySQL, Snowflake, StarRocks, Apache Doris, ClickHouse, ClickZetta, Hive, Spark, and Trino."
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
     <meta name="author" content="Datus" />

--- a/scripts/lib/i18n-shells.mjs
+++ b/scripts/lib/i18n-shells.mjs
@@ -15,7 +15,7 @@ import { dirname, join } from "node:path";
 // `<lastmod>` for the marketing pages — the date this copy last changed, which
 // is deliberately independent of the blog's own BUILD_DATE in build-blog.mjs.
 // Bump it when marketing copy changes materially.
-const BUILD_DATE = "2026-08-07";
+const BUILD_DATE = "2026-08-20";
 
 const escapeAttr = (s) =>
   String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/src/i18n/pageMeta.ts
+++ b/src/i18n/pageMeta.ts
@@ -74,7 +74,7 @@ export const ZH_PAGE_META: Record<string, PageMeta> = {
   "/databases/": {
     title: "支持的数据库 — Datus",
     description:
-      "Datus 开箱支持 11+ 种数据库，包括 SQLite、DuckDB、PostgreSQL、MySQL、Snowflake、StarRocks、ClickHouse、ClickZetta、Hive、Spark 与 Trino。",
+      "Datus 开箱支持 12+ 种数据库，包括 SQLite、DuckDB、PostgreSQL、MySQL、Snowflake、StarRocks、Apache Doris、ClickHouse、ClickZetta、Hive、Spark 与 Trino。",
     ogTitle: "支持的数据库 — Datus",
     ogDescription:
       "把 Datus 接入你的数据栈——从嵌入式 SQLite 到 Snowflake、StarRocks 这样的云数仓。",

--- a/src/pages/databases/Page.tsx
+++ b/src/pages/databases/Page.tsx
@@ -65,7 +65,7 @@ export default function DatabasesPage() {
       <CatalogSection alt>
         <div className="grid grid-4">
           {databases.map((db, i) => {
-            const tone = toneAt(i);
+            const tone = db.tone ?? toneAt(i);
             return (
               <SpecCard
                 key={db.type}

--- a/src/pages/databases/content.ts
+++ b/src/pages/databases/content.ts
@@ -12,6 +12,8 @@ export type DbEntry = {
   pkg: string;
   builtIn: boolean;
   since?: string;
+  /** Accent override; unset means the decorative cyan/amber/green/pink rotation. */
+  tone?: string;
   highlight: string;
 };
 
@@ -36,6 +38,9 @@ const ADAPTER_META = [
   { name: "MySQL", type: "mysql", pkg: "datus-mysql", builtIn: false },
   { name: "Snowflake", type: "snowflake", pkg: "datus-snowflake", builtIn: false },
   { name: "StarRocks", type: "starrocks", pkg: "datus-starrocks", builtIn: false },
+  // Amber to match StarRocks — same Cloud Warehouse tier. The positional
+  // rotation would land Doris on green, which reads as Lake & Distributed.
+  { name: "Apache Doris", type: "doris", pkg: "datus-doris", builtIn: false, tone: "var(--term-amber)" },
   { name: "ClickHouse", type: "clickhouse", pkg: "datus-clickhouse", builtIn: false, since: "v0.2.6" },
   { name: "ClickZetta", type: "clickzetta", pkg: "datus-clickzetta", builtIn: false },
   { name: "Hive", type: "hive", pkg: "datus-hive", builtIn: false, since: "v0.2.6" },
@@ -51,6 +56,7 @@ function databaseList(builtInLabel: string, highlights: string[]): DbEntry[] {
     pkg: "pkg" in m ? m.pkg : builtInLabel,
     builtIn: m.builtIn,
     since: "since" in m ? m.since : undefined,
+    tone: "tone" in m ? m.tone : undefined,
     highlight: highlights[i],
   }));
 }
@@ -108,7 +114,7 @@ const EN: DatabasesCopy = {
   hero: {
     eyebrow: "Databases",
     heading: "Supported Databases",
-    lead: "Eleven native database adapters, from embedded SQLite and DuckDB to cloud warehouses (Snowflake, StarRocks, ClickZetta) and lake engines (Hive, Spark, Trino, ClickHouse). All plug in via Python entry points — no adapter code required on your side.",
+    lead: "Twelve native database adapters, from embedded SQLite and DuckDB to cloud warehouses (Snowflake, StarRocks, Apache Doris, ClickZetta) and lake engines (Hive, Spark, Trino, ClickHouse). All plug in via Python entry points — no adapter code required on your side.",
   },
   builtIn: "Built-in",
   databases: databaseList("Built-in", [
@@ -118,6 +124,7 @@ const EN: DatabasesCopy = {
     "INFORMATION_SCHEMA + SHOW CREATE for rich metadata.",
     "Native SDK with Arrow transport for fast reads.",
     "Multi-catalog + materialized views, MySQL-wire.",
+    "Lakehousing, materialized views and hybrid search.",
     "HTTP protocol; database ≡ schema, lightweight DELETE.",
     "Workspace + Volume/Stage ops; lakehouse partner.",
     "HiveServer2 / Thrift with LDAP & Kerberos auth.",
@@ -131,7 +138,7 @@ const EN: DatabasesCopy = {
   },
   categories: [
     { title: "Relational", body: "PostgreSQL, MySQL — the classic OLTP stack with rich metadata endpoints." },
-    { title: "Cloud Warehouse", body: "Snowflake, StarRocks, ClickZetta — MPP engines with catalog + workspace models." },
+    { title: "Cloud Warehouse", body: "Snowflake, StarRocks, Apache Doris, ClickZetta — MPP engines with catalog + workspace models." },
     { title: "Lake & Distributed", body: "Hive, Spark, Trino — Thrift and HTTP engines over your data lake." },
     { title: "Analytical & Embedded", body: "DuckDB, ClickHouse, SQLite — from local files to columnar OLAP." },
   ],
@@ -165,7 +172,7 @@ const ZH: DatabasesCopy = {
   hero: {
     eyebrow: "数据库",
     heading: "支持的数据库",
-    lead: "十一个原生数据库适配器，从嵌入式的 SQLite、DuckDB，到云数仓（Snowflake、StarRocks、ClickZetta），再到湖上引擎（Hive、Spark、Trino、ClickHouse）。全部通过 Python entry points 接入——你这边不用写任何适配器代码。",
+    lead: "十二个原生数据库适配器，从嵌入式的 SQLite、DuckDB，到云数仓（Snowflake、StarRocks、Apache Doris、ClickZetta），再到湖上引擎（Hive、Spark、Trino、ClickHouse）。全部通过 Python entry points 接入——你这边不用写任何适配器代码。",
   },
   builtIn: "内置",
   databases: databaseList("内置", [
@@ -175,6 +182,7 @@ const ZH: DatabasesCopy = {
     "通过 INFORMATION_SCHEMA + SHOW CREATE 获取丰富元数据。",
     "原生 SDK 配合 Arrow 传输，读取更快。",
     "多 catalog + 物化视图，走 MySQL 协议。",
+    "湖仓一体、物化视图与混合检索。",
     "HTTP 协议；database 等同 schema，支持轻量 DELETE。",
     "工作空间 + Volume/Stage 操作；湖仓生态伙伴。",
     "HiveServer2 / Thrift，支持 LDAP 与 Kerberos 认证。",
@@ -188,7 +196,7 @@ const ZH: DatabasesCopy = {
   },
   categories: [
     { title: "关系型", body: "PostgreSQL、MySQL——经典 OLTP 组合，元数据接口丰富。" },
-    { title: "云数仓", body: "Snowflake、StarRocks、ClickZetta——带 catalog 与工作空间模型的 MPP 引擎。" },
+    { title: "云数仓", body: "Snowflake、StarRocks、Apache Doris、ClickZetta——带 catalog 与工作空间模型的 MPP 引擎。" },
     { title: "湖与分布式", body: "Hive、Spark、Trino——架在数据湖之上的 Thrift 与 HTTP 引擎。" },
     { title: "分析型与嵌入式", body: "DuckDB、ClickHouse、SQLite——从本地文件到列式 OLAP。" },
   ],

--- a/src/pages/databases/faq.ts
+++ b/src/pages/databases/faq.ts
@@ -7,7 +7,7 @@ import type { Locale } from "../../i18n/config";
 const EN: FaqItem[] = [
   {
     q: "Which databases does Datus support out of the box?",
-    a: "Datus supports 11+ databases: SQLite, DuckDB, PostgreSQL, MySQL, Snowflake, StarRocks, ClickHouse, ClickZetta, Hive, Spark and Trino. SQLite and DuckDB are built in; the rest ship as installable adapters (datus-postgresql, datus-snowflake, and so on).",
+    a: "Datus supports 12+ databases: SQLite, DuckDB, PostgreSQL, MySQL, Snowflake, StarRocks, Apache Doris, ClickHouse, ClickZetta, Hive, Spark and Trino. SQLite and DuckDB are built in; the rest ship as installable adapters (datus-postgresql, datus-snowflake, and so on).",
   },
   {
     q: "How do I install a database adapter?",
@@ -30,7 +30,7 @@ const EN: FaqItem[] = [
 const ZH: FaqItem[] = [
   {
     q: "Datus 开箱支持哪些数据库？",
-    a: "Datus 支持 11 种以上数据库：SQLite、DuckDB、PostgreSQL、MySQL、Snowflake、StarRocks、ClickHouse、ClickZetta、Hive、Spark 和 Trino。其中 SQLite 与 DuckDB 是内置的，其余以可安装适配器的形式提供（datus-postgresql、datus-snowflake 等）。",
+    a: "Datus 支持 12 种以上数据库：SQLite、DuckDB、PostgreSQL、MySQL、Snowflake、StarRocks、Apache Doris、ClickHouse、ClickZetta、Hive、Spark 和 Trino。其中 SQLite 与 DuckDB 是内置的，其余以可安装适配器的形式提供（datus-postgresql、datus-snowflake 等）。",
   },
   {
     q: "怎么安装数据库适配器？",

--- a/src/pages/products/cli/faq.ts
+++ b/src/pages/products/cli/faq.ts
@@ -12,7 +12,7 @@ const EN: FaqItem[] = [
   },
   {
     q: "Does Datus CLI work with my existing warehouse?",
-    a: "Yes. Every database is a native Datus adapter: SQLite and DuckDB are built in, and Snowflake, PostgreSQL, MySQL, ClickZetta, StarRocks, ClickHouse, Hive, Spark and Trino ship as installable adapter packages (datus-snowflake, datus-trino, and so on). You point the CLI at your catalog or JDBC connection—no need to migrate data. Custom DB adapters can be added via the plugin architecture described in the GitHub repo.",
+    a: "Yes. Every database is a native Datus adapter: SQLite and DuckDB are built in, and Snowflake, PostgreSQL, MySQL, ClickZetta, StarRocks, Apache Doris, ClickHouse, Hive, Spark and Trino ship as installable adapter packages (datus-snowflake, datus-trino, and so on). You point the CLI at your catalog or JDBC connection—no need to migrate data. Custom DB adapters can be added via the plugin architecture described in the GitHub repo.",
   },
   {
     q: "How is Datus CLI different from Datus Studio?",
@@ -35,7 +35,7 @@ const ZH: FaqItem[] = [
   },
   {
     q: "Datus CLI 能接我现有的数仓吗？",
-    a: "可以。所有数据库都通过 Datus 原生适配器接入：SQLite 与 DuckDB 是内置的，Snowflake、PostgreSQL、MySQL、ClickZetta、StarRocks、ClickHouse、Hive、Spark 与 Trino 则以可安装的适配器包形式提供（datus-snowflake、datus-trino 等）。你只需把 CLI 指向自己的数据目录或 JDBC 连接，不需要迁移数据。自定义数据库适配器可以按 GitHub 仓库中的插件架构自行扩展。",
+    a: "可以。所有数据库都通过 Datus 原生适配器接入：SQLite 与 DuckDB 是内置的，Snowflake、PostgreSQL、MySQL、ClickZetta、StarRocks、Apache Doris、ClickHouse、Hive、Spark 与 Trino 则以可安装的适配器包形式提供（datus-snowflake、datus-trino 等）。你只需把 CLI 指向自己的数据目录或 JDBC 连接，不需要迁移数据。自定义数据库适配器可以按 GitHub 仓库中的插件架构自行扩展。",
   },
   {
     q: "Datus CLI 和 Datus Studio 有什么区别？",


### PR DESCRIPTION
Adds **Apache Doris** as the twelfth native database adapter on `/databases/` and `/zh/databases/`, and updates every place the database count or the adapter list is spelled out.

## What changed

**Databases page (EN + /zh)**
- New `Apache Doris` entry (`type: doris`, `pkg: datus-doris`) placed right after StarRocks, in the Cloud Warehouse tier.
- Highlight copy: "Lakehousing, materialized views and hybrid search." / 「湖仓一体、物化视图与混合检索。」
- Hero lead, the Cloud Warehouse category blurb and the FAQ answer go 11 → 12 in both languages.

**Accent tone**
`SpecCard` tones come from a positional cyan/amber/green/pink rotation. Inserting Doris at index 6 would land it on green — the colour the page uses for the Lake & Distributed tier — which reads as a mis-tiering. Added an optional `tone` override on `DbEntry` so Doris keeps amber, matching StarRocks in the same tier. Every other entry is untouched and still follows the rotation.

**Counts elsewhere**
- `databases/index.html` meta description and `ZH_PAGE_META["/databases/"]` — "11+" → "12+", Doris added to the list.
- `/products/cli/` FAQ ("Does Datus CLI work with my existing warehouse?") — Doris added in both languages.

**Conventions**
- `CLAUDE.md` §2.2: locked two new terms used by this copy — lakehouse/lakehousing → 湖仓 / 湖仓一体, hybrid search → 混合检索 (never 混合搜索).
- `BUILD_DATE` in `scripts/lib/i18n-shells.mjs` bumped to `2026-08-20` (marketing copy changed, so the `<lastmod>` moves).

## Notes

- No new route, so `MIRRORED_PATHS`, `PAGES` and the sitemap are unchanged.
- EN and ZH numbers agree (12 / 十二 / 12+ / 12 种以上), per CLAUDE.md §3.
- "adapter" wording kept — Doris is a native adapter, not an MCP connector (§2.2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hekpE5Z9HfLY5RZLEferr
